### PR TITLE
fix: remove misuse merge_transitions

### DIFF
--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -29,7 +29,6 @@ use revm::{
         result::{ExecutionResult, ResultAndState},
 
     },
-    database::states::bundle_state::BundleRetention,
     state::Bytecode,
     DatabaseCommit,
 };
@@ -502,16 +501,6 @@ where
         ASSEMBLED_SYSTEM_TXS.with(|txs| {
             *txs.borrow_mut() = self.assembled_system_txs.clone();
         });
-        
-        // Merge all transitions into bundle state to ensure all state changes
-        // (including system contract calls like EIP-2935) are persisted
-        self.evm.db_mut().merge_transitions(BundleRetention::Reverts);
-        
-        debug!(
-            target: "bsc::executor",
-            block_number = self.evm.block().number.to::<u64>(),
-            "Merged transitions into bundle state before finish"
-        );
 
         Ok((
             self.evm,


### PR DESCRIPTION
### Description

Remove misuse merge_transitions.

### Rationale

`merge_transitions` should not be called inside the executor; it should be called by the executor caller.

More importantly, multiple calls to this function have side effects, potentially corrupting data, leading to mismatch roots, execution phase errors, database integrity errors, and so on.


### Example

related issues:
https://github.com/bnb-chain/reth-bsc/issues/162
https://github.com/bnb-chain/reth-bsc/issues/163

### Changes

Notable changes: 
* executor*.

### Potential Impacts
N/A.
