### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-pat
 
 # Build application
 COPY --exclude=dist . .
-RUN cargo build --bin reth-bsc --features jemalloc,asm-keccak --profile release
+RUN cargo build --bin reth-bsc --profile $BUILD_PROFILE --features "$FEATURES"
 
 # ARG is not resolved in COPY so we have to hack around it by copying the
 # binary to a temporary location


### PR DESCRIPTION
### Description

Adds a dockerfile, based on the base Reth repo, but using the reth-bsc cargo build command

### Rationale

So that an official image can be published

Fixes https://github.com/bnb-chain/reth-bsc/issues/103