### PR TITLE
chore: fix the wrong epoch length

### DIFF
--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -140,8 +140,10 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
         }
 
         let mut raw_attestation_data = if header.number() % self.get_epoch_length(header) != 0 {
+            tracing::debug!("header.number {} not an epoch", header.number());
             &header.extra_data[EXTRA_VANITY_LEN..extra_len - EXTRA_SEAL_LEN]
         } else {
+            tracing::debug!("header.number {} is an epoch", header.number());
             let validator_count =
                 header.extra_data[EXTRA_VANITY_LEN + VALIDATOR_NUMBER_SIZE - 1] as usize;
             let mut start =
@@ -159,6 +161,8 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
         if raw_attestation_data.is_empty() {
             return Ok(None);
         }
+        tracing::debug!("try debug attestation data, attestation_data_len: {:?}, header_number: {:?}", 
+            raw_attestation_data.len(), header.number());
 
         Ok(Some(
             Decodable::decode(&mut raw_attestation_data)

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -140,10 +140,8 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
         }
 
         let mut raw_attestation_data = if header.number() % epoch_length != 0 {
-            tracing::debug!("header.number {} not an epoch", header.number());
             &header.extra_data[EXTRA_VANITY_LEN..extra_len - EXTRA_SEAL_LEN]
         } else {
-            tracing::debug!("header.number {} is an epoch", header.number());
             let validator_count =
                 header.extra_data[EXTRA_VANITY_LEN + VALIDATOR_NUMBER_SIZE - 1] as usize;
             let mut start =

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -104,8 +104,8 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
     }
 
     /// Get turn length from header
-    pub fn get_turn_length_from_header(&self, header: &Header) -> Result<Option<u8>, ParliaConsensusError> {
-        if header.number % self.get_epoch_length(header) != 0 ||
+    pub fn get_turn_length_from_header(&self, header: &Header, epoch_length: u64) -> Result<Option<u8>, ParliaConsensusError> {
+        if header.number % epoch_length != 0 ||
             !self.spec.is_bohr_active_at_timestamp(header.timestamp)
         {
             return Ok(None);

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -129,7 +129,7 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
     }
 
     /// Get vote attestation from header
-    pub fn get_vote_attestation_from_header(&self, header: &Header) -> Result<Option<VoteAttestation>, ParliaConsensusError> {
+    pub fn get_vote_attestation_from_header(&self, header: &Header, epoch_length: u64) -> Result<Option<VoteAttestation>, ParliaConsensusError> {
         let extra_len = header.extra_data.len();
         if extra_len <= EXTRA_VANITY_LEN + EXTRA_SEAL_LEN {
             return Ok(None);
@@ -139,7 +139,7 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
             return Ok(None);
         }
 
-        let mut raw_attestation_data = if header.number() % self.get_epoch_length(header) != 0 {
+        let mut raw_attestation_data = if header.number() % epoch_length != 0 {
             tracing::debug!("header.number {} not an epoch", header.number());
             &header.extra_data[EXTRA_VANITY_LEN..extra_len - EXTRA_SEAL_LEN]
         } else {

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -162,7 +162,7 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
 
         Ok(Some(
             Decodable::decode(&mut raw_attestation_data)
-                .map_err(|_| ParliaConsensusError::ABIDecodeInnerError)?,
+                .map_err(|_| ParliaConsensusError::ExtraInvalidAttestation)?,
         ))
     }
 

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -63,14 +63,14 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
     }
 
     /// Get validator bytes from header extra data
-    pub fn get_validator_bytes_from_header(&self, header: &Header) -> Option<Vec<u8>> {
+    pub fn get_validator_bytes_from_header(&self, header: &Header, epoch_length: u64) -> Option<Vec<u8>> {
         let extra_len = header.extra_data.len();
         if extra_len <= EXTRA_VANITY_LEN + EXTRA_SEAL_LEN {
             return None;
         }
 
         let is_luban_active = self.spec.is_luban_active_at_block(header.number);
-        let is_epoch = header.number % self.get_epoch_length(header) == 0;
+        let is_epoch = header.number % epoch_length == 0;
 
         if is_luban_active {
             if !is_epoch {
@@ -291,8 +291,9 @@ where ChainSpec: EthChainSpec + BscHardforks + 'static,
     pub fn parse_validators_from_header(
         &self,
         header: &Header,
+        epoch_length: u64,
     ) -> Result<ValidatorsInfo, ParliaConsensusError> {
-        let val_bytes = self.get_validator_bytes_from_header(header).ok_or_else(|| {
+        let val_bytes = self.get_validator_bytes_from_header(header, epoch_length).ok_or_else(|| {
             ParliaConsensusError::InvalidHeaderExtraLen {
                 header_extra_len: header.extra_data.len() as u64,
             }

--- a/src/consensus/parlia/error.rs
+++ b/src/consensus/parlia/error.rs
@@ -38,10 +38,6 @@ pub enum ParliaConsensusError {
         block_number: BlockNumber,
     },
 
-    /// Error when encountering a abi decode inner error
-    #[error("abi decode inner error")]
-    ABIDecodeInnerError,
-
     /// Error when encountering a recover ecdsa inner error
     #[error("recover ecdsa inner error")]
     RecoverECDSAInnerError,
@@ -49,4 +45,8 @@ pub enum ParliaConsensusError {
     /// Error when header extra turn is invalid
     #[error("invalid turnLength")]
     ExtraInvalidTurnLength,
+
+    /// Error when header extra attestation is invalid
+    #[error("invalid attestation")]
+    ExtraInvalidAttestation,
 }

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -270,13 +270,13 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                     
                     if let Some(checkpoint_header) = checkpoint_header {
                         let parsed = self.parlia.parse_validators_from_header(checkpoint_header);
-                        turn_length = self.parlia.get_turn_length_from_header(checkpoint_header).ok()?;
+                        turn_length = self.parlia.get_turn_length_from_header(checkpoint_header, working_snapshot.epoch_num).ok()?;
                         parsed
                     } else {
                         match crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(checkpoint_block_number) {
                             Some(header_ref) => {
                                 let parsed = self.parlia.parse_validators_from_header(&header_ref);
-                                turn_length = self.parlia.get_turn_length_from_header(&header_ref).ok()?; 
+                                turn_length = self.parlia.get_turn_length_from_header(&header_ref, working_snapshot.epoch_num).ok()?; 
                                 parsed
                             },
                             None => {

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -229,7 +229,7 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
             if let Some(header) = crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(current_block) {
                     if header.number == 0 {
                         let ValidatorsInfo { consensus_addrs, vote_addrs } =
-                            self.parlia.parse_validators_from_header(&header).map_err(|err| {
+                            self.parlia.parse_validators_from_header(&header, self.parlia.epoch).map_err(|err| {
                                 BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }
                             }).ok()?;
                         let genesis_snap = Snapshot::new(
@@ -269,7 +269,7 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                         .find(|h| h.number == checkpoint_block_number);
                     
                     if let Some(checkpoint_header) = checkpoint_header {
-                        let parsed = self.parlia.parse_validators_from_header(checkpoint_header);
+                        let parsed = self.parlia.parse_validators_from_header(checkpoint_header, working_snapshot.epoch_num);
                         turn_length = self.parlia.get_turn_length_from_header(checkpoint_header, working_snapshot.epoch_num).map_err(|err| {
                             tracing::error!("Failed to get turn length from checkpoint header, block_number: {}, checkpoint_block_number: {}, epoch_num: {}, error: {:?}", 
                                 header.number, checkpoint_block_number, working_snapshot.epoch_num, err);
@@ -279,7 +279,7 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                     } else {
                         match crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(checkpoint_block_number) {
                             Some(header_ref) => {
-                                let parsed = self.parlia.parse_validators_from_header(&header_ref);
+                                let parsed = self.parlia.parse_validators_from_header(&header_ref, working_snapshot.epoch_num);
                                 turn_length = self.parlia.get_turn_length_from_header(&header_ref, working_snapshot.epoch_num).map_err(|err| {
                                     tracing::error!("Failed to get turn length from cached header, block_number: {}, checkpoint_block_number: {}, epoch_num: {}, error: {:?}", 
                                         header.number, checkpoint_block_number, working_snapshot.epoch_num, err);

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -294,7 +294,11 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
 
                 let new_validators = validators_info.consensus_addrs;
                 let vote_addrs = validators_info.vote_addrs;
-                let attestation = self.parlia.get_vote_attestation_from_header(header, working_snapshot.epoch_num).ok()?;
+                let attestation = self.parlia.get_vote_attestation_from_header(header, working_snapshot.epoch_num).map_err(|err| {
+                    tracing::error!("Failed to get vote attestation from header, block_number: {}, epoch_num: {}, error: {:?}", 
+                        header.number, working_snapshot.epoch_num, err);
+                    err
+                }).ok()?;
 
                 tracing::debug!("Start to apply header to snapshot, block_number: {:?}, turn_length: {:?}", header.number, turn_length);
                 // Apply header to snapshot (now determines hardfork activation internally)

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -262,6 +262,7 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                 let miner_check_len = working_snapshot.miner_history_check_len();
                 let is_epoch_boundary = header.number > 0 && epoch_remainder == miner_check_len;
                 let mut turn_length = None;
+                let mut epoch_length = None;
                 let validators_info = if is_epoch_boundary {
                     let checkpoint_block_number = header.number - miner_check_len;
                     tracing::debug!("Try update validator set, checkpoint_block_number: {:?}, block_number: {:?}", checkpoint_block_number, header.number);
@@ -271,12 +272,14 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                     if let Some(checkpoint_header) = checkpoint_header {
                         let parsed = self.parlia.parse_validators_from_header(checkpoint_header);
                         turn_length = self.parlia.get_turn_length_from_header(checkpoint_header).ok()?;
+                        epoch_length = Some(self.parlia.get_epoch_length(checkpoint_header));
                         parsed
                     } else {
                         match crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(checkpoint_block_number) {
                             Some(header_ref) => {
                                 let parsed = self.parlia.parse_validators_from_header(&header_ref);
-                                turn_length = self.parlia.get_turn_length_from_header(&header_ref).ok()?;                    
+                                turn_length = self.parlia.get_turn_length_from_header(&header_ref).ok()?; 
+                                epoch_length = Some(self.parlia.get_epoch_length(&header_ref));
                                 parsed
                             },
                             None => {
@@ -294,7 +297,7 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
 
                 let new_validators = validators_info.consensus_addrs;
                 let vote_addrs = validators_info.vote_addrs;
-                let attestation = self.parlia.get_vote_attestation_from_header(header).ok()?;
+                let attestation = self.parlia.get_vote_attestation_from_header(header, epoch_length?).ok()?;
 
                 tracing::debug!("Start to apply header to snapshot, block_number: {:?}, turn_length: {:?}", header.number, turn_length);
                 // Apply header to snapshot (now determines hardfork activation internally)

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -270,13 +270,21 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                     
                     if let Some(checkpoint_header) = checkpoint_header {
                         let parsed = self.parlia.parse_validators_from_header(checkpoint_header);
-                        turn_length = self.parlia.get_turn_length_from_header(checkpoint_header, working_snapshot.epoch_num).ok()?;
+                        turn_length = self.parlia.get_turn_length_from_header(checkpoint_header, working_snapshot.epoch_num).map_err(|err| {
+                            tracing::error!("Failed to get turn length from checkpoint header, block_number: {}, checkpoint_block_number: {}, epoch_num: {}, error: {:?}", 
+                                header.number, checkpoint_block_number, working_snapshot.epoch_num, err);
+                            err
+                        }).ok()?;
                         parsed
                     } else {
                         match crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(checkpoint_block_number) {
                             Some(header_ref) => {
                                 let parsed = self.parlia.parse_validators_from_header(&header_ref);
-                                turn_length = self.parlia.get_turn_length_from_header(&header_ref, working_snapshot.epoch_num).ok()?; 
+                                turn_length = self.parlia.get_turn_length_from_header(&header_ref, working_snapshot.epoch_num).map_err(|err| {
+                                    tracing::error!("Failed to get turn length from cached header, block_number: {}, checkpoint_block_number: {}, epoch_num: {}, error: {:?}", 
+                                        header.number, checkpoint_block_number, working_snapshot.epoch_num, err);
+                                    err
+                                }).ok()?; 
                                 parsed
                             },
                             None => {

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -158,13 +158,13 @@ where
         header: Option<Header>
     ) -> Result<(), BlockExecutionError> {
         let header_ref = header.as_ref().unwrap();
-        let epoch_length = self.parlia.get_epoch_length(header_ref);
+        let epoch_length = self.inner_ctx.snap.as_ref().unwrap().epoch_num;
         if header_ref.number % epoch_length != 0 || !self.spec.is_bohr_active_at_timestamp(header_ref.timestamp) {
             tracing::debug!("Skip verify turn length, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());
         }
         let turn_length_from_header = {
-            match self.parlia.get_turn_length_from_header(header_ref) {
+            match self.parlia.get_turn_length_from_header(header_ref, epoch_length) {
                 Ok(Some(length)) => length,
                 Ok(None) => return Ok(()),
                 Err(err) => return Err(BscBlockExecutionError::ParliaConsensusInnerError { error: Box::new(err) }.into()),

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -112,7 +112,7 @@ where
         header: Option<Header>
     ) -> Result<(), BlockExecutionError> {
         let header_ref = header.as_ref().unwrap();
-        let epoch_length = self.parlia.get_epoch_length(header_ref);
+        let epoch_length = self.inner_ctx.snap.as_ref().unwrap().epoch_num;
         if header_ref.number % epoch_length != 0 {
             tracing::debug!("Skip verify validator, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());
@@ -142,7 +142,7 @@ where
             })
             .collect();
 
-        let expected = self.parlia.get_validator_bytes_from_header(header_ref).unwrap();
+        let expected = self.parlia.get_validator_bytes_from_header(header_ref, epoch_length).unwrap();
         if !validator_bytes.as_slice().eq(expected.as_slice()) {
             warn!("validator bytes: {:?}", hex::encode(validator_bytes));
             warn!("expected: {:?}", hex::encode(expected));

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -144,6 +144,7 @@ where
 
         let expected = self.parlia.get_validator_bytes_from_header(header_ref, epoch_length).unwrap();
         if !validator_bytes.as_slice().eq(expected.as_slice()) {
+            // TODO: recheck it, maybe still has bugs.
             warn!("validator bytes: {:?}", hex::encode(validator_bytes));
             warn!("expected: {:?}", hex::encode(expected));
             return Err(BlockExecutionError::msg("Invalid validators"));

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -360,7 +360,7 @@ where
                 .ok_or_else(|| BlockExecutionError::msg(format!("Header not found for block number: {}", target_number)))?;
 
             if let Some(attestation) =
-                self.parlia.get_vote_attestation_from_header(&header).map_err(|err| {
+                self.parlia.get_vote_attestation_from_header(&header, self.inner_ctx.snap.as_ref().unwrap().epoch_num).map_err(|err| {
                     BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }
                 })?
             {

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -291,6 +291,7 @@ where
         let parlia = Parlia::new(Arc::new(self.spec.clone()), 200);
         let attestation =
             parlia.get_vote_attestation_from_header(header).map_err(|err| {
+                tracing::error!("Failed to get vote attestation from header, block_number: {}, error: {:?}", header.number(), err);
                 BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }
             })?;
         if let Some(attestation) = attestation {
@@ -404,6 +405,7 @@ where
     ) -> Result<(), BlockExecutionError> {
         let parlia = Parlia::new(Arc::new(self.spec.clone()), 200);
         let proposer = parlia.recover_proposer(header).map_err(|err| {
+            tracing::error!("Failed to recover proposer from header, block_number: {}, error: {:?}", header.number(), err);
             BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }
         })?;
 

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -290,7 +290,7 @@ where
 
         let parlia = Parlia::new(Arc::new(self.spec.clone()), 200);
         let attestation =
-            parlia.get_vote_attestation_from_header(header).map_err(|err| {
+            parlia.get_vote_attestation_from_header(header, snap.epoch_num).map_err(|err| {
                 tracing::error!("Failed to get vote attestation from header, block_number: {}, error: {:?}", header.number(), err);
                 BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }
             })?;

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -262,6 +262,7 @@ where
     ) -> Result<(), BlockExecutionError> {
         if self.spec.is_ramanujan_active_at_block(header.number()) {
             let block_interval = snap.block_interval;
+            // TODO: recheck it, maybe still has bugs.
             let back_off_time = self.parlia.back_off_time(snap, parent, header);
             let current_ts: u64 = calculate_millisecond_timestamp(header);
             let parent_ts: u64 = calculate_millisecond_timestamp(parent);

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -115,10 +115,6 @@ where
         }
 
         let epoch_length = self.parlia.get_epoch_length(&header);
-        if (header.number + 1)% epoch_length == 0 {
-            // cache it on pre block.
-            self.get_current_validators(header.number)?;
-        }
         if header.number % epoch_length == 0 {
             let (validator_set, vote_addresses) = self.get_current_validators(header.number-1 /*mostly in cache*/)?;
             tracing::debug!("validator_set: {:?}, vote_addresses: {:?}", validator_set, vote_addresses);
@@ -177,7 +173,7 @@ where
         Ok(())
     }
 
-    fn get_current_validators(
+    pub(crate) fn get_current_validators(
         &mut self, 
         block_number: u64
     ) -> Result<(Vec<Address>, Vec<VoteAddress>), BlockExecutionError> {
@@ -266,9 +262,7 @@ where
     ) -> Result<(), BlockExecutionError> {
         if self.spec.is_ramanujan_active_at_block(header.number()) {
             let block_interval = snap.block_interval;
-            // let back_off_time = self.parlia.back_off_time(snap, parent, header);
-            // TODO: fix it later.
-            let back_off_time = 0;
+            let back_off_time = self.parlia.back_off_time(snap, parent, header);
             let current_ts: u64 = calculate_millisecond_timestamp(header);
             let parent_ts: u64 = calculate_millisecond_timestamp(parent);
             if current_ts < parent_ts + block_interval + back_off_time {


### PR DESCRIPTION
### Description

Fix the wrong epoch length.

### Rationale

epoch number should be snap.epoch or boundary header.epoch.

### Example

N/A.

### Changes

Notable changes: 
* epoch related codes.

### Potential Impacts
N/A.
