### PR TITLE
chore: update reth deps to try fix storageroot inprogress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6900,7 +6900,7 @@ checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 [[package]]
 name = "reth"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -6946,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6970,7 +6970,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7116,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -7175,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7240,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7339,7 +7339,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7365,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7389,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7479,7 +7479,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7501,7 +7501,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7526,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "futures",
  "pin-project",
@@ -7549,7 +7549,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7647,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "bytes 1.10.1",
@@ -7662,7 +7662,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7695,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7724,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "clap",
  "eyre",
@@ -7770,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7847,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7865,7 +7865,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7875,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7920,7 +7920,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7951,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "serde",
  "serde_json",
@@ -8013,7 +8013,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8040,7 +8040,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "bytes 1.10.1",
  "futures",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8077,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -8086,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "futures",
  "metrics",
@@ -8098,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
 ]
@@ -8106,7 +8106,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8120,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8200,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8223,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8238,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8252,7 +8252,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8293,7 +8293,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8361,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8475,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8499,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -8520,7 +8520,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8532,7 +8532,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8551,7 +8551,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8572,7 +8572,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8584,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8613,7 +8613,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8660,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8705,7 +8705,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8733,7 +8733,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8747,7 +8747,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8766,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8793,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8806,7 +8806,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8912,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8950,7 +8950,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9044,7 +9044,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9091,7 +9091,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -9105,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9121,7 +9121,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9281,7 +9281,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9315,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9325,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "clap",
  "eyre",
@@ -9340,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9381,7 +9381,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9432,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9470,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9507,7 +9507,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=44b23084c03131e1be20b6ade1138e947a425144#44b23084c03131e1be20b6ade1138e947a425144"
+source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,42 +13,42 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144", features = ["test-utils"] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144", features = ["serde"] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144", features = ["test-utils"] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144", features = ["test-utils"] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144", features = ["test-utils"] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "44b23084c03131e1be20b6ade1138e947a425144" }
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["serde"] }
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
 revm = "29.0.0"
 
 # alloy dependencies


### PR DESCRIPTION
### Description

Update reth deps to try fix storageroot inprogress.

### Rationale

In situations where a single block might update a large number of slots, we need this https://github.com/bnb-chain/reth/pull/36 or `--engine.disable-parallel-sparse-trie ` to avoid storage-root is not completed.

Also note that there have been significant changes to the concurrent hash calculation part of upstream reth. In the long run, we will merge the upstream code to maintain stability.

### Example

```
2025-11-04T03:25:30.114112Z DEBUG engine::tree: failed to connect buffered block to tree err=InsertBlockError { error: Other(StorageRoot(Database(Other("StorageRoot returned Progress variant in parallel trie calculation")))), hash: 0xe74bccae1280a0338facc02a6d4fdfd4d8570a132d1feed4960750f0aeb3b797, number: 10571139, parent_hash: 0x36adc3313425a5e7a9a7d978f43f88b7252c8064bf6885798413f1b14c0f84cd, num_txs: 3721, .. } 
2025-11-04T03:25:30.114936Z  WARN engine::tree: fatal error occurred while connecting buffered blocks fatal=StorageRoot returned Progress variant in parallel trie calculation
2025-11-04T03:25:30.115663Z ERROR engine::tree: insert block fatal error fatal=StorageRoot returned Progress variant in parallel trie calculation
2025-11-04T03:25:30.816636Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x963f924a45cca840cae25d6074bd0b0279b160ff343e200e3d1515224e819151 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816674Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x453b822a65ca83b56a6aa91724cc901f21dcb142228111669fa50ccdada0eed1 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816798Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xd1cd93052b08f471ffd543654e1db461ea09abe9244463d4c6437c9650680001 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816804Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x2db5c296cb65f73932c230d54ec50d0fb5973da22dfb2b59759f9ed23ff22b17 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816816Z ERROR ChainOrchestrator::poll: engine::tree: Fatal error
2025-11-04T03:25:30.816824Z DEBUG reth::cli: Event: FatalError
2025-11-04T03:25:30.816828Z ERROR reth::cli: Fatal error in consensus engine
2025-11-04T03:25:30.816845Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xf82531a1e242df236b2bbd603931455501ffcc91e23013f1b8f40a8086099f0d error=beacon consensus engine task stopped
2025-11-04T03:25:30.816891Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xe5d7ebd9c7992a28d1a6da5194049345f58e3583e30a5b0bb5cc87ef15a20059 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816898Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xc49dac3c14c187a8e4b5b8cd1a4b22cdb247eb4c96efd8447e8650bf834840be error=beacon consensus engine task stopped
2025-11-04T03:25:30.816901Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xf58884abe463759515e54162074267d6326c8ecc191cc06b845a49a010f029ba error=beacon consensus engine task stopped
2025-11-04T03:25:30.816904Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xee7f0c423199f62962cbe4e3088c69e601da2644940c6e0ccddba83109e3e252 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816907Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x0bb895ca28be80ac28e32598c7f1403c1a10305d041c42378fb641a9b54282e0 error=beacon consensus engine task stopped
2025-11-04T03:25:30.818124Z ERROR reth::cli: shutting down due to error

```

Key log is 
`2025-11-04T03:25:30.114744Z  WARN fatal error occurred while connecting buffered blocks fatal=StorageRoot returned Progress variant in parallel trie calculation`

### Changes

Notable changes: 
* reth deps*.

### Potential Impacts
N/A.
