### PR TITLE
chore: fix calc blob fee check condition

### DIFF
--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -266,7 +266,7 @@ where
             });
 
   
-        // Refet to geth-bsc: https://github.com/bnb-chain/bsc/blob/master/consensus/misc/eip1559/eip1559.go#L61
+        // Refer to geth-bsc: https://github.com/bnb-chain/bsc/blob/master/consensus/misc/eip1559/eip1559.go#L61
         let mut basefee = Some(EIP1559_INITIAL_BASE_FEE);
 
         let mut gas_limit = U256::from(parent.gas_limit);

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -214,8 +214,13 @@ where
                 "Missing header in mining context"
             )) as Box<dyn std::error::Error + Send + Sync>
         })?;
-        if header.excess_blob_gas != Some(0) {
-            blob_fee = Some(calc_blob_fee(&self.chain_spec, header));
+        
+        if BscHardforks::is_cancun_active_at_timestamp(&self.chain_spec, header.number, header.timestamp) {
+            if let Some(excess) = header.excess_blob_gas {
+                if excess != 0 {
+                    blob_fee = Some(calc_blob_fee(&self.chain_spec, header));
+                }
+            }
         }
         let max_blob_count = blob_params.as_ref().map(|params| params.max_blob_count).unwrap_or_default();
         let mut best_tx_list = self.pool.best_transactions_with_attributes(BestTransactionsAttributes::new(base_fee, blob_fee.map(|fee| fee as u64)));

--- a/src/node/network/bsc_protocol/stream.rs
+++ b/src/node/network/bsc_protocol/stream.rs
@@ -278,7 +278,7 @@ impl BscProtocolConnection {
 
     /// Handle normal protocol messages after handshake
     fn handle_protocol_message(&mut self, frame: &BytesMut) -> Option<BytesMut> {
-        tracing::debug!(target: "bsc_protocol", "Handshake completed, processing normal message");
+        tracing::trace!(target: "bsc_protocol", "Handshake completed, processing normal message");
         let slice = frame.as_ref();
         let msg_id = slice[0];
 


### PR DESCRIPTION
### Description

Fix calc blob fee check condition.

### Rationale

`None != Some(0)` return true.

### Example

```
thread 'tokio-runtime-worker' (3633) panicked at src/consensus/eip4844/blob_fee.rs:48:5:
calculating blob fee on unsupported fork
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
### Changes

Notable changes: 
* calc blob-fee condition.

### Potential Impacts
N/A.
