### PR TITLE
feat(evn): EVN full-broadcast via BSC subprotocol + NodeIDs mgmt and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ This project aims to bring Reth's high-performance Ethereum client capabilities 
 
 Refer to the [Reth documentation](https://reth.rs/) for general guidance on running a node. Note that some BSC-specific configurations may be required.
 
+### EVN Support
+
+This client implements the BSC upgrade-status handshake extension. When EVN is enabled, the node requests peers to disable transaction broadcast towards it, mirroring the Enhanced Validator Network behavior used by validator/sentry nodes.
+
+- Enable via CLI: `--evn.enabled`
+- Or via env var: `BSC_EVN_ENABLED=true`
+- EVN activates only after the node is synced (based on head timestamp lag). Override lag threshold via `BSC_EVN_SYNC_LAG_SECS` (default 30s). Existing peers are refreshed once EVN is armed.
+
+Note: This currently affects the outgoing handshake signaling. Further EVN behaviors (e.g., peer whitelists, conditional broadcast policies) can be added incrementally.
+
 ## Contributing
 
 We welcome community contributions! Whether you're interested in helping with historical sync implementation, BSC Pectra support, or live sync functionality, your help is valuable. Please feel free to open issues or submit pull requests. You can reach out to me on [Telegram](https://t.me/loocapro).

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -253,7 +253,7 @@ where
             if let Some(outcome) = outcome {
                 if let Ok(BlockValidation::ValidBlock { block }) = &outcome.result {
                     this.processed_blocks.insert(block.hash);
-                    
+                    // TODO(reth hook): If from proxied validators, target EVN peers with ETH broadcast.
                     // Prune old votes from the vote pool based on the new block number
                     let block_number = block.block.0.block.header.number();
                     vote_pool::prune(block_number);

--- a/src/node/network/bsc_protocol/protocol/handler.rs
+++ b/src/node/network/bsc_protocol/protocol/handler.rs
@@ -52,6 +52,11 @@ impl ConnectionHandler for BscConnectionHandler {
         // when available. However, reth passes `_peer_id` which we can use.
         // Even if the connection drops, failed sends will lazily clean up entries.
         registry::register_peer(_peer_id, tx);
+        // EVN: mark this peer if present in whitelist
+        crate::node::network::evn_peers::mark_evn_if_whitelisted(_peer_id);
+        // Ensure EVN refresh listener is running to handle post-sync EVN updates
+        // for existing peers.
+        crate::node::network::bsc_protocol::registry::spawn_evn_refresh_listener();
         BscProtocolConnection::new(conn, rx, direction.is_outgoing())
     }
 }

--- a/src/node/network/bsc_protocol/protocol/proto.rs
+++ b/src/node/network/bsc_protocol/protocol/proto.rs
@@ -6,7 +6,9 @@ pub const BSC_PROTOCOL_VERSION: u64 = 1;
 /// BSC protocol name
 pub const BSC_PROTOCOL_NAME: &str = "bsc";
 
-/// Number of message types supported (0x00, 0x01)
+/// Number of message types supported (strict parity subset)
+/// 0x00: Capability
+/// 0x01: Votes
 pub const BSC_MESSAGE_COUNT: u8 = 2;
 
 #[repr(u8)]
@@ -14,9 +16,6 @@ pub const BSC_MESSAGE_COUNT: u8 = 2;
 pub enum BscProtoMessageId {
     Capability = 0x00,
     Votes = 0x01,
-    // TODO: Add these back in when we have a use case for them
-    // GetBlocksByRange = 0x02,
-    // BlocksByRange = 0x03,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -118,6 +117,3 @@ mod tests {
         assert_eq!(with_msg_id, encoded_packet);
     }
 }
-
-
-

--- a/src/node/network/bsc_protocol/registry.rs
+++ b/src/node/network/bsc_protocol/registry.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use once_cell::sync::Lazy;
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::task::JoinHandle;
+use tokio::sync::broadcast;
 
 use reth_network_api::PeerId;
 
@@ -12,6 +14,10 @@ use super::stream::BscCommand;
 /// Global registry of active BSC protocol senders per peer.
 static REGISTRY: Lazy<RwLock<HashMap<PeerId, UnboundedSender<BscCommand>>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Optional background task handle for EVN post-sync peer refresh.
+static EVN_REFRESH_TASK: Lazy<RwLock<Option<JoinHandle<()>>>> =
+    Lazy::new(|| RwLock::new(None));
 
 /// Register a new peer's sender channel.
 pub fn register_peer(peer: PeerId, tx: UnboundedSender<BscCommand>) {
@@ -33,7 +39,7 @@ pub fn broadcast_votes(votes: Vec<crate::consensus::parlia::vote::VoteEnvelope>)
     match REGISTRY.read() {
         Ok(guard) => {
             for (peer, tx) in guard.iter() {
-                if tx.send(BscCommand::SendVotes(Arc::clone(&votes_arc))).is_err() {
+                if tx.send(BscCommand::Votes(Arc::clone(&votes_arc))).is_err() {
                     to_remove.push(*peer);
                 }
             }
@@ -55,5 +61,76 @@ pub fn broadcast_votes(votes: Vec<crate::consensus::parlia::vote::VoteEnvelope>)
                 tracing::error!(target: "bsc::registry", error=%e, "Registry lock poisoned (cleanup)");
             }
         }
+    }
+}
+
+// Snapshot current connected peers (BSC protocol) by PeerId.
+// Note: currently used only as part of internal EVN refresh; can be reinstated if needed.
+
+/// Subscribe to EVN-armed notification and log-refresh current peers.
+/// This helps post-sync peers reflect EVN policy locally. Remote peers
+/// will pick up EVN on subsequent handshakes; this is a best-effort local refresh.
+pub fn spawn_evn_refresh_listener() {
+    // One-shot install only
+    if let Ok(mut guard) = EVN_REFRESH_TASK.write() {
+        if guard.is_some() { return; }
+
+        // Subscribe to EVN armed broadcast channel
+        let rx = crate::node::network::evn::subscribe_evn_armed();
+        let handle = tokio::spawn(async move {
+            let mut rx = rx;
+            loop {
+                match rx.recv().await {
+                    Ok(()) => {
+                        // On EVN arm, log the currently registered peers
+                        let peers: Vec<PeerId> = match REGISTRY.read() {
+                            Ok(g) => g.keys().copied().collect(),
+                            Err(_) => Vec::new(),
+                        };
+                        tracing::info!(
+                            target: "bsc::evn",
+                            peer_count = peers.len(),
+                            "EVN armed: refreshing EVN state for existing peers"
+                        );
+                        // Apply on-chain NodeIDs to current peers if available
+                        let nodeids = crate::node::network::evn_peers::get_onchain_nodeids_set();
+                        let mut marked = 0usize;
+                        for p in peers {
+                            let pid = p.to_string();
+                            let pid_norm = crate::node::network::evn_peers::normalize_node_id_str(&pid);
+                            if nodeids.contains(&pid_norm) {
+                                crate::node::network::evn_peers::mark_evn_onchain(p);
+                                marked += 1;
+                            }
+                        }
+                        tracing::info!(target: "bsc::evn", marked, "Applied on-chain EVN NodeIDs to peers");
+
+                        // Start periodic refresh every 60s to apply on-chain NodeIDs to existing peers
+                        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+                        loop {
+                            ticker.tick().await;
+                            let peers: Vec<PeerId> = match REGISTRY.read() {
+                                Ok(g) => g.keys().copied().collect(),
+                                Err(_) => Vec::new(),
+                            };
+                            let nodeids = crate::node::network::evn_peers::get_onchain_nodeids_set();
+                            let mut marked = 0usize;
+                            for p in peers {
+                                let pid = p.to_string();
+                                let pid_norm = crate::node::network::evn_peers::normalize_node_id_str(&pid);
+                                if nodeids.contains(&pid_norm) {
+                                    crate::node::network::evn_peers::mark_evn_onchain(p);
+                                    marked += 1;
+                                }
+                            }
+                            tracing::debug!(target: "bsc::evn", marked, "Periodic EVN on-chain NodeIDs applied to peers");
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                }
+            }
+        });
+        *guard = Some(handle);
     }
 }

--- a/src/node/network/evn.rs
+++ b/src/node/network/evn.rs
@@ -1,0 +1,74 @@
+use alloy_primitives::Address;
+use std::sync::{OnceLock, atomic::{AtomicBool, Ordering}};
+use tokio::sync::broadcast;
+
+/// EVN configuration
+#[derive(Clone, Debug, Default)]
+pub struct EvnConfig {
+    pub enabled: bool,
+    pub whitelist_nodeids: Vec<String>,
+    pub proxyed_validators: Vec<Address>,
+    pub nodeids_to_add: Vec<[u8; 32]>,
+    pub nodeids_to_remove: Vec<[u8; 32]>,
+    pub nodeids_nonce: Option<u64>,
+}
+
+/// Global EVN config
+static GLOBAL_EVN_CONFIG: OnceLock<EvnConfig> = OnceLock::new();
+
+/// Sets the global EVN config. Returns an error if already set.
+pub fn set_global_evn_config(cfg: EvnConfig) -> Result<(), EvnConfig> { GLOBAL_EVN_CONFIG.set(cfg) }
+
+/// Convenience: set only enabled flag.
+pub fn set_global_evn_enabled(enabled: bool) -> Result<(), bool> {
+    if let Some(cfg) = GLOBAL_EVN_CONFIG.get() {
+        let mut new = cfg.clone();
+        new.enabled = enabled;
+        return GLOBAL_EVN_CONFIG.set(new).map_err(|_| enabled);
+    }
+    GLOBAL_EVN_CONFIG.set(EvnConfig { enabled, ..Default::default() }).map_err(|_| enabled)
+}
+
+/// Returns the global EVN config if set.
+pub fn get_global_evn_config() -> Option<&'static EvnConfig> { GLOBAL_EVN_CONFIG.get() }
+
+/// Returns true if EVN is enabled globally either via explicit global set or
+/// via environment variable fallback.
+pub fn is_evn_enabled() -> bool {
+    if let Some(cfg) = GLOBAL_EVN_CONFIG.get() {
+        return cfg.enabled;
+    }
+    // Fallback to environment var if global not initialized by CLI.
+    std::env::var("BSC_EVN_ENABLED")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
+        .unwrap_or(false)
+}
+
+/// Global EVN synced flag (armed after node is considered synced)
+static EVN_SYNCED: AtomicBool = AtomicBool::new(false);
+static EVN_ARMED_TX: OnceLock<broadcast::Sender<()>> = OnceLock::new();
+
+/// Mark EVN as synced/armed. Once set to true it stays true.
+pub fn set_evn_synced(synced: bool) {
+    if synced {
+        EVN_SYNCED.store(true, Ordering::Relaxed);
+        // Broadcast EVN-armed event (create channel lazily)
+        if let Some(tx) = EVN_ARMED_TX.get() {
+            let _ = tx.send(());
+        }
+    } else {
+        // keep it sticky-on to mirror geth behavior once synced; do not flip off
+    }
+}
+
+/// Returns whether EVN is considered synced/armed.
+pub fn is_evn_synced() -> bool { EVN_SYNCED.load(Ordering::Relaxed) }
+
+/// EVN is ready only when enabled and synced (post-initial-sync)
+pub fn is_evn_ready() -> bool { is_evn_enabled() && is_evn_synced() }
+
+/// Returns a receiver for EVN armed notifications; creates the channel if missing.
+pub fn subscribe_evn_armed() -> broadcast::Receiver<()> {
+    let tx = EVN_ARMED_TX.get_or_init(|| broadcast::channel(4).0);
+    tx.subscribe()
+}

--- a/src/node/network/evn_peers.rs
+++ b/src/node/network/evn_peers.rs
@@ -1,0 +1,82 @@
+use once_cell::sync::Lazy;
+use reth_network_api::PeerId;
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
+
+/// Why a peer is considered an EVN peer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvnMarkReason {
+    Whitelist,
+    OnchainValidator,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct EvnPeerInfo {
+    pub is_evn: bool,
+    pub reason: Option<EvnMarkReason>,
+}
+
+static EVN_PEERS: Lazy<RwLock<HashMap<PeerId, EvnPeerInfo>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Global on-chain NodeIDs set (normalized hex strings without 0x)
+static ONCHAIN_NODEIDS: Lazy<RwLock<HashSet<String>>> =
+    Lazy::new(|| RwLock::new(HashSet::new()));
+
+/// Normalize an ID string for consistent comparison
+pub fn normalize_node_id_str(s: &str) -> String {
+    let s = s.trim().to_lowercase();
+    s.strip_prefix("0x").unwrap_or(&s).to_string()
+}
+
+/// Attempt to mark a peer as EVN by whitelist entries in the global EVN config.
+pub fn mark_evn_if_whitelisted(peer: PeerId) {
+    if let Some(cfg) = crate::node::network::evn::get_global_evn_config() {
+        if !cfg.enabled { return; }
+        if cfg.whitelist_nodeids.is_empty() { return; }
+
+        // Compare peer's ID string with whitelist entries
+        let pid = peer.to_string();
+        let pid_norm = normalize_node_id_str(&pid);
+        let is_whitelisted = cfg.whitelist_nodeids.iter().any(|w| normalize_node_id_str(w) == pid_norm);
+        if is_whitelisted {
+            if let Ok(mut map) = EVN_PEERS.write() {
+                map.entry(peer).and_modify(|e| { e.is_evn = true; e.reason = Some(EvnMarkReason::Whitelist); })
+                    .or_insert(EvnPeerInfo { is_evn: true, reason: Some(EvnMarkReason::Whitelist) });
+            }
+        }
+    }
+}
+
+/// Mark a peer as EVN due to onchain validator mapping.
+pub fn mark_evn_onchain(peer: PeerId) {
+    if let Ok(mut map) = EVN_PEERS.write() {
+        map.entry(peer).and_modify(|e| { e.is_evn = true; e.reason = Some(EvnMarkReason::OnchainValidator); })
+            .or_insert(EvnPeerInfo { is_evn: true, reason: Some(EvnMarkReason::OnchainValidator) });
+    }
+}
+
+/// Query whether a peer is currently marked EVN.
+pub fn is_evn_peer(peer: PeerId) -> bool {
+    if let Ok(map) = EVN_PEERS.read() { map.get(&peer).map(|i| i.is_evn).unwrap_or(false) } else { false }
+}
+
+/// Current EVN peer snapshot
+pub fn snapshot() -> Vec<(PeerId, EvnPeerInfo)> {
+    if let Ok(map) = EVN_PEERS.read() { map.iter().map(|(k,v)| (*k, v.clone())).collect() } else { Vec::new() }
+}
+
+/// Update the on-chain NodeIDs cache with the provided list
+pub fn update_onchain_nodeids(ids: Vec<[u8; 32]>) {
+    if let Ok(mut set) = ONCHAIN_NODEIDS.write() {
+        for id in ids {
+            let hex = alloy_primitives::hex::encode(id);
+            set.insert(hex);
+        }
+    }
+}
+
+/// Get a snapshot of on-chain NodeIDs as normalized hex strings
+pub fn get_onchain_nodeids_set() -> HashSet<String> {
+    if let Ok(set) = ONCHAIN_NODEIDS.read() { set.clone() } else { HashSet::new() }
+}

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -2,7 +2,7 @@ use crate::consensus::parlia::SnapshotProvider;
 use std::sync::{Arc, OnceLock};
 use alloy_consensus::Header;
 use alloy_primitives::B256;
-use reth_provider::HeaderProvider;
+use reth_provider::{HeaderProvider, BlockNumReader};
 use crate::node::network::block_import::service::IncomingBlock;
 use tokio::sync::mpsc::UnboundedSender;
 use reth_network_api::PeerId;
@@ -21,6 +21,12 @@ static HEADER_BY_HASH_PROVIDER: OnceLock<HeaderByHashFn> = OnceLock::new();
 
 /// Global header provider function - HeaderProvider::header_by_number() by number  
 static HEADER_BY_NUMBER_PROVIDER: OnceLock<HeaderByNumberFn> = OnceLock::new();
+
+/// Function type for BlockNumReader::best_block_number()
+type BestBlockNumberFn = Arc<dyn Fn() -> Option<u64> + Send + Sync>;
+
+/// Global best block number function
+static BEST_BLOCK_NUMBER_PROVIDER: OnceLock<BestBlockNumberFn> = OnceLock::new();
 
 /// Global sender for submitting mined blocks to the import service
 static BLOCK_IMPORT_SENDER: OnceLock<UnboundedSender<IncomingBlock>> = OnceLock::new();
@@ -42,7 +48,7 @@ pub fn get_snapshot_provider() -> Option<&'static Arc<dyn SnapshotProvider + Sen
 /// Creates functions that directly call HeaderProvider::header() and HeaderProvider::header_by_number()
 pub fn set_header_provider<T>(provider: Arc<T>) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 where
-    T: HeaderProvider<Header = Header> + Send + Sync + 'static,
+    T: HeaderProvider<Header = Header> + BlockNumReader + Send + Sync + 'static,
 {
     // Create function for header by hash
     let provider_clone = provider.clone();
@@ -65,6 +71,13 @@ where
     // Set both functions
     HEADER_BY_HASH_PROVIDER.set(header_by_hash_fn).map_err(|_| "Failed to set hash provider")?;
     HEADER_BY_NUMBER_PROVIDER.set(header_by_number_fn).map_err(|_| "Failed to set number provider")?;
+
+    // Create function for best block number
+    let provider_clone3 = provider.clone();
+    let best_block_number_fn = Arc::new(move || -> Option<u64> { provider_clone3.best_block_number().ok() });
+    BEST_BLOCK_NUMBER_PROVIDER
+        .set(best_block_number_fn)
+        .map_err(|_| "Failed to set best block number provider")?;
     
     Ok(())
 }
@@ -103,6 +116,11 @@ pub fn get_header_by_number(block_number: u64) -> Option<Header> {
     get_header_by_number_from_provider(block_number)
 }
 
+/// Get the best block number from the global provider if initialized
+pub fn get_best_block_number() -> Option<u64> {
+    BEST_BLOCK_NUMBER_PROVIDER.get().and_then(|f| f())
+}
+
 /// Store the block import sender globally. Returns an error if it was set before.
 pub fn set_block_import_sender(sender: UnboundedSender<IncomingBlock>) -> Result<(), UnboundedSender<IncomingBlock>> {
     BLOCK_IMPORT_SENDER.set(sender)
@@ -112,6 +130,7 @@ pub fn set_block_import_sender(sender: UnboundedSender<IncomingBlock>) -> Result
 pub fn get_block_import_sender() -> Option<&'static UnboundedSender<IncomingBlock>> {
     BLOCK_IMPORT_SENDER.get()
 }
+
 
 /// Store the local peer ID globally. Returns an error if it was set before.
 pub fn set_local_peer_id(peer_id: PeerId) -> Result<(), PeerId> {

--- a/src/system_contracts/mod.rs
+++ b/src/system_contracts/mod.rs
@@ -123,16 +123,21 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
 
     /// Return system address and input which is used to query validator election info.
     pub fn get_validator_election_info(&self) -> (Address, Bytes) {
+        self.get_validator_election_info_with(U256::from(0), U256::from(0))
+    }
+
+    /// Return system address and input which is used to query validator election info with pagination.
+    /// Offset and limit follow the StakeHub contract's semantics.
+    pub fn get_validator_election_info_with(&self, offset: U256, limit: U256) -> (Address, Bytes) {
         let function =
             self.stake_hub_abi.function("getValidatorElectionInfo").unwrap().first().unwrap();
-
         (
             STAKE_HUB_CONTRACT,
             Bytes::from(
                 function
                     .abi_encode_input(&[
-                        DynSolValue::from(U256::from(0)),
-                        DynSolValue::from(U256::from(0)),
+                        DynSolValue::from(offset),
+                        DynSolValue::from(limit),
                     ])
                     .unwrap(),
             ),
@@ -176,6 +181,47 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
         let output = function.abi_decode_output(data).unwrap();
 
         output[0].as_uint().unwrap().0
+    }
+
+    /// Return system address and input to query validator NodeIDs from StakeHub.
+    pub fn get_node_ids(&self, validators: Vec<Address>) -> (Address, Bytes) {
+        let function = self.stake_hub_abi.function("getNodeIDs").unwrap().first().unwrap();
+        let vals = validators.into_iter().map(DynSolValue::from).collect::<Vec<_>>();
+        let input = function.abi_encode_input(&[DynSolValue::Array(vals)]).unwrap();
+        (STAKE_HUB_CONTRACT, Bytes::from(input))
+    }
+
+    /// Unpack the data into (consensusAddresses, nodeIDsList)
+    pub fn unpack_data_into_node_ids(&self, data: &[u8]) -> (Vec<Address>, Vec<Vec<[u8; 32]>>) {
+        let function = self.stake_hub_abi.function("getNodeIDs").unwrap().first().unwrap();
+        let output = function.abi_decode_output(data).unwrap();
+
+        let consensus_addresses = output[0]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|val| val.as_address().unwrap())
+            .collect::<Vec<_>>();
+
+        let node_ids_list = output[1]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|arr| {
+                arr.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| {
+                        let (b, _size) = v.as_fixed_bytes().unwrap();
+                        let mut out = [0u8; 32];
+                        out.copy_from_slice(b);
+                        out
+                    })
+                    .collect::<Vec<[u8; 32]>>()
+            })
+            .collect::<Vec<_>>();
+
+        (consensus_addresses, node_ids_list)
     }
 
     /// Return a transaction to slash a validator.
@@ -246,6 +292,63 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
             value: U256::ZERO,
             input: Bytes::from(input),
             to: TxKind::Call(VALIDATOR_CONTRACT),
+        })
+    }
+
+    /// Creates a transaction to add NodeIDs for the validator in StakeHub.
+    /// Mirrors BSC's StakeHub.addNodeIDs(bytes32[] nodeIDs).
+    #[allow(dead_code)]
+    pub fn add_node_ids_tx(&self, node_ids: Vec<[u8; 32]>, nonce: u64) -> Transaction {
+        let function = self.stake_hub_abi.function("addNodeIDs").unwrap().first().unwrap();
+
+        // Encode bytes32[]
+        let node_ids_values: Vec<DynSolValue> = node_ids
+            .into_iter()
+            .map(|id| {
+                let fb: alloy_primitives::FixedBytes<32> = alloy_primitives::FixedBytes::from(id);
+                DynSolValue::FixedBytes(fb, 32)
+            })
+            .collect();
+        let input = function
+            .abi_encode_input(&[DynSolValue::Array(node_ids_values)])
+            .unwrap();
+
+        Transaction::Legacy(TxLegacy {
+            chain_id: Some(self.chain_spec.chain().id()),
+            nonce,
+            gas_limit: u64::MAX / 2,
+            gas_price: 0,
+            value: U256::ZERO,
+            input: Bytes::from(input),
+            to: TxKind::Call(STAKE_HUB_CONTRACT),
+        })
+    }
+
+    /// Creates a transaction to remove NodeIDs for the validator in StakeHub.
+    /// Mirrors BSC's StakeHub.removeNodeIDs(bytes32[] nodeIDs).
+    #[allow(dead_code)]
+    pub fn remove_node_ids_tx(&self, node_ids: Vec<[u8; 32]>, nonce: u64) -> Transaction {
+        let function = self.stake_hub_abi.function("removeNodeIDs").unwrap().first().unwrap();
+
+        let node_ids_values: Vec<DynSolValue> = node_ids
+            .into_iter()
+            .map(|id| {
+                let fb: alloy_primitives::FixedBytes<32> = alloy_primitives::FixedBytes::from(id);
+                DynSolValue::FixedBytes(fb, 32)
+            })
+            .collect();
+        let input = function
+            .abi_encode_input(&[DynSolValue::Array(node_ids_values)])
+            .unwrap();
+
+        Transaction::Legacy(TxLegacy {
+            chain_id: Some(self.chain_spec.chain().id()),
+            nonce,
+            gas_limit: u64::MAX / 2,
+            gas_price: 0,
+            value: U256::ZERO,
+            input: Bytes::from(input),
+            to: TxKind::Call(STAKE_HUB_CONTRACT),
         })
     }
 
@@ -346,6 +449,73 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
             })
             .collect()
     }
+}
+
+#[cfg(test)]
+mod nodeids_call_tests {
+    use super::*;
+
+    #[test]
+    fn encode_add_remove_nodeids_call_roundtrip() {
+        // Prepare two dummy node IDs (bytes32)
+        let id1 = [0x11u8; 32];
+        let id2 = [0x22u8; 32];
+        let (to_add, data_add) = encode_add_node_ids_call(vec![id1, id2]);
+        assert_eq!(to_add, STAKE_HUB_CONTRACT);
+
+        // Decode using ABI to ensure encoding correctness
+        let abi: JsonAbi = serde_json::from_str(*STAKE_HUB_ABI).unwrap();
+        let func = abi.function("addNodeIDs").unwrap().first().unwrap();
+        let out = func.abi_decode_input(&data_add[4..]).unwrap();
+        assert_eq!(out.len(), 1);
+        let arr = out[0].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let got1 = arr[0].as_fixed_bytes().unwrap().0;
+        let got2 = arr[1].as_fixed_bytes().unwrap().0;
+        assert_eq!(got1, id1);
+        assert_eq!(got2, id2);
+
+        let (to_rm, data_rm) = encode_remove_node_ids_call(vec![id2]);
+        assert_eq!(to_rm, STAKE_HUB_CONTRACT);
+        let func_rm = abi.function("removeNodeIDs").unwrap().first().unwrap();
+        let out_rm = func_rm.abi_decode_input(&data_rm[4..]).unwrap();
+        let arr_rm = out_rm[0].as_array().unwrap();
+        let got_rm = arr_rm[0].as_fixed_bytes().unwrap().0;
+        assert_eq!(got_rm, id2);
+    }
+}
+/// Encode StakeHub.addNodeIDs call data and return (to, data).
+pub fn encode_add_node_ids_call(node_ids: Vec<[u8; 32]>) -> (Address, Bytes) {
+    let stake_hub_abi: JsonAbi = serde_json::from_str(*STAKE_HUB_ABI).unwrap();
+    let function = stake_hub_abi.function("addNodeIDs").unwrap().first().unwrap();
+    let node_ids_values: Vec<DynSolValue> = node_ids
+        .into_iter()
+        .map(|id| {
+            let fb: alloy_primitives::FixedBytes<32> = alloy_primitives::FixedBytes::from(id);
+            DynSolValue::FixedBytes(fb, 32)
+        })
+        .collect();
+    let input = function
+        .abi_encode_input(&[DynSolValue::Array(node_ids_values)])
+        .unwrap();
+    (STAKE_HUB_CONTRACT, Bytes::from(input))
+}
+
+/// Encode StakeHub.removeNodeIDs call data and return (to, data).
+pub fn encode_remove_node_ids_call(node_ids: Vec<[u8; 32]>) -> (Address, Bytes) {
+    let stake_hub_abi: JsonAbi = serde_json::from_str(*STAKE_HUB_ABI).unwrap();
+    let function = stake_hub_abi.function("removeNodeIDs").unwrap().first().unwrap();
+    let node_ids_values: Vec<DynSolValue> = node_ids
+        .into_iter()
+        .map(|id| {
+            let fb: alloy_primitives::FixedBytes<32> = alloy_primitives::FixedBytes::from(id);
+            DynSolValue::FixedBytes(fb, 32)
+        })
+        .collect();
+    let input = function
+        .abi_encode_input(&[DynSolValue::Array(node_ids_values)])
+        .unwrap();
+    (STAKE_HUB_CONTRACT, Bytes::from(input))
 }
 
 pub const VALIDATOR_CONTRACT: Address = address!("0x0000000000000000000000000000000000001000");


### PR DESCRIPTION
…periodic refresh; CLI-driven StakeHub NodeIDs tx build/sign

### Description

Implemented (no reth changes)
  - On-chain NodeIDs identification:
      - Fetch (pre-exec) + global cache
      - Apply on EVN arm + periodic refresh (60s) to mark EVN peers
  - CLI-driven StakeHub NodeIDs management:
      - Parse add/remove node IDs + nonce
      - Build, sign with mining key, and log raw RLP + tx hash

https://github.com/bnb-chain/bsc/pull/3309
https://github.com/bnb-chain/bsc/pull/3212
https://github.com/bnb-chain/bsc/pull/3073
https://github.com/bnb-chain/bsc/pull/3083
https://github.com/bnb-chain/bsc/pull/3070
https://github.com/bnb-chain/bsc/pull/3101

  Not yet (requires small reth API)

  - Dynamic “trusted peer” marking for EVN peers at runtime
  - ETH gossiper filter to suppress tx broadcast to EVN peers
  - ETH-native targeted NewBlock/NewBlockHashes sender (we use BSC subprotocol hint instead)