### PR TITLE
fix: prev_randao

### DIFF
--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -518,3 +518,155 @@ pub fn revm_spec_by_timestamp_and_block_number(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::consensus::parlia::constants::{DIFF_INTURN, DIFF_NOTURN};
+    use crate::evm::api::BscEvm;
+    use crate::evm::transaction::BscTxEnv;
+    use crate::hardforks::bsc::BscHardfork;
+    use revm::{
+        context::{BlockEnv, CfgEnv, TxEnv},
+        context_interface::result::ExecutionResult,
+        inspector::NoOpInspector,
+        state::{AccountInfo, Bytecode},
+        ExecuteEvm,
+    };
+    use revm_database::InMemoryDB;
+    use alloy_primitives::{Address, Bytes, B256, U256};
+    use reth_evm::EvmEnv;
+
+    /// Bytecode: PREVRANDAO → PUSH1 0x00 → MSTORE → PUSH1 0x20 → PUSH1 0x00 → RETURN
+    /// Executes the PREVRANDAO opcode (0x44) and returns the 32-byte result.
+    const PREVRANDAO_BYTECODE: [u8; 9] = [
+        0x44,       // PREVRANDAO (returns prevrandao in post-merge, difficulty in pre-merge)
+        0x60, 0x00, // PUSH1 0x00
+        0x52,       // MSTORE (store result at memory offset 0)
+        0x60, 0x20, // PUSH1 0x20
+        0x60, 0x00, // PUSH1 0x00
+        0xf3,       // RETURN (return 32 bytes from memory offset 0)
+    ];
+
+    /// Execute the PREVRANDAO bytecode with the given BlockEnv and return the opcode result.
+    fn execute_prevrandao(prevrandao: Option<B256>, difficulty: U256) -> B256 {
+        let caller = Address::from([0x11; 20]);
+        let contract = Address::from([0x22; 20]);
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            caller,
+            AccountInfo { balance: U256::from(1_000_000u64), ..Default::default() },
+        );
+        db.insert_account_info(
+            contract,
+            AccountInfo::default()
+                .with_code(Bytecode::new_raw(Bytes::from(PREVRANDAO_BYTECODE.to_vec()))),
+        );
+
+        let block_env = BlockEnv {
+            difficulty,
+            prevrandao,
+            ..Default::default()
+        };
+        // BSC uses post-merge spec where opcode 0x44 returns prevrandao.
+        // Use a post-merge BscHardfork so the EVM spec matches production.
+        let cfg_env = CfgEnv::new_with_spec(BscHardfork::HaberFix).with_chain_id(56);
+        let env: EvmEnv<BscHardfork> = EvmEnv::new(cfg_env, block_env);
+
+        let tx = BscTxEnv::new(
+            TxEnv::builder()
+                .caller(caller)
+                .chain_id(Some(56))
+                .gas_limit(100_000)
+                .gas_price(1)
+                .kind(revm::primitives::TxKind::Call(contract))
+                .build()
+                .expect("tx env should build"),
+        );
+
+        let mut evm = BscEvm::new(env, db, NoOpInspector, false, false);
+        let result = evm.transact_one(tx).expect("execution should not error");
+
+        match result {
+            ExecutionResult::Success { output, .. } => {
+                let bytes = output.data();
+                B256::from_slice(bytes)
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    /// Demonstrates that the PREVRANDAO opcode output depends solely on BlockEnv.prevrandao
+    /// in post-merge spec, so both the validation and building paths must set it to the same
+    /// value to produce consistent state roots.
+    #[test]
+    fn prevrandao_opcode_returns_prevrandao_not_difficulty() {
+        let difficulty = DIFF_INTURN; // U256(2)
+
+        // Post-merge: opcode 0x44 returns prevrandao, ignores difficulty
+        let result = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+        assert_eq!(
+            result,
+            B256::from(difficulty),
+            "PREVRANDAO opcode should return the prevrandao value"
+        );
+
+        // Confirm that changing difficulty alone does NOT affect the opcode output
+        let result_diff_only = execute_prevrandao(Some(B256::ZERO), difficulty);
+        assert_eq!(
+            result_diff_only,
+            B256::ZERO,
+            "PREVRANDAO opcode should NOT read from the difficulty field"
+        );
+    }
+
+    /// Proves the bug: before the fix, the validation path and building path would set
+    /// different prevrandao values, causing the PREVRANDAO opcode to return different results.
+    ///
+    /// Validation path:  prevrandao = header.difficulty() (e.g. DIFF_INTURN = 2)
+    /// Building path (before fix): prevrandao = header.mix_hash (B256::ZERO for pre-Lorentz)
+    #[test]
+    fn prevrandao_mismatch_between_validation_and_building_paths() {
+        let difficulty = DIFF_INTURN; // U256(2)
+
+        // --- Validation path (evm_env in config.rs) ---
+        // Sets: difficulty = U256::ZERO, prevrandao = Some(header.difficulty().into())
+        let validation_result = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+
+        // --- Building path BEFORE fix (next_evm_env in config.rs) ---
+        // Sets: difficulty = U256::ZERO, prevrandao = Some(attributes.prev_randao)
+        // where prev_randao was mix_hash = B256::ZERO (pre-Lorentz)
+        let building_before_fix = execute_prevrandao(Some(B256::ZERO), U256::ZERO);
+
+        // These differ — any contract using PREVRANDAO would produce different state roots
+        assert_ne!(
+            validation_result, building_before_fix,
+            "Bug: validation and building paths return different PREVRANDAO values"
+        );
+        assert_eq!(validation_result, B256::from(difficulty));
+        assert_eq!(building_before_fix, B256::ZERO);
+
+        // --- Building path AFTER fix ---
+        // Sets: prev_randao = calculate_difficulty() = DIFF_INTURN, matching validation
+        let building_after_fix = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+
+        assert_eq!(
+            validation_result, building_after_fix,
+            "After fix: both paths should return the same PREVRANDAO value"
+        );
+    }
+
+    /// Same test with DIFF_NOTURN to cover the out-of-turn validator case.
+    #[test]
+    fn prevrandao_consistency_for_noturn_difficulty() {
+        let difficulty = DIFF_NOTURN; // U256(1)
+
+        let validation = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+        let building_fixed = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+        let building_broken = execute_prevrandao(Some(B256::ZERO), U256::ZERO);
+
+        assert_eq!(validation, building_fixed);
+        assert_ne!(validation, building_broken);
+        assert_eq!(validation, B256::from(difficulty));
+    }
+}

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -3,7 +3,7 @@ use alloy_consensus::{Header, BlockHeader};
 use alloy_primitives::{Address, Bytes, B256};
 use crate::consensus::parlia::Snapshot;
 use crate::consensus::parlia::consensus::Parlia;
-use crate::consensus::parlia::util::{calculate_difficulty, debug_header};
+use crate::consensus::parlia::util::{calculate_difficulty, debug_header, set_millisecond_part_of_timestamp};
 use crate::chainspec::BscChainSpec;
 use crate::consensus::parlia::{EXTRA_VANITY_LEN, EXTRA_SEAL_LEN};
 use reth::payload::EthPayloadBuilderAttributes;
@@ -17,11 +17,15 @@ use crate::consensus::parlia::provider::SnapshotProvider;
 pub fn prepare_new_attributes(ctx: &mut MiningContext, parlia: Arc<Parlia<BscChainSpec>>, parent_header: &Header, signer: Address) -> EthPayloadBuilderAttributes {
     let mut new_header = prepare_new_header(parlia.clone(), parent_header, signer);
     parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header, &mut new_header);
+    // BSC uses the PREVRANDAO opcode to return difficulty (not a random value like
+    // Ethereum PoS). The validation path in BscEvmConfig::evm_env sets
+    // `prevrandao = header.difficulty()`, so the building path must match.
+    let difficulty = calculate_difficulty(&ctx.parent_snapshot, signer);
     let mut attributes = EthPayloadBuilderAttributes{
         parent: new_header.parent_hash,
         timestamp: new_header.timestamp,
         suggested_fee_recipient: new_header.beneficiary,
-        prev_randao: new_header.mix_hash,
+        prev_randao: difficulty.into(),
         ..Default::default()
     };
     if BscHardforks::is_bohr_active_at_timestamp(&parlia.spec, new_header.number, new_header.timestamp) {
@@ -69,7 +73,19 @@ where
     ChainSpec: EthChainSpec + crate::hardforks::BscHardforks + 'static,
 {
     new_header.difficulty = calculate_difficulty(parent_snap, new_header.beneficiary);
-    
+
+    // Restore correct mix_hash for the sealed header. The assembler may have set
+    // mix_hash from BlockEnv.prevrandao (which is the difficulty value for EVM
+    // execution). BSC encodes the millisecond timestamp part in mix_hash post-Lorentz,
+    // or uses B256::ZERO pre-Lorentz.
+    let millisecond_timestamp =
+        parlia.block_time_for_ramanujan_fork(parent_snap, parent_header, new_header);
+    if parlia.spec.is_lorentz_active_at_timestamp(new_header.number, new_header.timestamp) {
+        set_millisecond_part_of_timestamp(millisecond_timestamp, new_header);
+    } else {
+        new_header.mix_hash = B256::ZERO;
+    }
+
     if new_header.extra_data.len() < EXTRA_VANITY_LEN {
         new_header.extra_data = Bytes::from(vec![0u8; EXTRA_VANITY_LEN]);
     }


### PR DESCRIPTION
## Summary

- **Bug**: The `PREVRANDAO` opcode returns different values during block building vs block validation, causing state root mismatches for any contract that reads `PREVRANDAO`
- **Root cause**: Block building path set `prevrandao = mix_hash` (B256::ZERO or millisecond timestamp), while validation path set `prevrandao = header.difficulty()` (Parlia INTURN=2 / NOTURN=1)
- **Fix**: Set `prev_randao` to the calculated difficulty in `prepare_new_attributes`, and restore the correct `mix_hash` in `finalize_new_header` (since the assembler derives `mix_hash` from `prevrandao`)

## Details

In BSC's Parlia consensus, the `PREVRANDAO` EVM opcode returns the block difficulty (not a random value like Ethereum PoS). Two code paths configure the EVM environment:

| Path | `prevrandao` value | Used for |
|------|-------------------|----------|
| `BscEvmConfig::evm_env` (validation) | `header.difficulty()` | Verifying existing blocks |
| `BscEvmConfig::next_evm_env` (building) | `attributes.prev_randao` = `mix_hash` | Building new blocks |

The `mix_hash` field in BSC is `B256::ZERO` (pre-Lorentz) or encodes the millisecond timestamp part (post-Lorentz) — neither matches the difficulty value. This causes the `PREVRANDAO` opcode to return different results during building vs validation.

### Changes in `src/node/miner/util.rs`

1. **`prepare_new_attributes`**: Changed `prev_randao` from `new_header.mix_hash` to `calculate_difficulty(&snapshot, signer).into()` — matching the validation path
2. **`finalize_new_header`**: Added `mix_hash` restoration after the assembler sets it from `prevrandao`. Recomputes the correct value using `block_time_for_ramanujan_fork` (B256::ZERO pre-Lorentz, millisecond part post-Lorentz)

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Run validator node on testnet and confirm blocks are accepted by peers
- [ ] Verify `mix_hash` in produced block headers matches expected format (zero pre-Lorentz, ms-encoded post-Lorentz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)