### PR TITLE
miner: actively remove transactions with nonce too low;

### DIFF
--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -389,7 +389,11 @@ where
                         );
                         best_tx_list.mark_invalid(
                             &pool_tx,
-                            InvalidPoolTransactionError::NonceTooLow(tx.nonce()),
+                            InvalidPoolTransactionError::Consensus(InvalidTransactionError::NonceNotConsistent {
+                                    tx: tx.nonce(),
+                                    state: 0_u64, // TODO: get the nonce from the state later.
+                                },
+                            ),
                         );
                     } else {
                         // if the transaction is invalid, we can skip it and all of its


### PR DESCRIPTION
### Description

This PR will actively remove transactions with nonce too low.


### Changes

Notable changes: 
* [add each change in a bullet point here](miner: actively remove transactions with nonce too low;)
* ...
