### PR TITLE
fix: update P2P network status on canonical chain progress

### DIFF
--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -35,6 +35,7 @@ use reth_ethereum_primitives::Receipt;
 use reth_payload_primitives::EngineApiMessageVersion;
 use reth_primitives::{gas_spent_by_transactions, GotExpected};
 use reth_primitives_traits::constants::{GAS_LIMIT_BOUND_DIVISOR, MINIMUM_GAS_LIMIT};
+use reth_ethereum_forks::Head;
 use reth_provider::{BlockNumReader, HeaderProvider};
 use std::sync::Arc;
 
@@ -1263,7 +1264,31 @@ where
                 PayloadStatusEnum::Invalid { validation_error } => {
                     Err(ParliaConsensusErr::ForkChoiceUpdateError(validation_error))
                 }
-                _ => Ok(()),
+                _ => {
+                    // Update P2P network status so peers see our current chain head.
+                    // Without this, the Status advertised to peers stays at the startup
+                    // value and peers will consider us stale/stalling.
+                    let td = self
+                        .header_td(
+                            &self.engine_handle,
+                            new_canonical_head.number,
+                            new_canonical_head.hash_slow(),
+                        )
+                        .await
+                        .ok()
+                        .flatten()
+                        .unwrap_or_default();
+                    if let Some(network_handle) = shared::get_network_handle() {
+                        network_handle.update_status(Head {
+                            number: new_canonical_head.number,
+                            hash: new_canonical_head.hash_slow(),
+                            difficulty: new_canonical_head.difficulty,
+                            timestamp: new_canonical_head.timestamp,
+                            total_difficulty: td,
+                        });
+                    }
+                    Ok(())
+                }
             },
             Err(err) => Err(ParliaConsensusErr::ForkChoiceUpdateError(err.to_string())),
         }


### PR DESCRIPTION
## Summary

- reth-bsc never called `network_handle.update_status()`, causing the P2P layer to advertise stale `total_difficulty`/`blockhash`/`ForkID` from startup time
- When sentry nodes restarted and exchanged ETH Status with reth-bsc, they saw a frozen chain head, judged reth as "stalling", and dropped the connection
- This led to the validator losing all peers, unable to receive new blocks, resulting in **271 cascading slashes** on the testnet (2026-03-19)

### Root Cause

The standard reth engine launch path (`reth/crates/node/builder/src/launch/engine.rs:366-386`) calls `network_handle.update_status(head)` on every canonical chain advance. reth-bsc's `BscForkChoiceEngine` did not have this call — the network Status was frozen at startup values indefinitely.

### Evidence from geth sentry logs

```
"Synchronisation failed, dropping peer" peer=98a4a172... err="peer is stalling"
"Synchronisation failed, dropping peer" peer=98a4a172... err="no peers available or all tried for download"
```

### Evidence from reth-bsc debug logs

```
06:48:19  net::session: failed to receive message err=disconnected remote_peer_id=0x28da...
06:51:33  net::session: failed to receive message err=disconnected remote_peer_id=0x665c...
06:53:37  net::session: failed to receive message err=disconnected remote_peer_id=0x788d...
```

All disconnections initiated by the remote sentry side. Reconnection attempts failed with `reason=already connected`.

### Fix

Call `update_status` after every successful forkchoice update in `BscForkChoiceEngine::update_forkchoice`, keeping the P2P Status in sync with the canonical chain head.

## Test plan

- [ ] Deploy to testnet validator, restart sentries, verify peers remain connected
- [ ] Confirm `connected_peers` stays stable across sentry restarts
- [ ] Verify via geth sentry logs that "peer is stalling" no longer appears for the reth peer

🤖 Generated with [Claude Code](https://claude.com/claude-code)