### PR TITLE
fix: fix get_node_ids panic

### DIFF
--- a/src/chainspec/parser.rs
+++ b/src/chainspec/parser.rs
@@ -207,5 +207,9 @@ fn add_hardforks_to_chainspec(
         chain_spec = chain_spec.with_fork(BscHardfork::Maxwell, ForkCondition::Timestamp(maxwell_time));
     }
     
+    if let Some(fermi_time) = config.get("fermiTime").and_then(|v| v.as_u64()) {
+        chain_spec = chain_spec.with_fork(BscHardfork::Fermi, ForkCondition::Timestamp(fermi_time));
+    }
+    
     Ok(chain_spec)
 }

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -101,12 +101,15 @@ where
             self.inner_ctx.current_validators = Some((validator_set, vote_addrs_map));
 
             // Also fetch on-chain NodeIDs for validators (EVN identification) and update cache.
-            let (to2, data2) = self.system_contracts.get_node_ids(self.inner_ctx.current_validators.as_ref().unwrap().0.clone());
-            if let Ok(output2) = self.eth_call(to2, data2) {
-                let (_consensus_addrs, node_ids_list) = self.system_contracts.unpack_data_into_node_ids(&output2);
-                let mut flat: Vec<[u8; 32]> = Vec::new();
-                for ids in node_ids_list { for id in ids { flat.push(id); } }
-                crate::node::network::evn_peers::update_onchain_nodeids(flat);
+            // Only available after Maxwell hardfork when StakeHub contract's getNodeIDs is deployed
+            if self.spec.is_maxwell_active_at_timestamp(header.number, header.timestamp) {
+                let (to2, data2) = self.system_contracts.get_node_ids(self.inner_ctx.current_validators.as_ref().unwrap().0.clone());
+                if let Ok(output2) = self.eth_call(to2, data2) {
+                    let (_consensus_addrs, node_ids_list) = self.system_contracts.unpack_data_into_node_ids(&output2);
+                    let mut flat: Vec<[u8; 32]> = Vec::new();
+                    for ids in node_ids_list { for id in ids { flat.push(id); } }
+                    crate::node::network::evn_peers::update_onchain_nodeids(flat);
+                }
             }
         }
     

--- a/src/system_contracts/mod.rs
+++ b/src/system_contracts/mod.rs
@@ -184,6 +184,7 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     }
 
     /// Return system address and input to query validator NodeIDs from StakeHub.
+    /// Note: This function should only be called after Maxwell hardfork when StakeHub.getNodeIDs is available.
     pub fn get_node_ids(&self, validators: Vec<Address>) -> (Address, Bytes) {
         let function = self.stake_hub_abi.function("getNodeIDs").unwrap().first().unwrap();
         let vals = validators.into_iter().map(DynSolValue::from).collect::<Vec<_>>();
@@ -192,6 +193,7 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     }
 
     /// Unpack the data into (consensusAddresses, nodeIDsList)
+    /// Note: This function should only be called after Maxwell hardfork when StakeHub.getNodeIDs is available.
     pub fn unpack_data_into_node_ids(&self, data: &[u8]) -> (Vec<Address>, Vec<Vec<[u8; 32]>>) {
         let function = self.stake_hub_abi.function("getNodeIDs").unwrap().first().unwrap();
         let output = function.abi_decode_output(data).unwrap();
@@ -297,6 +299,7 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
 
     /// Creates a transaction to add NodeIDs for the validator in StakeHub.
     /// Mirrors BSC's StakeHub.addNodeIDs(bytes32[] nodeIDs).
+    /// Note: This function should only be called after Maxwell hardfork when StakeHub.addNodeIDs is available.
     #[allow(dead_code)]
     pub fn add_node_ids_tx(&self, node_ids: Vec<[u8; 32]>, nonce: u64) -> Transaction {
         let function = self.stake_hub_abi.function("addNodeIDs").unwrap().first().unwrap();
@@ -326,6 +329,7 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
 
     /// Creates a transaction to remove NodeIDs for the validator in StakeHub.
     /// Mirrors BSC's StakeHub.removeNodeIDs(bytes32[] nodeIDs).
+    /// Note: This function should only be called after Maxwell hardfork when StakeHub.removeNodeIDs is available.
     #[allow(dead_code)]
     pub fn remove_node_ids_tx(&self, node_ids: Vec<[u8; 32]>, nonce: u64) -> Transaction {
         let function = self.stake_hub_abi.function("removeNodeIDs").unwrap().first().unwrap();


### PR DESCRIPTION
### Description

fix get_node_ids panic.

### Rationale

Only available after Maxwell hardfork when StakeHub contract's getNodeIDs is deployed.

### Example

```
thread 'tokio-runtime-worker' panicked at /src/system_contracts/mod.rs:197:55:
called `Result::unwrap()` on an `Err` value: SolTypes(Overrun)
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

### Changes

Notable changes: 
* EVN*.

### Potential Impacts
N/A.
