### PR TITLE
fix: prevent sync stall triggered by deep reorg with low peer count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "9247f0a399ef71aeb68f497b2b8fb348014f742b50d3b83b1e00dfe1b7d64b3d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -176,7 +176,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -395,7 +395,7 @@ dependencies = [
  "derive_more 2.1.1",
  "fixed-cache",
  "foldhash 0.2.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -790,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -883,14 +883,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "arrayvec",
  "derive_arbitrary",
  "derive_more 2.1.1",
  "nybbles",
@@ -934,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -949,15 +948,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1378,9 +1377,9 @@ checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1560,7 +1559,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1578,7 +1577,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1881,19 +1880,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes 1.11.1",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2191,9 +2191,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2226,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2236,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2248,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coins-bip32"
@@ -2317,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2453,7 +2453,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid 1.21.0",
+ "uuid 1.22.0",
  "walkdir",
 ]
 
@@ -2513,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2721,7 +2721,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winapi",
 ]
 
@@ -3012,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3033,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3244,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -4004,20 +4004,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -4496,7 +4496,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "log",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -4535,7 +4535,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -4792,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
  "bitflags 2.11.0",
  "inotify-sys",
@@ -4822,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -4835,9 +4835,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -4871,9 +4871,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -4947,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -4985,9 +4985,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5024,7 +5024,7 @@ dependencies = [
  "http 1.4.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
@@ -5077,7 +5077,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -5248,9 +5248,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
@@ -5312,13 +5312,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -5339,9 +5340,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
 dependencies = [
  "cc",
  "libc",
@@ -5373,9 +5374,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -5450,9 +5451,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "mach2"
@@ -5664,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5676,7 +5677,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid 1.21.0",
+ "uuid 1.22.0",
 ]
 
 [[package]]
@@ -5896,9 +5897,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -5906,9 +5907,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5951,9 +5952,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -6128,7 +6129,7 @@ dependencies = [
  "opentelemetry",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -6146,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -6476,18 +6477,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6496,9 +6497,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -6521,6 +6522,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -6615,11 +6622,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -6675,7 +6682,7 @@ checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.11.0",
  "procfs-core 0.18.0",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6826,7 +6833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6904,8 +6911,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.36",
- "socket2 0.6.2",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6914,9 +6921,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes 1.11.1",
  "getrandom 0.3.4",
@@ -6924,7 +6931,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6942,16 +6949,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6961,6 +6968,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -7166,9 +7179,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -7246,9 +7259,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regress"
@@ -7323,7 +7336,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -7353,22 +7366,22 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
  "clap",
  "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network",
  "reth-network-api",
  "reth-node-api",
@@ -7377,12 +7390,12 @@ dependencies = [
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ress-protocol",
  "reth-ress-provider",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
@@ -7399,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7407,47 +7420,16 @@ dependencies = [
  "futures-core",
  "futures-util",
  "metrics",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-chain-state"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
- "derive_more 2.1.1",
- "metrics",
- "parking_lot",
- "pin-project",
- "rand 0.9.2",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm-database",
- "revm-state",
- "serde",
- "tokio",
- "tokio-stream",
  "tracing",
 ]
 
@@ -7482,23 +7464,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-chainspec"
+name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
- "alloy-genesis",
  "alloy-primitives",
- "alloy-trie",
- "auto_impl",
+ "alloy-signer",
+ "alloy-signer-local",
  "derive_more 2.1.1",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde_json",
+ "metrics",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.2",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm-database",
+ "revm-state",
+ "serde",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -7522,15 +7515,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-chainspec"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde_json",
+]
+
+[[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-genesis",
  "clap",
  "eyre",
  "reth-cli-runner",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde_json",
  "shellexpand",
 ]
@@ -7538,7 +7551,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7562,16 +7575,16 @@ dependencies = [
  "proptest-arbitrary-interop",
  "ratatui",
  "reqwest 0.12.28",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-cli",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-discv4",
  "reth-discv5",
  "reth-downloaders",
@@ -7580,34 +7593,34 @@ dependencies = [
  "reth-era-downloader",
  "reth-era-utils",
  "reth-eth-wire",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-exex",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-prune",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-stages",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-static-file",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde",
@@ -7624,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7634,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7642,31 +7655,11 @@ dependencies = [
  "eyre",
  "libc",
  "rand 0.8.5",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
  "tikv-jemallocator",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "arbitrary",
- "bytes 1.11.1",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "visibility",
 ]
 
 [[package]]
@@ -7690,13 +7683,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-codecs-derive"
+name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "arbitrary",
+ "bytes 1.11.1",
+ "modular-bitfield",
+ "op-alloy-consensus",
+ "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "visibility",
 ]
 
 [[package]]
@@ -7710,19 +7713,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-config"
+name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "eyre",
- "humantime-serde",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "toml 0.8.23",
- "url",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7739,16 +7736,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-consensus"
+name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "auto_impl",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "thiserror 2.0.18",
+ "eyre",
+ "humantime-serde",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "toml 0.8.23",
+ "url",
 ]
 
 [[package]]
@@ -7765,15 +7765,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-consensus-common"
+name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "alloy-primitives",
+ "auto_impl",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7789,9 +7790,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-consensus-common"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+]
+
+[[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7806,38 +7819,12 @@ dependencies = [
  "futures",
  "reqwest 0.12.28",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "ringbuffer",
  "serde",
  "serde_json",
  "tokio",
-]
-
-[[package]]
-name = "reth-db"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "eyre",
- "metrics",
- "page_size",
- "parking_lot",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "rustc-hash",
- "strum 0.27.2",
- "sysinfo",
- "tempfile",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7867,31 +7854,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-db-api"
+name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-consensus",
- "alloy-genesis",
  "alloy-primitives",
- "arbitrary",
- "bytes 1.11.1",
  "derive_more 2.1.1",
+ "eyre",
  "metrics",
- "modular-bitfield",
- "parity-scale-codec",
- "proptest",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-optimism-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "roaring",
- "serde",
+ "page_size",
+ "parking_lot",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "rustc-hash",
+ "strum 0.27.2",
+ "sysinfo",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7923,37 +7908,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-db-common"
+name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-trie",
- "boyer-moore-magiclen",
- "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-state-trie",
+ "arbitrary",
+ "bytes 1.11.1",
+ "derive_more 2.1.1",
+ "metrics",
+ "modular-bitfield",
+ "parity-scale-codec",
+ "proptest",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-optimism-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "roaring",
  "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -7991,18 +7970,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-db-models"
+name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-eips",
+ "alloy-consensus",
+ "alloy-genesis",
  "alloy-primitives",
- "arbitrary",
- "bytes 1.11.1",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "alloy-trie",
+ "boyer-moore-magiclen",
+ "eyre",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-state-trie",
  "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -8021,9 +8019,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-db-models"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "arbitrary",
+ "bytes 1.11.1",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+]
+
+[[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8032,10 +8045,10 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "rand 0.8.5",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-net-nat",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8048,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8059,10 +8072,10 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rand 0.9.2",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
  "tokio",
@@ -8072,7 +8085,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8080,8 +8093,8 @@ dependencies = [
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tokio-util",
  "schnellru",
  "secp256k1 0.30.0",
@@ -8096,7 +8109,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8109,15 +8122,15 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-testing-utils",
  "tempfile",
@@ -8131,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8146,7 +8159,7 @@ dependencies = [
  "hmac",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -8159,49 +8172,24 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-payload-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "reth-engine-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "futures",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]
@@ -8230,32 +8218,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-engine-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "futures",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "futures",
  "pin-project",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-engine-tree",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-p2p",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-payload-builder",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8273,34 +8286,34 @@ dependencies = [
  "moka",
  "parking_lot",
  "rayon",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-p2p",
  "reth-payload-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-prune",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
  "reth-tasks",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-trie-parallel",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
@@ -8315,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8323,16 +8336,16 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "pin-project",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-engine-tree",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde",
  "serde_json",
  "tokio",
@@ -8343,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8358,7 +8371,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8366,7 +8379,7 @@ dependencies = [
  "futures-util",
  "reqwest 0.12.28",
  "reth-era",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "sha2 0.10.9",
  "tokio",
 ]
@@ -8374,34 +8387,23 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "eyre",
  "futures-util",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-era",
  "reth-era-downloader",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "reth-errors"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8416,9 +8418,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-errors"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8428,13 +8441,13 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "pin-project",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ecies",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde",
  "snap",
  "thiserror 2.0.18",
@@ -8447,7 +8460,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8460,10 +8473,10 @@ dependencies = [
  "derive_more 2.1.1",
  "proptest",
  "proptest-arbitrary-interop",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -8471,38 +8484,22 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "clap",
  "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-rpc-server-types",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "tracing",
-]
-
-[[package]]
-name = "reth-ethereum-consensus"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "tracing",
 ]
 
@@ -8523,21 +8520,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-ethereum-engine-primitives"
+name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "sha2 0.10.9",
- "thiserror 2.0.18",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "tracing",
 ]
 
 [[package]]
@@ -8559,17 +8554,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-ethereum-forks"
+name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
+ "alloy-eips",
  "alloy-primitives",
- "arbitrary",
- "auto_impl",
- "once_cell",
- "rustc-hash",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8586,9 +8585,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ethereum-forks"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "arbitrary",
+ "auto_impl",
+ "once_cell",
+ "rustc-hash",
+]
+
+[[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8596,42 +8609,22 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-payload-validator",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-transaction-pool",
  "revm",
  "tracing",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "arbitrary",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -8655,13 +8648,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-etl"
+name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "rayon",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "tempfile",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "arbitrary",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -8675,27 +8678,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-evm"
+name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "auto_impl",
- "derive_more 2.1.1",
- "futures-util",
- "metrics",
  "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "tempfile",
 ]
 
 [[package]]
@@ -8721,24 +8710,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-evm-ethereum"
+name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
- "alloy-rpc-types-engine",
+ "auto_impl",
  "derive_more 2.1.1",
- "parking_lot",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "futures-util",
+ "metrics",
+ "rayon",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "revm",
 ]
 
@@ -8764,16 +8755,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-execution-errors"
+name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
- "alloy-rlp",
- "nybbles",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "thiserror 2.0.18",
+ "alloy-rpc-types-engine",
+ "derive_more 2.1.1",
+ "parking_lot",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm",
 ]
 
 [[package]]
@@ -8790,21 +8790,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-execution-types"
+name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
- "derive_more 2.1.1",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm",
- "serde",
- "serde_with",
+ "alloy-rlp",
+ "nybbles",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8826,9 +8821,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-execution-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "derive_more 2.1.1",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8838,24 +8851,24 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-exex-types",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-stages-api",
  "reth-tasks",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "rmp-serde",
  "thiserror 2.0.18",
  "tokio",
@@ -8866,25 +8879,15 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "reth-fs-util"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8898,9 +8901,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-fs-util"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8910,14 +8923,14 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "pretty_assertions",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-api",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "revm",
  "revm-bytecode",
  "revm-database",
@@ -8928,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8942,22 +8955,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
- "tracing",
-]
-
-[[package]]
-name = "reth-libmdbx"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "bitflags 2.11.0",
- "byteorder",
- "dashmap 6.1.0",
- "derive_more 2.1.1",
- "parking_lot",
- "reth-mdbx-sys 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "smallvec",
- "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -8978,12 +8975,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-mdbx-sys"
+name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "bindgen 0.71.1",
- "cc",
+ "bitflags 2.11.0",
+ "byteorder",
+ "dashmap 6.1.0",
+ "derive_more 2.1.1",
+ "parking_lot",
+ "reth-mdbx-sys 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -8996,27 +9000,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-metrics"
-version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git#012ffc045031c923a757444f6cdbc1e72fa0c269"
-dependencies = [
- "futures",
- "metrics",
- "metrics-derive",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "reth-metrics"
+name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "futures",
- "metrics",
- "metrics-derive",
- "tokio",
- "tokio-util",
+ "bindgen 0.71.1",
+ "cc",
 ]
 
 [[package]]
@@ -9026,12 +9015,36 @@ source = "git+https://github.com/bnb-chain/reth.git?branch=feat%2Feth_getFinaliz
 dependencies = [
  "metrics",
  "metrics-derive",
+]
+
+[[package]]
+name = "reth-metrics"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "futures",
+ "metrics",
+ "metrics-derive",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "reth-metrics"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+dependencies = [
+ "futures",
+ "metrics",
+ "metrics-derive",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=feat%2Feth_getFinalizedHeader-bsc-fix#c511fff6df7cafc4f74f9c2742bb7974782044c0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9040,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=feat%2Feth_getFinalizedHeader-bsc-fix#c511fff6df7cafc4f74f9c2742bb7974782044c0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9049,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9063,7 +9076,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9082,25 +9095,25 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-discv4",
  "reth-discv5",
  "reth-dns-discovery",
  "reth-ecies",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9119,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9130,10 +9143,10 @@ dependencies = [
  "enr",
  "futures",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tokio-util",
  "serde",
  "thiserror 2.0.18",
@@ -9144,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9153,30 +9166,15 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "parking_lot",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-eth-wire-types",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "reth-network-peers"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "enr",
- "secp256k1 0.30.0",
- "serde_with",
- "thiserror 2.0.18",
- "tokio",
- "url",
 ]
 
 [[package]]
@@ -9193,17 +9191,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-network-types"
+name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-eip2124",
- "humantime-serde",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "serde_json",
- "tracing",
+ "alloy-primitives",
+ "alloy-rlp",
+ "enr",
+ "secp256k1 0.30.0",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -9219,20 +9218,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-nippy-jar"
+name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "anyhow",
- "bincode",
- "derive_more 2.1.1",
- "lz4_flex",
- "memmap2",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "alloy-eip2124",
+ "humantime-serde",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde",
- "thiserror 2.0.18",
+ "serde_json",
  "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -9253,24 +9249,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-nippy-jar"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "derive_more 2.1.1",
+ "lz4_flex",
+ "memmap2",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "reth-basic-payload-builder",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
  "reth-node-core",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9279,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9295,23 +9308,23 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-consensus-debug-client",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-downloaders",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-exex",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-invalid-block-hooks",
  "reth-network",
  "reth-network-api",
@@ -9322,8 +9335,8 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-prune",
  "reth-rpc",
  "reth-rpc-api",
@@ -9335,9 +9348,9 @@ dependencies = [
  "reth-static-file",
  "reth-tasks",
  "reth-tokio-util",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-transaction-pool",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde_json",
@@ -9349,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9363,32 +9376,32 @@ dependencies = [
  "humantime",
  "ipnet",
  "rand 0.9.2",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-cli-util",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-discv4",
  "reth-discv5",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
@@ -9405,36 +9418,36 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-transaction-pool",
  "revm",
  "tokio",
@@ -9443,16 +9456,16 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "chrono",
  "futures-util",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-transaction-pool",
  "serde",
  "serde_json",
@@ -9467,7 +9480,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9477,13 +9490,13 @@ dependencies = [
  "futures",
  "humantime",
  "pin-project",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-stages",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "tokio",
  "tracing",
 ]
@@ -9491,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9504,24 +9517,12 @@ dependencies = [
  "metrics-util",
  "procfs 0.17.0",
  "reqwest 0.12.28",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
  "tower",
  "tracing",
-]
-
-[[package]]
-name = "reth-node-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
 ]
 
 [[package]]
@@ -9537,18 +9538,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-optimism-primitives"
+name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "op-alloy-consensus",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "serde_with",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
 ]
 
 [[package]]
@@ -9567,33 +9565,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "op-alloy-consensus",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-payload-builder-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "pin-project",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9612,26 +9613,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-payload-primitives"
+name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "either",
- "op-alloy-rpc-types-engine",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "thiserror 2.0.18",
+ "pin-project",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -9658,27 +9648,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-payload-validator"
+name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
  "alloy-rpc-types-engine",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "auto_impl",
+ "either",
+ "op-alloy-rpc-types-engine",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
-name = "reth-primitives"
+name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
- "c-kzg",
- "once_cell",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "alloy-rpc-types-engine",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
 ]
 
 [[package]]
@@ -9696,36 +9695,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-primitives-traits"
+name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "arbitrary",
- "auto_impl",
- "byteorder",
- "bytes 1.11.1",
- "derive_more 2.1.1",
- "modular-bitfield",
+ "c-kzg",
  "once_cell",
- "op-alloy-consensus",
- "proptest",
- "proptest-arbitrary-interop",
- "rayon",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
 ]
 
 [[package]]
@@ -9761,47 +9741,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-provider"
+name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
- "alloy-rpc-types-engine",
- "dashmap 6.1.0",
- "eyre",
- "itertools 0.14.0",
- "metrics",
- "notify",
- "parking_lot",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie",
+ "arbitrary",
+ "auto_impl",
+ "byteorder",
+ "bytes 1.11.1",
+ "derive_more 2.1.1",
+ "modular-bitfield",
+ "once_cell",
+ "op-alloy-consensus",
+ "proptest",
+ "proptest-arbitrary-interop",
  "rayon",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm-database",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm-bytecode",
+ "revm-primitives",
  "revm-state",
- "rust-eth-triedb",
- "strum 0.27.2",
- "tokio",
- "tracing",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9849,9 +9818,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-provider"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "dashmap 6.1.0",
+ "eyre",
+ "itertools 0.14.0",
+ "metrics",
+ "notify",
+ "parking_lot",
+ "rayon",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm-database",
+ "revm-state",
+ "rust-eth-triedb",
+ "strum 0.27.2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9859,36 +9872,21 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-exex-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tokio-util",
  "rustc-hash",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-primitives",
- "arbitrary",
- "derive_more 2.1.1",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
- "strum 0.27.2",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9907,19 +9905,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-prune-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-primitives",
+ "arbitrary",
+ "derive_more 2.1.1",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network",
  "reth-network-api",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9928,41 +9941,28 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "eyre",
  "futures",
  "parking_lot",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ress-protocol",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-tokio-util",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "schnellru",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "reth-revm"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-primitives",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm",
 ]
 
 [[package]]
@@ -9978,9 +9978,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-revm"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-primitives",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm",
+]
+
+[[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10017,34 +10030,34 @@ dependencies = [
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-api",
  "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -10063,7 +10076,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10082,18 +10095,18 @@ dependencies = [
  "alloy-rpc-types-txpool",
  "alloy-serde",
  "jsonrpsee",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-eth-api",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10102,23 +10115,23 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "pin-project",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
  "reth-node-core",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -10134,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10146,9 +10159,9 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -10156,7 +10169,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10165,16 +10178,16 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-api",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
@@ -10186,7 +10199,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10206,21 +10219,21 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "revm",
  "revm-inspectors",
  "rust-eth-triedb",
@@ -10231,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10250,21 +10263,21 @@ dependencies = [
  "metrics",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "revm",
  "revm-inspectors",
  "schnellru",
@@ -10279,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10293,14 +10306,14 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-api",
  "serde",
  "strum 0.27.2",
@@ -10309,7 +10322,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10322,35 +10335,35 @@ dependencies = [
  "num-traits",
  "rayon",
  "reqwest 0.12.28",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-exex",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-prune",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-stages-api",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-testing-utils",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "rust-eth-triedb",
  "tempfile",
  "thiserror 2.0.18",
@@ -10361,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10369,34 +10382,20 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "metrics",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-prune",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-static-file",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tokio-util",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-primitives",
- "arbitrary",
- "bytes 1.11.1",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "serde",
 ]
 
 [[package]]
@@ -10414,36 +10413,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-stages-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-primitives",
+ "arbitrary",
+ "bytes 1.11.1",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "serde",
+]
+
+[[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
  "rayon",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-primitives",
- "clap",
- "derive_more 2.1.1",
- "fixed-map",
- "serde",
- "strum 0.27.2",
 ]
 
 [[package]]
@@ -10459,27 +10459,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-storage-api"
+name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm-database",
- "serde_json",
+ "clap",
+ "derive_more 2.1.1",
+ "fixed-map",
+ "serde",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -10507,20 +10496,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-storage-errors"
+name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.1.1",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm-database-interface",
- "revm-state",
- "thiserror 2.0.18",
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm-database",
+ "serde_json",
 ]
 
 [[package]]
@@ -10541,9 +10537,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-storage-errors"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 2.1.1",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm-database-interface",
+ "revm-state",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10551,7 +10564,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10561,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10569,34 +10582,19 @@ dependencies = [
  "alloy-primitives",
  "rand 0.8.5",
  "rand 0.9.2",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "secp256k1 0.30.0",
 ]
 
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "reth-tracing"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "clap",
- "eyre",
- "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "rolling-file",
- "tracing",
- "tracing-appender",
- "tracing-journald",
- "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -10611,25 +10609,22 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-journald",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
-name = "reth-tracing-otlp"
+name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "clap",
  "eyre",
- "opentelemetry",
- "opentelemetry-appender-tracing",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "rolling-file",
  "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber 0.3.22",
- "url",
+ "tracing-appender",
+ "tracing-journald",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -10645,14 +10640,32 @@ dependencies = [
  "opentelemetry_sdk",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
+ "url",
+]
+
+[[package]]
+name = "reth-tracing-otlp"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "clap",
+ "eyre",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10667,15 +10680,15 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.9.2",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-eth-wire-types",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-tasks",
  "revm-interpreter",
  "revm-primitives",
@@ -10688,32 +10701,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "reth-trie"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "itertools 0.14.0",
- "metrics",
- "parking_lot",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "revm-database",
- "tracing",
- "triehash",
 ]
 
 [[package]]
@@ -10743,32 +10730,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-trie-common"
+name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
  "alloy-trie",
- "arbitrary",
- "arrayvec",
- "bytes 1.11.1",
- "derive_more 2.1.1",
- "hash-db",
+ "auto_impl",
  "itertools 0.14.0",
- "nybbles",
- "plain_hasher",
- "rayon",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "metrics",
+ "parking_lot",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "revm-database",
- "rust-eth-triedb",
- "rust-eth-triedb-state-trie",
- "serde",
- "serde_with",
+ "tracing",
+ "triehash",
 ]
 
 [[package]]
@@ -10801,24 +10785,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-trie-db"
+name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
- "metrics",
- "parking_lot",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-trie",
+ "arbitrary",
+ "arrayvec",
+ "bytes 1.11.1",
+ "derive_more 2.1.1",
+ "hash-db",
+ "itertools 0.14.0",
+ "nybbles",
+ "plain_hasher",
+ "rayon",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "revm-database",
  "rust-eth-triedb",
- "tracing",
+ "rust-eth-triedb-state-trie",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -10843,9 +10835,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-trie-db"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-primitives",
+ "metrics",
+ "parking_lot",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "rust-eth-triedb",
+ "tracing",
+]
+
+[[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10855,34 +10868,15 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-sparse"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "metrics",
- "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "smallvec",
  "tracing",
 ]
 
@@ -10904,19 +10898,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-trie-sparse"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "metrics",
+ "rayon",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
  "metrics",
  "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "smallvec",
  "tracing",
 ]
@@ -10924,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.8#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
+source = "git+https://github.com/bnb-chain/reth.git?branch=feat%2Feth_getFinalizedHeader-bsc-fix#c511fff6df7cafc4f74f9c2742bb7974782044c0"
 dependencies = [
  "zstd",
 ]
@@ -10932,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=feat%2Feth_getFinalizedHeader-bsc-fix#c511fff6df7cafc4f74f9c2742bb7974782044c0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19#e811290609f3a4d3b06d070a8a3028aa8df954c7"
 dependencies = [
  "zstd",
 ]
@@ -10996,46 +11009,46 @@ dependencies = [
  "rand 0.9.2",
  "reth",
  "reth-basic-payload-builder",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-util",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-discv4",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-node-core",
  "reth-node-ethereum",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-server-types",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.8)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix%2Fvalidator-slash-2026-03-19)",
  "revm",
  "revm-context-interface",
  "revm-database",
@@ -11054,7 +11067,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "uuid 1.21.0",
+ "uuid 1.22.0",
  "zeroize",
 ]
 
@@ -11189,9 +11202,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e435414e9de50a1b930da602067c76365fea2fea11e80ceb50783c94ddd127f"
+checksum = "e341d9777b1903a8428bc6f8fe7a8f80671d2249837c9749566e61328ef14125"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11222,9 +11235,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.0.0"
+version = "32.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-bn254",
@@ -11246,9 +11259,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11448,7 +11461,7 @@ dependencies = [
  "metrics",
  "once_cell",
  "rayon",
- "reth-metrics 1.7.0",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
  "rust-eth-triedb-common",
  "rust-eth-triedb-pathdb",
  "rust-eth-triedb-state-trie",
@@ -11478,7 +11491,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "metrics",
- "reth-metrics 1.7.0",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
  "rocksdb",
  "rust-eth-triedb-common",
  "schnellru",
@@ -11570,14 +11583,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -11595,9 +11608,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -11662,7 +11675,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.9",
@@ -11749,9 +11762,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -12076,9 +12089,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -12095,11 +12108,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12206,9 +12219,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
@@ -12307,9 +12320,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -12354,12 +12367,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12596,9 +12609,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -12607,14 +12620,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -12819,9 +12832,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -12834,9 +12847,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes 1.11.1",
  "libc",
@@ -12844,16 +12857,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12876,7 +12889,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -12900,7 +12913,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -12956,9 +12969,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
@@ -12974,28 +12987,28 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -13089,7 +13102,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.21.0",
+ "uuid 1.22.0",
 ]
 
 [[package]]
@@ -13125,7 +13138,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13167,7 +13180,7 @@ checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13193,7 +13206,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -13218,9 +13231,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -13294,7 +13307,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -13461,11 +13474,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -13600,9 +13613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -13613,9 +13626,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -13627,9 +13640,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13637,9 +13650,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -13650,9 +13663,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -13720,9 +13733,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14273,9 +14286,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -14425,7 +14447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -14465,18 +14487,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,58 +16,58 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8", features = [
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.8" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "fix/validator-slash-2026-03-19" }
 revm = "34.0.0"
 revm-context-interface = "14.0.0"
 revm-database = "10.0.0"

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -35,6 +35,7 @@ use reth_ethereum_primitives::Receipt;
 use reth_payload_primitives::EngineApiMessageVersion;
 use reth_primitives::{gas_spent_by_transactions, GotExpected};
 use reth_primitives_traits::constants::{GAS_LIMIT_BOUND_DIVISOR, MINIMUM_GAS_LIMIT};
+use reth_ethereum_forks::Head;
 use reth_provider::{BlockNumReader, HeaderProvider};
 use std::sync::Arc;
 
@@ -1263,7 +1264,31 @@ where
                 PayloadStatusEnum::Invalid { validation_error } => {
                     Err(ParliaConsensusErr::ForkChoiceUpdateError(validation_error))
                 }
-                _ => Ok(()),
+                _ => {
+                    // Update P2P network status so peers see our current chain head.
+                    // Without this, the Status advertised to peers stays at the startup
+                    // value and peers will consider us stale/stalling.
+                    let td = self
+                        .header_td(
+                            &self.engine_handle,
+                            new_canonical_head.number,
+                            new_canonical_head.hash_slow(),
+                        )
+                        .await
+                        .ok()
+                        .flatten()
+                        .unwrap_or_default();
+                    if let Some(network_handle) = shared::get_network_handle() {
+                        network_handle.update_status(Head {
+                            number: new_canonical_head.number,
+                            hash: new_canonical_head.hash_slow(),
+                            difficulty: new_canonical_head.difficulty,
+                            timestamp: new_canonical_head.timestamp,
+                            total_difficulty: td,
+                        });
+                    }
+                    Ok(())
+                }
             },
             Err(err) => Err(ParliaConsensusErr::ForkChoiceUpdateError(err.to_string())),
         }

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -1196,6 +1196,37 @@ where
         // Determine if we need to reorg using fork choice rules
         let need_reorg = self.is_need_reorg(incoming_header, &current_head).await?;
 
+        // Guard: if fork choice wants to switch to a block far ahead of the canonical
+        // head AND the block is not a direct child of the current head, defer the FCU.
+        // Sending an FCU for a distant block whose ancestors the engine-tree hasn't
+        // processed yet will trigger the missing-block path and, if the gap exceeds the
+        // pipeline threshold (32 blocks), start a heavyweight pipeline/backfill sync
+        // that stalls live sync.
+        //
+        // Instead, we skip the FCU and let intermediate blocks arrive through normal
+        // P2P propagation. Once the chain is connected, a subsequent update_forkchoice
+        // call for a closer block will apply the reorg correctly.
+        const MAX_FCU_AHEAD_DISTANCE: u64 = 16;
+        if need_reorg
+            && incoming_header.number > current_head.number
+            && incoming_header.parent_hash != current_head.hash_slow()
+        {
+            let gap = incoming_header.number - current_head.number;
+            if gap > MAX_FCU_AHEAD_DISTANCE {
+                tracing::warn!(
+                    target: "bsc::forkchoice",
+                    incoming_number = incoming_header.number,
+                    incoming_hash = ?incoming_header.hash_slow(),
+                    current_number = current_head.number,
+                    current_hash = ?current_head.hash_slow(),
+                    gap,
+                    "Skipping FCU for distant reorg target to avoid pipeline sync; \
+                     waiting for intermediate blocks"
+                );
+                return Ok(());
+            }
+        }
+
         // Only count as reorg if:
         // 1. Fork choice says we need to reorg AND
         // 2. The incoming block number is <= current head (actual chain reorganization)

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -540,3 +540,155 @@ pub fn revm_spec_by_timestamp_and_block_number(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::consensus::parlia::constants::{DIFF_INTURN, DIFF_NOTURN};
+    use crate::evm::api::BscEvm;
+    use crate::evm::transaction::BscTxEnv;
+    use crate::hardforks::bsc::BscHardfork;
+    use revm::{
+        context::{BlockEnv, CfgEnv, TxEnv},
+        context_interface::result::ExecutionResult,
+        inspector::NoOpInspector,
+        state::{AccountInfo, Bytecode},
+        ExecuteEvm,
+    };
+    use revm_database::InMemoryDB;
+    use alloy_primitives::{Address, Bytes, B256, U256};
+    use reth_evm::EvmEnv;
+
+    /// Bytecode: PREVRANDAO → PUSH1 0x00 → MSTORE → PUSH1 0x20 → PUSH1 0x00 → RETURN
+    /// Executes the PREVRANDAO opcode (0x44) and returns the 32-byte result.
+    const PREVRANDAO_BYTECODE: [u8; 9] = [
+        0x44,       // PREVRANDAO (returns prevrandao in post-merge, difficulty in pre-merge)
+        0x60, 0x00, // PUSH1 0x00
+        0x52,       // MSTORE (store result at memory offset 0)
+        0x60, 0x20, // PUSH1 0x20
+        0x60, 0x00, // PUSH1 0x00
+        0xf3,       // RETURN (return 32 bytes from memory offset 0)
+    ];
+
+    /// Execute the PREVRANDAO bytecode with the given BlockEnv and return the opcode result.
+    fn execute_prevrandao(prevrandao: Option<B256>, difficulty: U256) -> B256 {
+        let caller = Address::from([0x11; 20]);
+        let contract = Address::from([0x22; 20]);
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            caller,
+            AccountInfo { balance: U256::from(1_000_000u64), ..Default::default() },
+        );
+        db.insert_account_info(
+            contract,
+            AccountInfo::default()
+                .with_code(Bytecode::new_raw(Bytes::from(PREVRANDAO_BYTECODE.to_vec()))),
+        );
+
+        let block_env = BlockEnv {
+            difficulty,
+            prevrandao,
+            ..Default::default()
+        };
+        // BSC uses post-merge spec where opcode 0x44 returns prevrandao.
+        // Use a post-merge BscHardfork so the EVM spec matches production.
+        let cfg_env = CfgEnv::new_with_spec(BscHardfork::HaberFix).with_chain_id(56);
+        let env: EvmEnv<BscHardfork> = EvmEnv::new(cfg_env, block_env);
+
+        let tx = BscTxEnv::new(
+            TxEnv::builder()
+                .caller(caller)
+                .chain_id(Some(56))
+                .gas_limit(100_000)
+                .gas_price(1)
+                .kind(revm::primitives::TxKind::Call(contract))
+                .build()
+                .expect("tx env should build"),
+        );
+
+        let mut evm = BscEvm::new(env, db, NoOpInspector, false, false);
+        let result = evm.transact_one(tx).expect("execution should not error");
+
+        match result {
+            ExecutionResult::Success { output, .. } => {
+                let bytes = output.data();
+                B256::from_slice(bytes)
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    /// Demonstrates that the PREVRANDAO opcode output depends solely on BlockEnv.prevrandao
+    /// in post-merge spec, so both the validation and building paths must set it to the same
+    /// value to produce consistent state roots.
+    #[test]
+    fn prevrandao_opcode_returns_prevrandao_not_difficulty() {
+        let difficulty = DIFF_INTURN; // U256(2)
+
+        // Post-merge: opcode 0x44 returns prevrandao, ignores difficulty
+        let result = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+        assert_eq!(
+            result,
+            B256::from(difficulty),
+            "PREVRANDAO opcode should return the prevrandao value"
+        );
+
+        // Confirm that changing difficulty alone does NOT affect the opcode output
+        let result_diff_only = execute_prevrandao(Some(B256::ZERO), difficulty);
+        assert_eq!(
+            result_diff_only,
+            B256::ZERO,
+            "PREVRANDAO opcode should NOT read from the difficulty field"
+        );
+    }
+
+    /// Proves the bug: before the fix, the validation path and building path would set
+    /// different prevrandao values, causing the PREVRANDAO opcode to return different results.
+    ///
+    /// Validation path:  prevrandao = header.difficulty() (e.g. DIFF_INTURN = 2)
+    /// Building path (before fix): prevrandao = header.mix_hash (B256::ZERO for pre-Lorentz)
+    #[test]
+    fn prevrandao_mismatch_between_validation_and_building_paths() {
+        let difficulty = DIFF_INTURN; // U256(2)
+
+        // --- Validation path (evm_env in config.rs) ---
+        // Sets: difficulty = U256::ZERO, prevrandao = Some(header.difficulty().into())
+        let validation_result = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+
+        // --- Building path BEFORE fix (next_evm_env in config.rs) ---
+        // Sets: difficulty = U256::ZERO, prevrandao = Some(attributes.prev_randao)
+        // where prev_randao was mix_hash = B256::ZERO (pre-Lorentz)
+        let building_before_fix = execute_prevrandao(Some(B256::ZERO), U256::ZERO);
+
+        // These differ — any contract using PREVRANDAO would produce different state roots
+        assert_ne!(
+            validation_result, building_before_fix,
+            "Bug: validation and building paths return different PREVRANDAO values"
+        );
+        assert_eq!(validation_result, B256::from(difficulty));
+        assert_eq!(building_before_fix, B256::ZERO);
+
+        // --- Building path AFTER fix ---
+        // Sets: prev_randao = calculate_difficulty() = DIFF_INTURN, matching validation
+        let building_after_fix = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+
+        assert_eq!(
+            validation_result, building_after_fix,
+            "After fix: both paths should return the same PREVRANDAO value"
+        );
+    }
+
+    /// Same test with DIFF_NOTURN to cover the out-of-turn validator case.
+    #[test]
+    fn prevrandao_consistency_for_noturn_difficulty() {
+        let difficulty = DIFF_NOTURN; // U256(1)
+
+        let validation = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+        let building_fixed = execute_prevrandao(Some(difficulty.into()), U256::ZERO);
+        let building_broken = execute_prevrandao(Some(B256::ZERO), U256::ZERO);
+
+        assert_eq!(validation, building_fixed);
+        assert_ne!(validation, building_broken);
+        assert_eq!(validation, B256::from(difficulty));
+    }
+}

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use alloy_consensus::{Header, BlockHeader};
+use alloy_consensus::Header;
 use alloy_primitives::{Address, Bytes, B256};
 use crate::consensus::parlia::Snapshot;
 use crate::consensus::parlia::consensus::Parlia;
@@ -202,12 +202,7 @@ where
         extra_data[start..].copy_from_slice(&seal_data);
         new_header.extra_data = Bytes::from(extra_data);
 
-        debug_header(
-            parent_snap,
-            parent_header,
-            new_header,
-            snapshot_provider,
-        );
+        debug_header(new_header, parlia.spec.chain().id(), "finalize_new_header");
     }
 
     Ok(())

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -1,19 +1,19 @@
+use std::sync::Arc;
+use alloy_consensus::{Header, BlockHeader};
+use alloy_primitives::{Address, Bytes, B256};
+use crate::consensus::parlia::Snapshot;
+use crate::consensus::parlia::consensus::Parlia;
+use crate::consensus::parlia::util::{calculate_difficulty, debug_header, set_millisecond_part_of_timestamp};
 use crate::chainspec::BscChainSpec;
 use crate::consensus::eip4844::next_block_excess_blob_gas_with_mendel;
-use crate::consensus::parlia::consensus::Parlia;
 use crate::consensus::parlia::provider::SnapshotProvider;
-use crate::consensus::parlia::util::{calculate_difficulty, debug_header};
-use crate::consensus::parlia::{Snapshot, VoteAddress};
-use crate::consensus::parlia::{EXTRA_SEAL_LEN, EXTRA_VANITY_LEN};
+use crate::consensus::parlia::{VoteAddress, EXTRA_SEAL_LEN, EXTRA_VANITY_LEN};
 use crate::hardforks::BscHardforks;
 use crate::node::evm::pre_execution::VALIDATOR_CACHE;
 use crate::node::miner::bsc_miner::MiningContext;
 use crate::node::miner::signer::{seal_header_with_global_signer, SignerError};
-use alloy_consensus::Header;
-use alloy_primitives::{Address, Bytes, B256};
 use reth::payload::EthPayloadBuilderAttributes;
 use reth_chainspec::EthChainSpec;
-use std::sync::Arc;
 
 fn resolve_epoch_validators(
     parent_snap: &Snapshot,
@@ -67,11 +67,15 @@ pub fn prepare_new_attributes(
 ) -> EthPayloadBuilderAttributes {
     let mut new_header = prepare_new_header(parlia.clone(), parent_header, signer);
     parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header, &mut new_header);
+    // BSC uses the PREVRANDAO opcode to return difficulty (not a random value like
+    // Ethereum PoS). The validation path in BscEvmConfig::evm_env sets
+    // `prevrandao = header.difficulty()`, so the building path must match.
+    let difficulty = calculate_difficulty(&ctx.parent_snapshot, signer);
     let mut attributes = EthPayloadBuilderAttributes {
         parent: new_header.parent_hash,
         timestamp: new_header.timestamp,
         suggested_fee_recipient: new_header.beneficiary,
-        prev_randao: new_header.mix_hash,
+        prev_randao: difficulty.into(),
         ..Default::default()
     };
     if BscHardforks::is_bohr_active_at_timestamp(
@@ -138,6 +142,18 @@ where
 {
     new_header.difficulty = calculate_difficulty(parent_snap, new_header.beneficiary);
 
+    // Restore correct mix_hash for the sealed header. The assembler may have set
+    // mix_hash from BlockEnv.prevrandao (which is the difficulty value for EVM
+    // execution). BSC encodes the millisecond timestamp part in mix_hash post-Lorentz,
+    // or uses B256::ZERO pre-Lorentz.
+    let millisecond_timestamp =
+        parlia.block_time_for_ramanujan_fork(parent_snap, parent_header, new_header);
+    if parlia.spec.is_lorentz_active_at_timestamp(new_header.number, new_header.timestamp) {
+        set_millisecond_part_of_timestamp(millisecond_timestamp, new_header);
+    } else {
+        new_header.mix_hash = B256::ZERO;
+    }
+
     if new_header.extra_data.len() < EXTRA_VANITY_LEN {
         new_header.extra_data = Bytes::from(vec![0u8; EXTRA_VANITY_LEN]);
     }
@@ -186,85 +202,13 @@ where
         extra_data[start..].copy_from_slice(&seal_data);
         new_header.extra_data = Bytes::from(extra_data);
 
-        debug_header(new_header, parlia.spec.chain().id(), "finalize_new_header");
+        debug_header(
+            parent_snap,
+            parent_header,
+            new_header,
+            snapshot_provider,
+        );
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_primitives::B256;
-
-    fn unique_parent_header(number: u64) -> Header {
-        Header { number, parent_hash: B256::random(), ..Default::default() }
-    }
-
-    #[test]
-    fn resolve_epoch_validators_falls_back_to_snapshot_on_cache_miss() {
-        let parent_header = unique_parent_header(499);
-        let parent_hash = parent_header.hash_slow();
-
-        let validators = vec![
-            Address::with_last_byte(2),
-            Address::with_last_byte(1),
-            Address::with_last_byte(3),
-        ];
-        let vote_addresses = vec![
-            VoteAddress::with_last_byte(22),
-            VoteAddress::with_last_byte(11),
-            VoteAddress::with_last_byte(33),
-        ];
-        let parent_snap =
-            Snapshot::new(validators, 499, B256::random(), 500, Some(vote_addresses.clone()));
-
-        let resolved = resolve_epoch_validators(&parent_snap, &parent_header).unwrap();
-
-        assert_eq!(resolved.0, parent_snap.validators);
-        assert_eq!(resolved.1.len(), parent_snap.validators.len());
-        for (i, validator) in parent_snap.validators.iter().enumerate() {
-            assert_eq!(resolved.1[i], parent_snap.validators_map.get(validator).unwrap().vote_addr);
-        }
-
-        let mut cache = VALIDATOR_CACHE.lock().unwrap();
-        let cached = cache.get(&parent_hash).unwrap();
-        assert_eq!(cached.0, resolved.0);
-        assert_eq!(cached.1, resolved.1);
-    }
-
-    #[test]
-    fn resolve_epoch_validators_prefers_cache() {
-        let parent_header = unique_parent_header(799);
-        let parent_hash = parent_header.hash_slow();
-
-        let cached_validators = vec![Address::with_last_byte(9), Address::with_last_byte(7)];
-        let cached_vote_addresses =
-            vec![VoteAddress::with_last_byte(99), VoteAddress::with_last_byte(77)];
-        {
-            let mut cache = VALIDATOR_CACHE.lock().unwrap();
-            cache.insert(parent_hash, (cached_validators.clone(), cached_vote_addresses.clone()));
-        }
-
-        let parent_snap =
-            Snapshot::new(vec![Address::with_last_byte(1)], 799, B256::random(), 500, None);
-        let resolved = resolve_epoch_validators(&parent_snap, &parent_header).unwrap();
-
-        assert_eq!(resolved.0, cached_validators);
-        assert_eq!(resolved.1, cached_vote_addresses);
-    }
-
-    #[test]
-    fn resolve_epoch_validators_errors_when_no_cache_or_snapshot_validators() {
-        let parent_header = unique_parent_header(999);
-        let parent_snap = Snapshot::default();
-
-        let err = resolve_epoch_validators(&parent_snap, &parent_header).unwrap_err();
-        match err {
-            SignerError::SigningFailed(msg) => {
-                assert!(msg.contains("Missing epoch validators"), "unexpected message: {}", msg);
-            }
-            other => panic!("unexpected error: {:?}", other),
-        }
-    }
 }

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -163,52 +163,31 @@ where
                     }
                     .into(),
                     PayloadStatusEnum::Syncing => {
-                        // When new_payload returns Syncing status, we need to manually trigger FCU
-                        // to avoid the engine-tree being stuck in syncing state without any driver.
-                        // By calling FCU, we inform the engine about the new head block hash,
-                        // which can help trigger additional sync/download activities in the engine-tree.
+                        // The engine-tree has buffered this disconnected block and will
+                        // request downloads of its missing ancestors automatically.
+                        //
+                        // We intentionally do NOT send an FCU here. Sending an FCU with
+                        // the disconnected block's hash causes the engine-tree to enter
+                        // handle_missing_block(), which triggers a download request. If
+                        // the gap between the canonical tip and this block exceeds the
+                        // pipeline threshold (default 32 blocks), the engine falls back
+                        // to pipeline/backfill sync — a heavyweight operation that stalls
+                        // live sync for seconds to minutes.
+                        //
+                        // Instead, we rely on the engine-tree's built-in mechanism: when
+                        // the missing parent blocks arrive (via normal P2P block
+                        // propagation or NewBlockHashes download), the buffered block
+                        // will be connected and processed through a regular FCU on the
+                        // next valid block import.
                         let block_hash = header.hash_slow();
                         let block_number = header.number;
                         tracing::debug!(
                             target: "bsc::block_import",
                             block_hash = %block_hash,
                             block_number = block_number,
-                            "New payload returned Syncing status - attempting fork choice update"
+                            "New payload returned Syncing status - block buffered, \
+                             skipping FCU to avoid unnecessary pipeline sync"
                         );
-
-                        // Direct FCU call to help sync progress
-                        let forkchoice_state = alloy_rpc_types::engine::ForkchoiceState {
-                            head_block_hash: block_hash,
-                            safe_block_hash: alloy_primitives::B256::ZERO,
-                            finalized_block_hash: alloy_primitives::B256::ZERO,
-                        };
-                        match engine
-                            .fork_choice_updated(
-                                forkchoice_state,
-                                None,
-                                reth_payload_primitives::EngineApiMessageVersion::V1,
-                            )
-                            .await
-                        {
-                            Ok(result) => {
-                                tracing::debug!(
-                                    target: "bsc::block_import",
-                                    block_hash = %block_hash,
-                                    block_number = block_number,
-                                    status = ?result.payload_status.status,
-                                    "FCU result for syncing block"
-                                );
-                            }
-                            Err(err) => {
-                                tracing::trace!(
-                                    target: "bsc::block_import",
-                                    block_hash = %block_hash,
-                                    block_number = block_number,
-                                    error = %err,
-                                    "Failed to update fork choice for syncing block"
-                                );
-                            }
-                        }
                         None
                     }
                     _ => None,
@@ -726,6 +705,10 @@ mod tests {
                 fcu: PayloadStatusEnum::Invalid { validation_error: "fcu error".into() },
             }
         }
+
+        fn syncing_new_payload() -> Self {
+            Self { new_payload: PayloadStatusEnum::Syncing, fcu: PayloadStatusEnum::Valid }
+        }
     }
 
     /// Test fixture for block import tests
@@ -856,5 +839,94 @@ mod tests {
                 }
             }
         }));
+    }
+
+    /// Same as `handle_engine_msg` but tracks how many FCU messages were received.
+    async fn handle_engine_msg_with_fcu_counter(
+        mut from_engine: mpsc::UnboundedReceiver<BeaconEngineMessage<BscPayloadTypes>>,
+        responses: EngineResponses,
+        fcu_count: Arc<std::sync::atomic::AtomicU64>,
+    ) {
+        tokio::spawn(Box::pin(async move {
+            while let Some(message) = from_engine.recv().await {
+                match message {
+                    BeaconEngineMessage::NewPayload { payload: _, tx } => {
+                        tx.send(Ok(PayloadStatus::new(responses.new_payload.clone(), None)))
+                            .unwrap();
+                    }
+                    BeaconEngineMessage::ForkchoiceUpdated {
+                        state: _,
+                        payload_attrs: _,
+                        version: _,
+                        tx,
+                    } => {
+                        fcu_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::new(
+                            responses.fcu.clone(),
+                            None,
+                        ))))
+                        .unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    /// Verifies that when new_payload returns Syncing (disconnected block), no FCU
+    /// is sent to the engine. This prevents unnecessary pipeline sync for blocks
+    /// whose parents haven't arrived yet.
+    #[tokio::test]
+    async fn syncing_payload_does_not_trigger_fcu() {
+        let fcu_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        let provider = MockProvider::new();
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(
+            crate::chainspec::bsc::bsc_mainnet(),
+        ));
+
+        let (to_engine, from_engine) = mpsc::unbounded_channel();
+        let engine_handle = ConsensusEngineHandle::new(to_engine);
+
+        handle_engine_msg_with_fcu_counter(
+            from_engine,
+            EngineResponses::syncing_new_payload(),
+            fcu_count.clone(),
+        )
+        .await;
+
+        let (to_import, from_network) = mpsc::unbounded_channel();
+        let (_, from_builder) = mpsc::unbounded_channel();
+        let (_, from_hashes) = mpsc::unbounded_channel();
+        let (to_network, _import_outcome) = mpsc::unbounded_channel();
+
+        let _handle = ImportHandle::new(to_import.clone(), mpsc::unbounded_channel().0, _import_outcome);
+
+        let service = ImportService::new(
+            provider,
+            chain_spec,
+            engine_handle,
+            from_network,
+            from_builder,
+            from_hashes,
+            to_network,
+        );
+        tokio::spawn(Box::pin(async move {
+            service.await.unwrap();
+        }));
+
+        // Send a block that will get a Syncing response
+        let block_msg = create_test_block();
+        to_import.send((block_msg, PeerId::random())).unwrap();
+
+        // Give enough time for the async processing
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        // No FCU should have been sent — only new_payload was called
+        assert_eq!(
+            fcu_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "FCU should not be sent when new_payload returns Syncing"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Removes the FCU (fork choice updated) call from the `Syncing` handler in `ImportService::new_payload`, which was inadvertently triggering pipeline sync for disconnected blocks
- Adds a distance guard in `BscForkChoiceEngine::update_forkchoice` to skip FCU for reorg targets more than 16 blocks ahead of the canonical head
- Adds a test verifying that no FCU is sent when `new_payload` returns `Syncing`

## Problem

The node occasionally stalls during live sync after concurrent deep reorgs with low peer count (#290). The root cause is:

1. A block arrives whose parent chain is unknown (disconnected). `new_payload` buffers it and returns `Syncing`.
2. The import service then sends an FCU with the disconnected block's hash to the engine-tree.
3. The engine-tree does not have this block in its canonical or in-memory state, so it falls through to `handle_missing_block()`, issuing a download request.
4. If the gap between the canonical tip and this block exceeds 32 (the `min_blocks_for_pipeline_run` threshold), the engine triggers pipeline/backfill sync -- a heavyweight operation that stalls live sync for seconds to minutes.

In the reported case, the gap was 61 blocks (87262716 to 87262777), well above the 32-block threshold.

## Solution

**Change 1 — `ImportService::new_payload` (Syncing handler):** Remove the FCU call when `new_payload` returns `Syncing`. The engine-tree already buffers the disconnected block and will process it once parent blocks arrive via normal P2P propagation or `NewBlockHashes` download. Sending an FCU for an unknown block only triggers the expensive pipeline sync path.

**Change 2 — `BscForkChoiceEngine::update_forkchoice`:** Add a guard that skips FCU when:
- Fork choice says to reorg to an incoming block
- The incoming block is more than 16 blocks ahead of the canonical head
- The incoming block is not a direct child of the current head

This prevents the engine-tree from entering the missing-block/pipeline path for distant reorg targets during concurrent deep reorgs. The intermediate blocks will arrive naturally via P2P, and a closer subsequent block will trigger the correct FCU.

## Test plan

- [x] Added `syncing_payload_does_not_trigger_fcu` test that verifies zero FCU messages are sent when `new_payload` returns `Syncing`
- [x] Existing `can_handle_valid_block`, `can_handle_invalid_new_payload`, and `deduplicates_blocks` tests pass
- [x] Existing `forkchoice_rule` tests pass
- [x] `cargo check` and `cargo clippy` pass cleanly
- [ ] Deploy to staging BSC mainnet node and monitor `reth_consensus_engine_beacon_pipeline_runs` counter over 24-48 hours

Fixes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)