### PR TITLE
chore: add Osaka and Mendel hardfork timestamps for testnet

### DIFF
--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -162,6 +162,8 @@ impl BscHardfork {
             (Self::Lorentz.boxed(), ForkCondition::Timestamp(1744097580)),
             (Self::Maxwell.boxed(), ForkCondition::Timestamp(1748243100)),
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1762741500)),
+            (Self::Osaka.boxed(), ForkCondition::Timestamp(1774319400)),
+            (Self::Mendel.boxed(), ForkCondition::Timestamp(1774319400)),
         ])
     }
 


### PR DESCRIPTION
## Summary
- Add Osaka and Mendel hardfork activation timestamps (1774319400) to BSC Chapel testnet configuration in `bsc_testnet()`

## Test plan
- [x] `cargo check` passes
- [ ] Verify testnet node syncs correctly past the fork timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)