### PR TITLE
chore: fix parent_beacon_block_root

### DIFF
--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -24,7 +24,7 @@ pub fn prepare_new_attributes(parlia: Arc<Parlia<BscChainSpec>>, parent_snap: &S
     if BscHardforks::is_bohr_active_at_timestamp(&parlia.spec, new_header.number, new_header.timestamp) {
         attributes.parent_beacon_block_root = Some(B256::default());
     }
-    return attributes;
+    attributes
 }
 
 /// prepare a tmp new header for preparing attributes.


### PR DESCRIPTION
### Description

Fix parent_beacon_block_root.

### Rationale

N/A.

### Example

otherwise:
```
2025-09-19T09:01:55.570949Z ERROR engine::tree: Failed to validate header 0x5e42fce9d34d72cf9024bc3e0f2f210c697e93ca63bcd461529a884c98096be6: unexpected parent beacon block root block=RecoveredBlock ...
```
### Changes

Notable changes: 
* miner*

### Potential Impacts
N/A.
