### PR TITLE
chore: bump-v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6900,7 +6900,7 @@ checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 [[package]]
 name = "reth"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -6946,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6970,7 +6970,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7081,6 +7081,7 @@ dependencies = [
  "reth-evm",
  "reth-exex",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
@@ -7116,7 +7117,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7126,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7144,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7164,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -7175,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7190,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7203,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7215,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7240,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7266,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7294,7 +7295,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7324,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7339,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7365,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7389,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7413,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7448,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7479,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7501,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7526,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "futures",
  "pin-project",
@@ -7549,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7603,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7631,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7647,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "bytes 1.10.1",
@@ -7662,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7684,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7695,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7724,7 +7725,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7748,7 +7749,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "clap",
  "eyre",
@@ -7770,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7786,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7804,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7818,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7847,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7865,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7875,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7898,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7920,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7933,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7951,7 +7952,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7989,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8003,7 +8004,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "serde",
  "serde_json",
@@ -8013,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8040,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "bytes 1.10.1",
  "futures",
@@ -8060,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8077,7 +8078,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -8086,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "futures",
  "metrics",
@@ -8098,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
 ]
@@ -8106,7 +8107,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8120,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8175,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8200,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8223,7 +8224,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8238,7 +8239,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8252,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8269,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8293,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8361,7 +8362,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8413,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8451,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8475,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8499,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -8520,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8532,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8551,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8572,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8584,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8603,7 +8604,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8613,7 +8614,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -8627,7 +8628,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8660,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8705,7 +8706,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8733,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8747,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8766,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8793,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8806,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8884,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8912,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8950,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -8970,7 +8971,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9000,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9044,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9091,7 +9092,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -9105,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9121,7 +9122,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9196,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9210,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9230,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9242,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9265,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9281,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9299,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9315,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9325,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "clap",
  "eyre",
@@ -9340,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9381,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9406,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9432,7 +9433,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9445,7 +9446,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9470,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9489,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9507,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=8756105f9520996629876c3f75bcac5fbce25883#8756105f9520996629876c3f75bcac5fbce25883"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.4#93678359038b3096d6fe738bdea1a42b46ec7f43"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,42 +13,42 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["serde"] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883", features = ["test-utils"] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "8756105f9520996629876c3f75bcac5fbce25883" }
+reth = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4", features = ["test-utils"] }
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4", features = ["serde"] }
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4", features = ["test-utils"] }
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4", features = ["test-utils"] }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4", features = ["test-utils"] }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.4" }
 revm = "29.0.0"
 
 # alloy dependencies


### PR DESCRIPTION
### Description

bump-v0.0.4.

### Rationale

Update reth deps to https://github.com/bnb-chain/reth/releases/tag/v0.0.4.

### Example

N/A.

### Changes

Notable changes: 
* cargo deps.

### Potential Impacts
N/A.
