### PR TITLE
fix ci error

### DIFF
--- a/src/consensus/parlia/snapshot.rs
+++ b/src/consensus/parlia/snapshot.rs
@@ -193,10 +193,10 @@ impl Snapshot {
 
         let epoch_length = snap.epoch_num;
         let next_block_number = block_number + 1;
-        if snap.epoch_num == DEFAULT_EPOCH_LENGTH && is_lorentz_active && next_block_number % LORENTZ_EPOCH_LENGTH == 0 {
+        if snap.epoch_num == DEFAULT_EPOCH_LENGTH && is_lorentz_active && next_block_number.is_multiple_of(LORENTZ_EPOCH_LENGTH) {
             snap.epoch_num = LORENTZ_EPOCH_LENGTH;
         }
-        if snap.epoch_num == LORENTZ_EPOCH_LENGTH && is_maxwell_active && next_block_number % MAXWELL_EPOCH_LENGTH == 0 {
+        if snap.epoch_num == LORENTZ_EPOCH_LENGTH && is_maxwell_active && next_block_number.is_multiple_of(MAXWELL_EPOCH_LENGTH) {
             snap.epoch_num = MAXWELL_EPOCH_LENGTH;
         }
 

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -97,7 +97,7 @@ where
         }
 
         let epoch_length = self.parlia.get_epoch_length(&header);
-        if (header.number + 1)% epoch_length == 0 {
+        if (header.number + 1).is_multiple_of(epoch_length) {
             // cache it on pre block.
             self.get_current_validators(header.number)?;
         }
@@ -113,7 +113,7 @@ where
     ) -> Result<(), BlockExecutionError> {
         let header_ref = header.as_ref().unwrap();
         let epoch_length = self.parlia.get_epoch_length(header_ref);
-        if header_ref.number % epoch_length != 0 {
+        if !header_ref.number.is_multiple_of(epoch_length) {
             tracing::trace!("Skip verify validator, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());
         }
@@ -160,7 +160,7 @@ where
     ) -> Result<(), BlockExecutionError> {
         let header_ref = header.as_ref().unwrap();
         let epoch_length = self.inner_ctx.snap.as_ref().unwrap().epoch_num;
-        if header_ref.number % epoch_length != 0 || !self.spec.is_bohr_active_at_timestamp(header_ref.number, header_ref.timestamp) {
+        if !header_ref.number.is_multiple_of(epoch_length) || !self.spec.is_bohr_active_at_timestamp(header_ref.number, header_ref.timestamp) {
             tracing::trace!("Skip verify turn length, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());
         }
@@ -346,7 +346,7 @@ where
     ) -> Result<(), BlockExecutionError> {
         // distribute finality reward per 200 blocks.
         let distribute_interval = 200;
-        if header.number % distribute_interval != 0 {
+        if !header.number.is_multiple_of(distribute_interval) {
             return Ok(());
         }
 


### PR DESCRIPTION
### Description

fix ci

### Rationale

```
error: manual implementation of `.is_multiple_of()`
   --> src/node/evm/post_execution.rs:163:12
    |
163 |         if header_ref.number % epoch_length != 0 || !self.spec.is_bohr_active_at_timestamp(header_ref.number, header_ref.timestamp) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!header_ref.number.is_multiple_of(epoch_length)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
```

### Example

NA
### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
