### PR TITLE
fix: add keystore parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.18.0",
  "walkdir",
 ]
 
@@ -3183,6 +3183,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex 0.4.3",
+ "hmac",
+ "pbkdf2",
+ "rand 0.8.5",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "thiserror 1.0.69",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -5383,7 +5405,7 @@ dependencies = [
  "smallvec",
  "tagptr",
  "thiserror 1.0.69",
- "uuid",
+ "uuid 1.18.0",
 ]
 
 [[package]]
@@ -5833,6 +5855,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "peg"
@@ -9402,6 +9433,7 @@ dependencies = [
  "cometbft-light-client-verifier",
  "cometbft-proto",
  "derive_more 0.99.20",
+ "eth-keystore",
  "eyre",
  "futures",
  "jsonrpsee",
@@ -9463,7 +9495,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "uuid",
+ "uuid 1.18.0",
 ]
 
 [[package]]
@@ -10097,6 +10129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10160,6 +10201,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "sct"
@@ -11340,7 +11393,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid",
+ "uuid 1.18.0",
 ]
 
 [[package]]
@@ -11696,6 +11749,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.16",
+ "serde",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ prost = { version = "0.12.6" }
 tendermint = { git = "https://github.com/bnb-chain/tendermint-rs-parlia", rev = "8c21ccbd58a174e07eed2c9343e63ccd00f0fbd5", features = ["secp256k1"] }
 signature = "2.2.0"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
+eth-keystore = "0.5"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemalloc-ctl = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,14 @@ pub struct BscCliArgs {
     #[arg(long = "mining.private-key")]
     pub private_key: Option<String>,
 
+    /// Path to an Ethereum V3 keystore JSON for mining
+    #[arg(long = "mining.keystore-path")]
+    pub keystore_path: Option<PathBuf>,
+
+    /// Password for the keystore file (plain string)
+    #[arg(long = "mining.keystore-password")]
+    pub keystore_password: Option<String>,
+
     /// Custom genesis file path
     #[arg(long = "genesis")]
     pub genesis_file: Option<PathBuf>,
@@ -83,6 +91,13 @@ fn main() -> eyre::Result<()> {
                         let addr = mining_config::keystore::get_validator_address(&sk);
                         mining_config.validator_address = Some(addr);
                     }
+                }
+
+                if let Some(ref path) = args.keystore_path {
+                    mining_config.keystore_path = Some(path.clone());
+                }
+                if let Some(ref pass) = args.keystore_password {
+                    mining_config.keystore_password = Some(pass.clone());
                 }
 
                 // Ensure keys are available if enabled but none provided


### PR DESCRIPTION
### Description
fix: add keystore parser

### 

After this fix, the reth start up cmd can use "--mining.keystore-path" and "--mining.keystore-password" options 
        --mining.enabled \
        --mining.keystore-path "${keystore_file}" \
        --mining.keystore-password "$(cat ${password_file})" \
