### PR TITLE
fix: add bsc validation error for new payload

### DIFF
--- a/SNAPSHOT.md
+++ b/SNAPSHOT.md
@@ -30,10 +30,10 @@ After building, the binary will be located at `./target/maxperf/reth-bsc`.
 
 | Type | Network | File | Size | Special Parameters |
 | ---- | ------- | ---- | ---- | ------------------ |
-| Archive | BSC-MainNet | [reth_static_files_20251126.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/reth_static_files_20251126.tar.zst) <br> [reth_db_20251126.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/reth_db_20251126.tar.zst) | 1.828 TiB <br> 2.286 TiB | `--db.max-size=12TB` <br> `--db.page-size=8KB` |
+| Archive | BSC-MainNet | [reth_static_files_20260109.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/reth_static_files_20260109.tar.zst) <br> [reth_db_20260109.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/reth_db_20260109.tar.zst) | 1.955 TiB <br> 2.556 TiB | `--db.max-size=12TB` <br> `--db.page-size=8KB` |
 | Archive | BSC-TestNet | [bsc-reth-archivenode-testnet-64665542.tar.gz](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/bsc-reth-archivenode-testnet-64665542.tar.gz) | 392 GiB | - |
 | Full | BSC-TestNet | [bsc-reth-testnet-63271461.tar.gz](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/bsc-reth-testnet-63271461.tar.gz) | 232 GiB | - |
-| Full | BSC-MainNet | coming soon | - | - |
+| Full | BSC-MainNet | [reth_full_static_files_20260109.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/reth_full_static_files_20260109.tar.zst) <br> [reth_full_db_20260109.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/reth_full_db_20260109.tar.zst) | 1.310 TiB <br> 1.109 TiB | - |
 | Full TrieDB | BSC-TestNet | [75105967_testnet_fullnode.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/75105967_testnet_fullnode.tar.zst) | 259 GiB | - |
 | Full TrieDB | BSC-MainNet | [69615424_mainnet__fullnode.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/69615424_mainnet__fullnode.tar.zst) | 2.73 TiB | - |
 | Archive TrieDB | BSC-TestNet | [80135040_testnet_reth_triedb_archive.tar.zst](https://pub-c5400abe5bed4adbaf8cd47467747e74.r2.dev/80135040_testnet_reth_triedb_archive.tar.zst) | 450 GiB | - |
@@ -124,8 +124,8 @@ For single-file snapshots (TestNet Archive, TestNet FullNode):
 ### Requirements
 
 - **Disk Space**: 
-  - MainNet Archive: ~15TB+ free space
-  - MainNet FullNode: ~7TB+ free space
+  - MainNet Archive: ~20TB+ free space
+  - MainNet FullNode: ~8TB+ free space
   - TestNet Archive: ~1.5TB+ free space  
   - TestNet FullNode: ~900GB+ free space
 - **Tools**: `zstd` (for .zst files), `tar`, `gzip` (for .tar.gz files)

--- a/src/node/evm/error.rs
+++ b/src/node/evm/error.rs
@@ -6,6 +6,9 @@ use reth_evm::execute::{BlockExecutionError, BlockValidationError};
 use reth_provider::ProviderError;
 use reth_primitives::{GotExpected, GotExpectedBoxed};
 
+/// Prefix used to identify BSC validation errors in error messages.
+pub const BSC_VALIDATION_ERROR_PREFIX: &str = "BSC validation error:";
+
 /// BSC specific block validation error
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum BscBlockValidationError {
@@ -206,7 +209,7 @@ impl From<BscBlockExecutionError> for BlockExecutionError {
                 // but we should refine it by rewrite some validation error types in reth engine-tree.
                 // Note: Validation errors will be identified in the engine-tree and treated as invalid blocks. 
                 Self::Validation(BlockValidationError::DepositRequestDecode(
-                    format!("BSC validation error: {}", validation_err)
+                    format!("{} {}", BSC_VALIDATION_ERROR_PREFIX, validation_err)
                 ))
             }
             

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -157,11 +157,25 @@ where
                         Outcome { peer: peer_id, result: Ok(BlockValidation::ValidBlock { block }) }
                             .into()
                     }
-                    PayloadStatusEnum::Invalid { validation_error } => Outcome {
-                        peer: peer_id,
-                        result: Err(BlockImportError::Other(validation_error.into())),
+                    PayloadStatusEnum::Invalid { validation_error } => {
+                        if validation_error.contains("BSC validation error:") {
+                            tracing::warn!(
+                                target: "bsc::block_import",
+                                %validation_error,
+                                peer = %peer_id,
+                                block_number = header.number,
+                                block_hash = %header.hash_slow(),
+                                "Block rejected due to BSC-specific validation error, skipping peer penalty"
+                            );
+                            None
+                        } else {
+                            Outcome {
+                                peer: peer_id,
+                                result: Err(BlockImportError::Other(validation_error.into())),
+                            }
+                            .into()
+                        }
                     }
-                    .into(),
                     PayloadStatusEnum::Syncing => {
                         // When new_payload returns Syncing status, we need to manually trigger FCU
                         // to avoid the engine-tree being stuck in syncing state without any driver.
@@ -377,26 +391,29 @@ where
 
     /// Transfer the block to EVN peers if from proxied validators or validator address.
     fn transfer_to_evn_peers(&self, block: BlockMsg) -> Result<(), Box<dyn std::error::Error>> {
-        let mining_config = crate::node::miner::config::get_global_mining_config().ok_or("Mining config is not set")?;
-        let cfg = crate::node::network::evn::get_global_evn_config().ok_or("EVN config is not set")?;
+        let mining_config = crate::node::miner::config::get_global_mining_config()
+            .ok_or("Mining config is not set")?;
+        let cfg =
+            crate::node::network::evn::get_global_evn_config().ok_or("EVN config is not set")?;
         if !cfg.enabled {
             return Ok(());
         }
         let header_ref = &block.block.0.block.header;
         let coinbase = header_ref.beneficiary;
         // If from proxied validators or validator address, target EVN peers with ETH NewBlockHashes.
-        if cfg.proxyed_validators.contains(&coinbase) || (mining_config.enabled && mining_config.validator_address.unwrap_or_default() == coinbase) {
+        if cfg.proxyed_validators.contains(&coinbase)
+            || (mining_config.enabled
+                && mining_config.validator_address.unwrap_or_default() == coinbase)
+        {
             if let Some(net) = crate::shared::get_network_handle() {
                 let peers = crate::node::network::evn_peers::snapshot();
                 for (peer_id, info) in peers {
                     // Send to EVN peers or proxyed peers
-                    let is_proxyed = crate::node::network::bsc_protocol::registry::is_proxyed_peer(&peer_id);
+                    let is_proxyed =
+                        crate::node::network::bsc_protocol::registry::is_proxyed_peer(&peer_id);
                     if info.is_evn || is_proxyed {
                         // Send full NewBlock to EVN/proxyed peers to avoid re-fetching.
-                        net.send_eth_message(
-                            peer_id,
-                            PeerMessage::NewBlock(block.clone()),
-                        );
+                        net.send_eth_message(peer_id, PeerMessage::NewBlock(block.clone()));
                         tracing::debug!(target: "bsc::block_import", "Sent full NewBlock to EVN/proxyed peer: number = {:?}, hash = {:?}, peer = {:?}", block.block.0.block.header.number, block.hash, peer_id);
                     }
                 }

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -4,8 +4,8 @@ use crate::{
     consensus::{parlia::vote_pool, ParliaConsensusErr},
     node::{
         consensus::BscForkChoiceEngine, engine::BscBuiltPayload,
-        engine_api::payload::BscPayloadTypes, evm::util::insert_header_to_cache,
-        network::BscNewBlock,
+        engine_api::payload::BscPayloadTypes, evm::error::BSC_VALIDATION_ERROR_PREFIX,
+        evm::util::insert_header_to_cache, network::BscNewBlock,
     },
     BscBlock, BscBlockBody,
 };
@@ -53,8 +53,8 @@ pub(crate) type Outcome = BlockImportOutcome<BscNewBlock>;
 /// Import event for a block
 pub(crate) type ImportEvent = BlockImportEvent<BscNewBlock>;
 
-/// Future that processes a block import and returns its outcome
-type ImportFut = Pin<Box<dyn Future<Output = Option<Outcome>> + Send + Sync>>;
+/// Future that processes a block import and returns its outcome along with the block hash for cleanup.
+type ImportFut = Pin<Box<dyn Future<Output = (Option<Outcome>, B256)> + Send + Sync>>;
 
 /// Channel message type for incoming blocks
 pub(crate) type IncomingBlock = (BlockMsg, PeerId);
@@ -138,13 +138,14 @@ where
     fn new_payload(&self, block: BlockMsg, peer_id: PeerId) -> ImportFut {
         let engine = self.engine.clone();
         let forkchoice_engine = self.forkchoice_engine.clone();
+        let block_hash = block.hash;
 
         tracing::debug!(target: "bsc::block_import", "New payload: block = ({:?}, {:?}), peer_id = {:?}", block.block.0.block.header.number, block.block.0.block.header.hash_slow(), peer_id);
         Box::pin(async move {
             let sealed_block = block.block.0.block.clone().seal();
             let header = sealed_block.header().clone();
             let payload = BscPayloadTypes::block_to_payload(sealed_block);
-            match engine.new_payload(payload).await {
+            let outcome = match engine.new_payload(payload).await {
                 Ok(payload_status) => match payload_status.status {
                     PayloadStatusEnum::Valid => {
                         tracing::debug!(target: "bsc::block_import", "New payload is valid, block = {:?}, peer_id = {:?}", block, peer_id);
@@ -158,14 +159,11 @@ where
                             .into()
                     }
                     PayloadStatusEnum::Invalid { validation_error } => {
-                        if validation_error.contains("BSC validation error:") {
-                            tracing::warn!(
+                        if validation_error.starts_with(BSC_VALIDATION_ERROR_PREFIX) {
+                            tracing::debug!(
                                 target: "bsc::block_import",
-                                %validation_error,
-                                peer = %peer_id,
-                                block_number = header.number,
-                                block_hash = %header.hash_slow(),
-                                "Block rejected due to BSC-specific validation error, skipping peer penalty"
+                                error = %validation_error,
+                                "Skipping block with BSC validation error without penalizing peer"
                             );
                             None
                         } else {
@@ -228,7 +226,8 @@ where
                     _ => None,
                 },
                 Err(err) => None,
-            }
+            };
+            (outcome, block_hash)
         })
     }
 
@@ -454,11 +453,15 @@ where
         }
 
         // Process completed imports and send events to network
-        while let Poll::Ready(Some(outcome)) = this.pending_imports.poll_next_unpin(cx) {
+        while let Poll::Ready(Some((outcome, import_block_hash))) =
+            this.pending_imports.poll_next_unpin(cx)
+        {
+            // Always clean up queued_blocks for the imported block hash,
+            // regardless of the outcome (valid, invalid, skipped).
+            this.queued_blocks.remove(&import_block_hash);
+
             if let Some(outcome) = outcome {
-                let mut block_hash = None;
                 if let Ok(BlockValidation::ValidBlock { block }) = &outcome.result {
-                    block_hash = Some(block.hash);
                     this.processed_blocks.insert(block.hash);
                     // Cache the full block body for later range responses.
                     crate::shared::cache_full_block(block.block.0.block.clone());
@@ -466,13 +469,6 @@ where
                         tracing::warn!(target: "bsc::block_import", "Failed to transfer block to EVN peers: number = {:?}, hash = {:?}, error = {}", block.block.0.block.header.number, block.hash, e);
                     }
                 }
-
-                // TODO: add queued blocks removal later, to avoid milicious block import, and trigger next download.
-                // now, it must wait backfilling to download the correct block.
-                // the verified header can drop the peer later, it cannot transfer a bad header now.
-                // if let Some(block_hash) = outcome.block.hash {
-                //     this.queued_blocks.remove(&block_hash);
-                // }
 
                 if let Err(e) = this.to_network.send(BlockImportEvent::Outcome(outcome)) {
                     return Poll::Ready(Err(Box::new(e)));
@@ -534,6 +530,35 @@ mod tests {
                 )
             })
             .await;
+    }
+
+    #[tokio::test]
+    async fn bsc_validation_error_skips_peer_punishment() {
+        let mut fixture =
+            TestFixture::new(EngineResponses::bsc_invalid_new_payload()).await;
+
+        let block_msg = create_test_block();
+        fixture.handle.send_block(block_msg, PeerId::random()).unwrap();
+
+        // Wait briefly for the import to be processed
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // BSC validation errors return None, so no Outcome event should be produced.
+        // Only Announcement events (ValidHeader) are expected.
+        loop {
+            match fixture.handle.poll_outcome(&mut cx) {
+                Poll::Ready(Some(event)) => {
+                    assert!(
+                        !matches!(event, BlockImportEvent::Outcome(_)),
+                        "BSC validation error should not produce an Outcome event"
+                    );
+                }
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
     }
 
     #[tokio::test]
@@ -741,6 +766,18 @@ mod tests {
             Self {
                 new_payload: PayloadStatusEnum::Valid,
                 fcu: PayloadStatusEnum::Invalid { validation_error: "fcu error".into() },
+            }
+        }
+
+        fn bsc_invalid_new_payload() -> Self {
+            Self {
+                new_payload: PayloadStatusEnum::Invalid {
+                    validation_error: format!(
+                        "{} unexpected system tx",
+                        BSC_VALIDATION_ERROR_PREFIX
+                    ),
+                },
+                fcu: PayloadStatusEnum::Valid,
             }
         }
     }


### PR DESCRIPTION
### Description

https://github.com/bnb-chain/reth-bsc/issues/258
Currently, the reth-bsc node occasionally experiences bad blocks, and the cause is a problem with the computing of its own node. This fix means that when there is a problem with the node itself, no penalty will be imposed on the peer. This can prevent all cases where peers are disconnected.