### PR TITLE
fix: fix qanet fermi HF timestamp

### DIFF
--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -201,7 +201,7 @@ impl BscHardfork {
             (Self::Pascal.boxed(), ForkCondition::Timestamp(1754967081)),
             (Self::Lorentz.boxed(), ForkCondition::Timestamp(1754967081)),
             (Self::Maxwell.boxed(), ForkCondition::Timestamp(1754967101)),
-            (Self::Fermi.boxed(), ForkCondition::Timestamp(9999999999)), 
+            (Self::Fermi.boxed(), ForkCondition::Timestamp(1761030900)), 
         ])
     }
 


### PR DESCRIPTION
### Description

Fix qanet fermi HF timestamp

### Rationale

The qanet fermi HF timestamp is mis-overwritten in the rebase of https://github.com/bnb-chain/reth-bsc/pull/36.

### Example

N/A.

### Changes

Notable changes: 
* qanet HF configs.

### Potential Impacts
N/A.
