### PR TITLE
feat: add header cache reader to enable live sync 

### DIFF
--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -236,12 +236,12 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                 }
             }
 
-            // Collect header for forward application - fail if not available 
+        // Collect header for forward application - fail if not available 
         if let Some(header) = crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(current_block) {
                 headers_to_apply.push(header);
                 current_block = current_block.saturating_sub(1);
             } else {
-                tracing::error!("Failed get snap due to load header in DB for block {}", current_block);
+                tracing::error!("Failed to get snap due to load header in DB for block {}", current_block);
                 return None;
             }
         };
@@ -327,8 +327,6 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
     }
     
     fn get_checkpoint_header(&self, block_number: u64) -> Option<alloy_consensus::Header> {
-        tracing::info!("Get checkpoint header for block {} in enhanced snapshot provider", block_number);
-        // Use the global HEADER_CACHE_READER to fetch header
         let header = crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(block_number);
         tracing::info!("Succeed to fetch header, is_none: {} for block {} in enhanced snapshot provider", header.is_none(), block_number);
         header

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -45,12 +45,12 @@ where
             snapshot_provider as Arc<dyn crate::consensus::parlia::SnapshotProvider + Send + Sync>,
         );
 
-               // Store the header provider globally for shared access
-         if let Err(_) = crate::shared::set_header_provider(Arc::new(ctx.provider().clone())) {
-             tracing::warn!("Failed to set global header provider");
-         } else {
-             tracing::info!("Succeed to set global header provider");
-         }
+        // Store the header provider globally for shared access
+        if let Err(_) = crate::shared::set_header_provider(Arc::new(ctx.provider().clone())) {
+            tracing::warn!("Failed to set global header provider");
+        } else {
+            tracing::info!("Succeed to set global header provider");
+        }
 
         // Store consensus globally for RPC access as a trait object that also exposes validator API
         let consensus_obj_global: Arc<dyn crate::consensus::parlia::ParliaConsensusObject + Send + Sync> = Arc::new(consensus_concrete.clone());

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -44,6 +44,14 @@ where
             snapshot_provider as Arc<dyn crate::consensus::parlia::SnapshotProvider + Send + Sync>,
         );
 
+        // Store the header provider globally for shared access
+        let header_provider = Arc::new(ctx.provider().clone());
+        if let Err(_) = crate::shared::set_header_provider(header_provider) {
+            tracing::warn!("Failed to set global header provider - it may already be set");
+        } else {
+            tracing::info!("Successfully set global header provider");
+        }
+
         // Store consensus globally for RPC access as a trait object that also exposes validator API
         let consensus_obj_global: Arc<dyn crate::consensus::parlia::ParliaConsensusObject + Send + Sync> = Arc::new(consensus_concrete.clone());
         let _ = crate::shared::set_parlia_consensus(consensus_obj_global);

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -1,12 +1,127 @@
 use crate::{
-    node::evm::config::{BscBlockExecutorFactory, BscEvmConfig},
+    node::evm::config::{BscBlockExecutorFactory, BscEvmConfig, BscBlockExecutionCtx},
+    chainspec::BscChainSpec,
     BscBlock, BscBlockBody,
 };
-use alloy_consensus::{Block, Header};
+use alloy_consensus::{Block, BlockBody, Header, EMPTY_OMMER_ROOT_HASH, proofs, Transaction, BlockHeader};
+use alloy_eips::{eip7840::BlobParams, merge::BEACON_NONCE};
+use alloy_primitives::Bytes;
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_ethereum_primitives::{Receipt, TransactionSigned};
 use reth_evm::{
-    block::BlockExecutionError,
+    block::{BlockExecutionError, BlockExecutorFactory},
     execute::{BlockAssembler, BlockAssemblerInput},
 };
+use reth_primitives_traits::logs_bloom;
+use reth_provider::BlockExecutionResult;
+use std::sync::Arc;
+
+/// Block assembler for BSC, mainly for support BscBlockExecutionCtx.
+#[derive(Debug, Clone)]
+pub struct BscBlockAssembler<ChainSpec = BscChainSpec> {
+    /// The chainspec.
+    pub chain_spec: Arc<ChainSpec>,
+    /// Extra data to use for the blocks.
+    pub extra_data: Bytes,
+}
+
+impl<ChainSpec> BscBlockAssembler<ChainSpec> {
+    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
+        Self { chain_spec, extra_data: Default::default() }
+    }
+}
+
+impl<F, ChainSpec> BlockAssembler<F> for BscBlockAssembler<ChainSpec>
+where
+    F: for<'a> BlockExecutorFactory<
+        ExecutionCtx<'a> = BscBlockExecutionCtx<'a>,
+        Transaction = TransactionSigned,
+        Receipt = Receipt,
+    >,
+    ChainSpec: EthChainSpec + EthereumHardforks,
+{
+    type Block = Block<TransactionSigned>;
+
+    fn assemble_block(
+        &self,
+        input: BlockAssemblerInput<'_, '_, F>,
+    ) -> Result<Block<TransactionSigned>, BlockExecutionError> {
+        let BlockAssemblerInput {
+            evm_env,
+            execution_ctx: ctx,
+            parent,
+            transactions,
+            output: BlockExecutionResult { receipts, requests, gas_used },
+            state_root,
+            ..
+        } = input;
+
+        // Use the base EthBlockExecutionCtx for compatibility
+        let eth_ctx = ctx.as_eth_context();
+        let timestamp = evm_env.block_env.timestamp.saturating_to();
+        let transactions_root = proofs::calculate_transaction_root(&transactions);
+        let receipts_root = Receipt::calculate_receipt_root_no_memo(receipts);
+        let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| &r.logs));
+
+        let withdrawals = self
+            .chain_spec
+            .is_shanghai_active_at_timestamp(timestamp)
+            .then(|| eth_ctx.withdrawals.clone().map(|w| w.into_owned()).unwrap_or_default());
+
+        let withdrawals_root =
+            withdrawals.as_deref().map(|w| proofs::calculate_withdrawals_root(w));
+        let requests_hash = self
+            .chain_spec
+            .is_prague_active_at_timestamp(timestamp)
+            .then(|| requests.requests_hash());
+
+        let mut excess_blob_gas = None;
+        let mut blob_gas_used = None;
+
+        if self.chain_spec.is_cancun_active_at_timestamp(timestamp) {
+            blob_gas_used =
+                Some(transactions.iter().map(|tx| tx.blob_gas_used().unwrap_or_default()).sum());
+            excess_blob_gas = if self.chain_spec.is_cancun_active_at_timestamp(parent.timestamp) {
+                parent.maybe_next_block_excess_blob_gas(
+                    self.chain_spec.blob_params_at_timestamp(timestamp),
+                )
+            } else {
+                // for the first post-fork block, both parent.blob_gas_used and
+                // parent.excess_blob_gas are evaluated as 0
+                Some(BlobParams::cancun().next_block_excess_blob_gas(0, 0))
+            };
+        }
+
+        let header = Header {
+            parent_hash: eth_ctx.parent_hash,
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: evm_env.block_env.beneficiary,
+            state_root,
+            transactions_root,
+            receipts_root,
+            withdrawals_root,
+            logs_bloom,
+            timestamp,
+            mix_hash: evm_env.block_env.prevrandao.unwrap_or_default(),
+            nonce: BEACON_NONCE.into(),
+            base_fee_per_gas: Some(evm_env.block_env.basefee),
+            number: evm_env.block_env.number.saturating_to(),
+            gas_limit: evm_env.block_env.gas_limit,
+            difficulty: evm_env.block_env.difficulty,
+            gas_used: *gas_used,
+            extra_data: self.extra_data.clone(),
+            parent_beacon_block_root: eth_ctx.parent_beacon_block_root,
+            blob_gas_used,
+            excess_blob_gas,
+            requests_hash,
+        };
+
+        Ok(Block {
+            header,
+            body: BlockBody { transactions, ommers: Default::default(), withdrawals },
+        })
+    }
+}
 
 impl BlockAssembler<BscBlockExecutorFactory> for BscEvmConfig {
     type Block = BscBlock;

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -348,8 +348,6 @@ where
         }
     }
 
-
-
     fn tx_iterator_for_payload(
         &self,
         payload: &BscExecutionData,

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -1,4 +1,4 @@
-use super::{executor::BscBlockExecutor, factory::BscEvmFactory};
+use super::{assembler::BscBlockAssembler, executor::BscBlockExecutor, factory::BscEvmFactory};
 use crate::{
     chainspec::BscChainSpec,
     evm::transaction::BscTxEnv,
@@ -18,7 +18,7 @@ use reth_evm::{
     ConfigureEngineEvm, ConfigureEvm, EvmEnv, EvmFactory, ExecutableTxIterator, ExecutionCtxFor,
     FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, NextBlockEnvAttributes,
 };
-use reth_evm_ethereum::{EthBlockAssembler, RethReceiptBuilder};
+use reth_evm_ethereum::RethReceiptBuilder;
 use reth_primitives::{BlockTy, HeaderTy, SealedBlock, SealedHeader, TransactionSigned};
 use reth_revm::State;
 use revm::{
@@ -29,14 +29,32 @@ use revm::{
 };
 use std::{borrow::Cow, convert::Infallible, sync::Arc};
 
+/// Context for BSC block execution.
+/// Contains all the fields from EthBlockExecutionCtx plus additional header field.
+#[derive(Debug, Clone)]
+pub struct BscBlockExecutionCtx<'a> {
+    /// Base Ethereum execution context.
+    pub base: EthBlockExecutionCtx<'a>,
+    /// Block header (optional for BSC-specific logic).
+    pub header: Option<Header>,
+}
+
+impl<'a> BscBlockExecutionCtx<'a> {
+    /// Convert to EthBlockExecutionCtx for compatibility with existing BlockAssembler.
+    pub fn as_eth_context(&self) -> &EthBlockExecutionCtx<'a> {
+        &self.base
+    }
+}
+
+
 /// Ethereum-related EVM configuration.
 #[derive(Debug, Clone)]
 pub struct BscEvmConfig {
     /// Inner [`BscBlockExecutorFactory`].
     pub executor_factory:
         BscBlockExecutorFactory<RethReceiptBuilder, Arc<BscChainSpec>, BscEvmFactory>,
-    /// Ethereum block assembler.
-    pub block_assembler: EthBlockAssembler<BscChainSpec>,
+    /// BSC block assembler.
+    pub block_assembler: BscBlockAssembler<BscChainSpec>,
 }
 
 impl BscEvmConfig {
@@ -55,7 +73,7 @@ impl BscEvmConfig {
     /// Creates a new Ethereum EVM configuration with the given chain spec and EVM factory.
     pub fn new_with_evm_factory(chain_spec: Arc<BscChainSpec>, evm_factory: BscEvmFactory) -> Self {
         Self {
-            block_assembler: EthBlockAssembler::new(chain_spec.clone()),
+            block_assembler: BscBlockAssembler::new(chain_spec.clone()),
             executor_factory: BscBlockExecutorFactory::new(
                 RethReceiptBuilder::default(),
                 chain_spec,
@@ -113,7 +131,7 @@ where
     BscTxEnv: IntoTxEnv<<EvmF as EvmFactory>::Tx>,
 {
     type EvmFactory = EvmF;
-    type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
+    type ExecutionCtx<'a> = BscBlockExecutionCtx<'a>;
     type Transaction = TransactionSigned;
     type Receipt = R::Receipt;
 
@@ -281,11 +299,14 @@ where
         &self,
         block: &'a SealedBlock<BlockTy<Self::Primitives>>,
     ) -> ExecutionCtxFor<'a, Self> {
-        EthBlockExecutionCtx {
-            parent_hash: block.header().parent_hash,
-            parent_beacon_block_root: block.header().parent_beacon_block_root,
-            ommers: &block.body().ommers,
-            withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),
+        BscBlockExecutionCtx {
+            base: EthBlockExecutionCtx {
+                parent_hash: block.header().parent_hash,
+                parent_beacon_block_root: block.header().parent_beacon_block_root,
+                ommers: &block.body().ommers,
+                withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),
+            },
+            header: Some(block.header().clone()),
         }
     }
 
@@ -294,11 +315,14 @@ where
         parent: &SealedHeader<HeaderTy<Self::Primitives>>,
         attributes: Self::NextBlockEnvCtx,
     ) -> ExecutionCtxFor<'_, Self> {
-        EthBlockExecutionCtx {
-            parent_hash: parent.hash(),
-            parent_beacon_block_root: attributes.parent_beacon_block_root,
-            ommers: &[],
-            withdrawals: attributes.withdrawals.map(Cow::Owned),
+        BscBlockExecutionCtx {
+            base: EthBlockExecutionCtx {
+                parent_hash: parent.hash(),
+                parent_beacon_block_root: attributes.parent_beacon_block_root,
+                ommers: &[],
+                withdrawals: attributes.withdrawals.map(Cow::Owned),
+            },
+            header: None, // No header available for next block context
         }
     }
 }
@@ -311,15 +335,20 @@ where
         self.evm_env(&payload.0.header)
     }
 
-    fn context_for_payload<'a>(&self, payload: &'a BscExecutionData) -> EthBlockExecutionCtx<'a> {
+    fn context_for_payload<'a>(&self, payload: &'a BscExecutionData) -> BscBlockExecutionCtx<'a> {
         let block = &payload.0;
-        EthBlockExecutionCtx {
-            parent_hash: block.header.parent_hash(),
-            parent_beacon_block_root: block.header.parent_beacon_block_root,
-            ommers: &block.body.inner.ommers,
-            withdrawals: block.body.inner.withdrawals.as_ref().map(Cow::Borrowed),
+        BscBlockExecutionCtx {
+            base: EthBlockExecutionCtx {
+                parent_hash: block.header.parent_hash(),
+                parent_beacon_block_root: block.header.parent_beacon_block_root,
+                ommers: &block.body.inner.ommers,
+                withdrawals: block.body.inner.withdrawals.as_ref().map(Cow::Borrowed),
+            },
+            header: Some(block.header.clone()),
         }
     }
+
+
 
     fn tx_iterator_for_payload(
         &self,

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -117,6 +117,12 @@ where
         let hertz_patch_manager = HertzPatchManager::new(is_mainnet);
         tracing::info!("Succeed to new block executor, header: {:?}", ctx.header);
 
+        if let Some(ref header) = ctx.header {
+            crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().insert_header_to_cache(header.clone());
+        } else {
+            tracing::warn!("No header found in the context, block_number: {:?}", evm.block().number.to::<u64>());
+        }
+
         let spec_clone = spec.clone();
         Self {
             spec,

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -75,7 +75,7 @@ where
     #[allow(dead_code)]
     hertz_patch_manager: HertzPatchManager,
     /// Context for block execution.
-    _ctx: BscBlockExecutionCtx<'a>,
+    pub(super) ctx: BscBlockExecutionCtx<'a>,
     /// Utility to call system caller.
     pub(super) system_caller: SystemCaller<Spec>,
     /// State hook.
@@ -133,7 +133,7 @@ where
             receipt_builder,
             system_contracts,
             hertz_patch_manager,
-            _ctx: ctx,
+            ctx,
             system_caller: SystemCaller::new(spec_clone),
             hook: None,
             snapshot_provider: crate::shared::get_snapshot_provider().cloned(),
@@ -341,7 +341,7 @@ where
             self.apply_history_storage_account(self.evm.block().number.to::<u64>())?;
         }
         if self.spec.is_prague_active_at_timestamp(self.evm.block().timestamp.to()) {
-            self.system_caller.apply_blockhashes_contract_call(self._ctx.base.parent_hash, &mut self.evm)?;
+            self.system_caller.apply_blockhashes_contract_call(self.ctx.base.parent_hash, &mut self.evm)?;
         }
 
         Ok(())

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -37,20 +37,18 @@ where
         let block_number = block.number.to::<u64>();
         tracing::info!("Check new block, block_number: {}", block_number);
 
-        let header = self
-            .snapshot_provider
-            .as_ref()
+        let header = crate::node::evm::util::HEADER_CACHE_READER
+            .lock()
             .unwrap()
-            .get_checkpoint_header(block_number)
-            .ok_or(BlockExecutionError::msg("Failed to get header from snapshot provider"))?;
+            .get_header_by_number(block_number)
+            .ok_or(BlockExecutionError::msg("Failed to get header from global header reader"))?;
         self.inner_ctx.header = Some(header.clone());
 
-        let parent_header = self
-            .snapshot_provider
-            .as_ref()
+        let parent_header = crate::node::evm::util::HEADER_CACHE_READER
+            .lock()
             .unwrap()
-            .get_checkpoint_header(block_number - 1)
-            .ok_or(BlockExecutionError::msg("Failed to get parent header from snapshot provider"))?;
+            .get_header_by_number(block_number - 1)
+            .ok_or(BlockExecutionError::msg("Failed to get parent header from global header reader"))?;
         self.inner_ctx.parent_header = Some(parent_header.clone());
 
         let snap = self

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -30,6 +30,7 @@ pub fn set_nonce(transaction: Transaction, nonce: u64) -> Transaction {
 }
 
 // HeaderReader add a cache layer on the provider.
+#[derive(Debug)]
 pub struct HeaderCacheReader {
     pub blocknumber_to_header: LruMap<u64, Header, ByLength>,
     pub blockhash_to_header: LruMap<B256, Header, ByLength>,
@@ -71,9 +72,10 @@ impl HeaderCacheReader {
     pub fn insert_header_to_cache(&mut self, header: Header) {
         let block_number = header.number();
         let block_hash = header.hash_slow();
+        let header_clone_for_log = header.clone();
         self.blocknumber_to_header.insert(block_number, header.clone());
         self.blockhash_to_header.insert(block_hash, header);
-        tracing::info!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header);
+        tracing::info!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header_clone_for_log);
     }
 }
 

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -73,10 +73,10 @@ impl HeaderCacheReader {
         let block_hash = header.hash_slow();
         self.blocknumber_to_header.insert(block_number, header.clone());
         self.blockhash_to_header.insert(block_hash, header);
-        tracing::info!("Insert header to cache, block_number: {:?}, block_hash: {:?}", block_number, block_hash);
+        tracing::info!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header);
     }
 }
 
 pub static HEADER_CACHE_READER: LazyLock<Mutex<HeaderCacheReader>> = LazyLock::new(|| {
-    Mutex::new(HeaderCacheReader::new(10000))
+    Mutex::new(HeaderCacheReader::new(100000))
 });

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -4,13 +4,27 @@
 //! both the consensus builder and RPC modules can access the same instance.
 
 use crate::consensus::parlia::{SnapshotProvider, ParliaConsensusObject};
-// use reth::consensus::ConsensusError; // not needed in this module
 use std::sync::{Arc, OnceLock};
+use alloy_consensus::Header;
+use alloy_primitives::B256;
+use reth_provider::HeaderProvider;
+
+/// Function type for HeaderProvider::header() access (by hash)
+type HeaderByHashFn = Arc<dyn Fn(&B256) -> Option<Header> + Send + Sync>;
+
+/// Function type for HeaderProvider::header_by_number() access (by number)  
+type HeaderByNumberFn = Arc<dyn Fn(u64) -> Option<Header> + Send + Sync>;
 
 /// Global shared access to the snapshot provider for RPC
 static SNAPSHOT_PROVIDER: OnceLock<Arc<dyn SnapshotProvider + Send + Sync>> = OnceLock::new();
 
 static PARLIA_CONSENSUS: OnceLock<Arc<dyn ParliaConsensusObject + Send + Sync>> = OnceLock::new();
+
+/// Global header provider function - HeaderProvider::header() by hash
+static HEADER_BY_HASH_PROVIDER: OnceLock<HeaderByHashFn> = OnceLock::new();
+
+/// Global header provider function - HeaderProvider::header_by_number() by number  
+static HEADER_BY_NUMBER_PROVIDER: OnceLock<HeaderByNumberFn> = OnceLock::new();
 
 /// Store the snapshot provider globally
 pub fn set_snapshot_provider(provider: Arc<dyn SnapshotProvider + Send + Sync>) -> Result<(), Arc<dyn SnapshotProvider + Send + Sync>> {
@@ -30,4 +44,69 @@ pub fn set_parlia_consensus(consensus: Arc<dyn ParliaConsensusObject + Send + Sy
 /// Get the global parlia consensus
 pub fn get_parlia_consensus() -> Option<&'static Arc<dyn ParliaConsensusObject + Send + Sync>> {
     PARLIA_CONSENSUS.get()
+}
+
+/// Store the header provider globally
+/// Creates functions that directly call HeaderProvider::header() and HeaderProvider::header_by_number()
+pub fn set_header_provider<T>(provider: Arc<T>) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    T: HeaderProvider<Header = Header> + Send + Sync + 'static,
+{
+    // Create function for header by hash
+    let provider_clone = provider.clone();
+    let header_by_hash_fn = Arc::new(move |block_hash: &B256| -> Option<Header> {
+        match provider_clone.header(block_hash) {
+            Ok(Some(header)) => Some(header),
+            _ => None,
+        }
+    });
+    
+    // Create function for header by number
+    let provider_clone2 = provider.clone();
+    let header_by_number_fn = Arc::new(move |block_number: u64| -> Option<Header> {
+        match provider_clone2.header_by_number(block_number) {
+            Ok(Some(header)) => Some(header),
+            _ => None,
+        }
+    });
+    
+    // Set both functions
+    HEADER_BY_HASH_PROVIDER.set(header_by_hash_fn).map_err(|_| "Failed to set hash provider")?;
+    HEADER_BY_NUMBER_PROVIDER.set(header_by_number_fn).map_err(|_| "Failed to set number provider")?;
+    
+    Ok(())
+}
+
+/// Get the global header by hash provider function
+pub fn get_header_by_hash_provider() -> Option<&'static HeaderByHashFn> {
+    HEADER_BY_HASH_PROVIDER.get()
+}
+
+/// Get the global header by number provider function  
+pub fn get_header_by_number_provider() -> Option<&'static HeaderByNumberFn> {
+    HEADER_BY_NUMBER_PROVIDER.get()
+}
+
+/// Get header by hash from the global header provider
+/// Directly calls the stored HeaderProvider::header() function
+pub fn get_header_by_hash_from_provider(block_hash: &B256) -> Option<Header> {
+    let provider_fn = HEADER_BY_HASH_PROVIDER.get()?;
+    provider_fn(block_hash)
+}
+
+/// Get header by number from the global header provider
+/// Directly calls the stored HeaderProvider::header_by_number() function
+pub fn get_header_by_number_from_provider(block_number: u64) -> Option<Header> {
+    let provider_fn = HEADER_BY_NUMBER_PROVIDER.get()?;
+    provider_fn(block_number)
+}
+
+/// Get header by hash - simplified interface
+pub fn get_header_by_hash(block_hash: &B256) -> Option<Header> {
+    get_header_by_hash_from_provider(block_hash)
+}
+
+/// Get header by number - simplified interface
+pub fn get_header_by_number(block_number: u64) -> Option<Header> {
+    get_header_by_number_from_provider(block_number)
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -2,7 +2,7 @@
 //! 
 //! This module provides global access to the snapshot provider so that
 //! both the consensus builder and RPC modules can access the same instance.
-
+// TODO: refine it later.
 use crate::consensus::parlia::{SnapshotProvider, ParliaConsensusObject};
 use std::sync::{Arc, OnceLock};
 use alloy_consensus::Header;


### PR DESCRIPTION
### Description

Add header cacher reader to enable live sync.

### Rationale

Enable executor perceive headers, and cache it. 

1. Enble live-sync(described by https://github.com/loocapro/reth-bsc/issues/64).
2. The header cache also speeds some performance.
3. Make snap-provider lighter, and facilitate further optimization.



### Example

N/A.

### Changes

Notable changes: 
* executor/snap-provider.
### Potential Impacts
N/A.
