### PR TITLE
fix: fix state root mismatch in engine-tree rerun

### DIFF
--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -249,8 +249,15 @@ where
     type Evm = E;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
-        // pre check and prepare some intermediate data for commit parlia snapshot in finish function.
         let block_env = self.evm.block().clone();
+        debug!(
+            target: "bsc::executor", 
+            block_id = %block_env.number,
+            is_miner = self.ctx.is_miner,
+            "Start to apply_pre_execution_changes"
+        );
+        
+        // pre check and prepare some intermediate data for commit parlia snapshot in finish function.
         if self.ctx.is_miner {
             self.prepare_new_block(&block_env)?;
         } else {
@@ -342,6 +349,14 @@ where
     fn finish(
         mut self,
     ) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
+        let block_env = self.evm.block().clone();
+        debug!(
+            target: "bsc::executor", 
+            block_id = %block_env.number,
+            is_miner = self.ctx.is_miner,
+            "Start to finish"
+        );
+
         // If first block deploy genesis contracts
         if self.evm.block().number == uint!(1U256) {
             self.deploy_genesis_contracts(self.evm.block().beneficiary)?;

--- a/src/node/miner/payload_builder.rs
+++ b/src/node/miner/payload_builder.rs
@@ -53,13 +53,14 @@ where
         Self { client, pool, evm_config, builder_config }
     }
 
+    // todo: check more and refine it later.
     pub fn build_payload(self,args: BuildArguments<EthPayloadBuilderAttributes, BscBuiltPayload>) -> Result<BscBuiltPayload, Box<dyn std::error::Error + Send + Sync>> {
         let BuildArguments { mut cached_reads, config, cancel: _cancel, best_payload: _best_payload } = args;
         let PayloadConfig { parent_header, attributes } = config;
 
         let state_provider = self.client.state_by_block_hash(parent_header.hash_slow())?;
         let state = StateProviderDatabase::new(&state_provider);
-        let mut db = State::builder().with_database(cached_reads.as_db_mut(state)).build();
+        let mut db = State::builder().with_database(cached_reads.as_db_mut(state)).with_bundle_update().build();
         
         let mut builder = self.evm_config
             .builder_for_next_block(


### PR DESCRIPTION
### Description

Fix state root mismatch in engine-tree rerun.

### Rationale

state root calu depend bundle which in the build.finish().

### Example

N/A.

### Changes

Notable changes: 
* miner*

### Potential Impacts
N/A.
