### PR TITLE
fix: fix signature in the seal block

### DIFF
--- a/src/node/engine.rs
+++ b/src/node/engine.rs
@@ -37,6 +37,7 @@ use reth::payload::EthPayloadBuilderAttributes;
 use reth_revm::cancelled::CancelOnDrop;
 use crate::node::miner::signer::init_global_signer;
 use alloy_primitives::B256;
+use reth_primitives_traits::BlockBody;
 
 /// Built payload for BSC. This is similar to [`EthBuiltPayload`] but without sidecars as those
 /// included into [`BscBlock`].
@@ -248,6 +249,7 @@ where
 
         // queue to engine-api for memory tree and broadcast it block_import channel.
         // todo: check it.
+        debug!("Submitting block: {:?}, tx_len: {}", payload.block().header(), payload.block().body().transaction_count());
         self.submit_block(payload.block()).await?;
 
         Ok(())

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -152,6 +152,8 @@ where
             ) {
                 tracing::warn!("Failed to finalize header: {}", e);
             }
+
+            tracing::debug!("Succeed to finalize header: {:?}", header)
         }
 
         Ok(Block {

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -328,6 +328,7 @@ where
         parent: &SealedHeader<HeaderTy<Self::Primitives>>,
         attributes: Self::NextBlockEnvCtx,
     ) -> ExecutionCtxFor<'_, Self> {
+        tracing::debug!("try to create next block ctx for miner, next_block_numer={}", parent.number+1);
         BscBlockExecutionCtx {
             base: EthBlockExecutionCtx {
                 parent_hash: parent.hash(),


### PR DESCRIPTION
### Description

Fix signature in the seal block.

### Rationale

sign_message() has recovery_id conversion, which causes unexpected recover_id, so secp256k1 is used directly

### Example

N/A.

### Changes

Notable changes: 
* signer, which impacts the seal block hash workflow.

### Potential Impacts
* verify signature in receiving the new block.
