### PR TITLE
chore: convert execution-err to validation-err and avoid thread exit

### DIFF
--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::chainspec::BscChainSpec;
 
 use crate::consensus::parlia::{Parlia, VoteAddress};
-use crate::node::evm::error::BscBlockExecutionError;
+use crate::node::evm::error::{BscBlockExecutionError, BscBlockValidationError};
 use alloy_primitives::{Address, B256};
 
 /// Validator information extracted from header
@@ -227,7 +227,7 @@ impl<DB: Database + 'static> SnapshotProvider for EnhancedDbSnapshotProvider<DB>
                 if let Some(header) = crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().get_header_by_number(0) {
                     let ValidatorsInfo { consensus_addrs, vote_addrs } =
                         self.parlia.parse_validators_from_header(&header, self.parlia.epoch).map_err(|err| {
-                            BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }
+                            BscBlockExecutionError::Validation(BscBlockValidationError::ParliaConsensusError { error: err.into() })
                         }).ok()?;
                     let genesis_snap = Snapshot::new(
                         consensus_addrs,

--- a/src/node/evm/error.rs
+++ b/src/node/evm/error.rs
@@ -2,37 +2,13 @@
 
 use alloy_primitives::{Address, BlockHash, BlockNumber, B256, U256};
 use crate::consensus::parlia::error::ParliaConsensusError;
-use reth_evm::execute::BlockExecutionError;
+use reth_evm::execute::{BlockExecutionError, BlockValidationError};
 use reth_provider::ProviderError;
 use reth_primitives::{GotExpected, GotExpectedBoxed};
 
-/// Bsc Block Executor Errors
+/// BSC specific block validation error
 #[derive(thiserror::Error, Debug, Clone)]
-pub enum BscBlockExecutionError {
-    /// Error when the system txs are more than expected
-    #[error("unexpected system tx")]
-    UnexpectedSystemTx,
-
-    /// Error when there are normal tx after system tx
-    #[error("unexpected normal tx after system tx")]
-    UnexpectedNormalTx,
-
-    /// Error when there is no snapshot found
-    #[error("no snapshot found")]
-    SnapshotNotFound,
-
-    /// Error when eth call failed
-    #[error("eth call failed")]
-    EthCallFailed,
-
-    /// Error when the validators in header are invalid
-    #[error("invalid validators in header")]
-    InvalidValidators,
-
-    /// Error when get top validators failed
-    #[error("get top validators failed")]
-    GetTopValidatorsFailed,
-
+pub enum BscBlockValidationError {
     /// Error when the block proposer is in the backoff period
     #[error("block [number={block_number}, hash={hash}] proposer is in the backoff period")]
     FutureBlock {
@@ -41,30 +17,24 @@ pub enum BscBlockExecutionError {
         /// The block hash
         hash: B256,
     },
+    
+    /// Error when the system txs are more than expected
+    #[error("unexpected system tx")]
+    UnexpectedSystemTx,
 
-    /// Error when the parent hash of a block is not known.
-    #[error("block parent [hash={hash}] is not known")]
-    ParentUnknown {
-        /// The hash of the unknown parent block.
-        hash: BlockHash,
-    },
+    /// Error when there are normal tx after system tx
+    #[error("unexpected normal tx after system tx")]
+    UnexpectedNormalTx,
 
-    /// Error when apply snapshot failed
-    #[error("apply snapshot failed")]
-    ApplySnapshotFailed,
+    /// Error when the validators in header are invalid
+    #[error("invalid validators in header")]
+    InvalidValidators,
 
     /// Error when the attestation's extra length is too large
     #[error("attestation extra length {extra_len} is too large")]
     TooLargeAttestationExtraLen {
         /// The extra length
         extra_len: usize,
-    },
-
-    /// Error when the header is unknown
-    #[error("unknown header [hash={block_hash}]")]
-    UnknownHeader {
-        /// The block hash
-        block_hash: B256,
     },
 
     /// Error when the attestation's target is invalid
@@ -88,13 +58,6 @@ pub enum BscBlockExecutionError {
     /// Error when the attestation's vote count is invalid
     #[error("invalid attestation vote count: {0}")]
     InvalidAttestationVoteCount(GotExpected<u64>),
-
-    /// Error when the vote address is not found
-    #[error("vote address not found: {address}")]
-    VoteAddrNotFoundInSnap {
-        /// The vote address
-        address: Address,
-    },
 
     /// Error when the block's header signer is invalid
     #[error("wrong header signer: block number {block_number}, signer {signer}")]
@@ -136,6 +99,63 @@ pub enum BscBlockExecutionError {
     #[error("invalid validators election info data")]
     InvalidValidatorsElectionInfoData,
 
+    /// Error when the turn length is different from the calculated turn length
+    #[error("mismatching turn length on epoch block")]
+    MismatchingEpochTurnLengthError,
+
+    /// Error when encountering a parlia consensus error
+    #[error("parlia consensus error: {error}")]
+    ParliaConsensusError {
+        /// The parlia error.
+        #[source]
+        error: Box<ParliaConsensusError>,
+    },
+}
+
+/// Bsc Block Executor Errors
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum BscBlockExecutionError {
+    /// BSC validation error
+    #[error(transparent)]
+    Validation(#[from] BscBlockValidationError),
+
+    /// Error when there is no snapshot found
+    #[error("no snapshot found")]
+    SnapshotNotFound,
+
+    /// Error when eth call failed
+    #[error("eth call failed")]
+    EthCallFailed,
+
+    /// Error when get top validators failed
+    #[error("get top validators failed")]
+    GetTopValidatorsFailed,
+
+    /// Error when the parent hash of a block is not known.
+    #[error("block parent [hash={hash}] is not known")]
+    ParentUnknown {
+        /// The hash of the unknown parent block.
+        hash: BlockHash,
+    },
+
+    /// Error when apply snapshot failed
+    #[error("apply snapshot failed")]
+    ApplySnapshotFailed,
+
+    /// Error when the header is unknown
+    #[error("unknown header [hash={block_hash}]")]
+    UnknownHeader {
+        /// The block hash
+        block_hash: B256,
+    },
+
+    /// Error when the vote address is not found
+    #[error("vote address not found: {address}")]
+    VoteAddrNotFoundInSnap {
+        /// The vote address
+        address: Address,
+    },
+
     /// Error when encountering a blst inner error
     #[error("blst inner error")]
     BLSTInnerError,
@@ -148,21 +168,9 @@ pub enum BscBlockExecutionError {
         error: Box<ProviderError>,
     },
 
-    /// Error when encountering a parlia inner error
-    #[error("parlia inner error: {error}")]
-    ParliaConsensusInnerError {
-        /// The parlia error.
-        #[source]
-        error: Box<ParliaConsensusError>,
-    },
-
     /// Error when failed to execute system contract upgrade
     #[error("system contract upgrade error")]
     SystemContractUpgradeError,
-
-    /// Error when the turn length is different from the calculated turn length
-    #[error("mismatching turn length on epoch block")]
-    MismatchingEpochTurnLengthError,
 
     /// Error when failed to sign system transaction
     #[error("failed to sign system transaction: {error}")]
@@ -178,6 +186,32 @@ pub enum BscBlockExecutionError {
 
 impl From<BscBlockExecutionError> for BlockExecutionError {
     fn from(err: BscBlockExecutionError) -> Self {
-        Self::other(err)
+        match err {
+            BscBlockExecutionError::Validation(validation_err) => {
+                // TODO: now use DepositRequestDecode as the validation error carrier,
+                // but we should refine it by rewrite some validation error types in reth engine-tree.
+                // Note: Validation errors will be identified in the engine-tree and treated as invalid blocks. 
+                Self::Validation(BlockValidationError::DepositRequestDecode(
+                    format!("BSC validation error: {}", validation_err)
+                ))
+            }
+            
+            BscBlockExecutionError::SnapshotNotFound |
+            BscBlockExecutionError::EthCallFailed |
+            BscBlockExecutionError::GetTopValidatorsFailed |
+            BscBlockExecutionError::ParentUnknown { .. } |
+            BscBlockExecutionError::ApplySnapshotFailed |
+            BscBlockExecutionError::UnknownHeader { .. } |
+            BscBlockExecutionError::VoteAddrNotFoundInSnap { .. } |
+            BscBlockExecutionError::BLSTInnerError |
+            BscBlockExecutionError::ProviderInnerError { .. } |
+            BscBlockExecutionError::SystemContractUpgradeError |
+            BscBlockExecutionError::FailedToSignSystemTransaction { .. } |
+            BscBlockExecutionError::GlobalSignerNotInitializedForMiningMode => {
+                // Note: Internal errors will be identified in the engine-tree, 
+                // and the entire program will exit.
+                Self::other(err)
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description

Convert execution-err to validation-err and avoid thread exit by execution-err.

### Rationale

engine-tree will exit by execution error, but only mark invalid block by validation error.

### Example

N/A.

### Changes

Notable changes: 
* error related*

### Potential Impacts
N/A.
