### PR TITLE
chore: fix verify validators in some edge case

### DIFF
--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -112,7 +112,7 @@ where
         header: Option<Header>
     ) -> Result<(), BlockExecutionError> {
         let header_ref = header.as_ref().unwrap();
-        let epoch_length = self.inner_ctx.snap.as_ref().unwrap().epoch_num;
+        let epoch_length = self.parlia.get_epoch_length(&header_ref);
         if header_ref.number % epoch_length != 0 {
             tracing::debug!("Skip verify validator, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -112,7 +112,7 @@ where
         header: Option<Header>
     ) -> Result<(), BlockExecutionError> {
         let header_ref = header.as_ref().unwrap();
-        let epoch_length = self.parlia.get_epoch_length(&header_ref);
+        let epoch_length = self.parlia.get_epoch_length(header_ref);
         if header_ref.number % epoch_length != 0 {
             tracing::debug!("Skip verify validator, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());


### PR DESCRIPTION
### Description

Fix verify validators in some edge case.

### Rationale

Verify validators at the header's epoch-length.

### Example

N/A.

### Changes

Notable changes: 
* verify-validators related*.

### Potential Impacts
N/A.
