### PR TITLE
Perf/fix usage of hash slow

### DIFF
--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -761,7 +761,7 @@ where
             }
 
             tracing::debug!(target: "parlia::consensus", "vote count is less than 2/3 of validators, skip assemble vote attestation, number={}, parent={:?}, vote count={}, validators count={}", 
-                target_header.number(), target_hash, vote_count, snap.validators.len());
+                target_header.number(), target_hash, votes.len(), snap.validators.len());
             let block_hash = parent_hash;
             if let Some(header) =
                 crate::shared::get_canonical_header_by_hash_from_provider(&block_hash)

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -748,13 +748,12 @@ where
         let mut target_header = parent_header.clone();
         let mut target_header_parent_snap = None;
         for _ in 0..times {
-            let snap = snapshot_provider.snapshot_by_hash(&target_header.parent_hash()).ok_or(
-                ParliaConsensusError::SnapshotNotFound { block_hash: target_header.parent_hash() },
+            let parent_hash = target_header.parent_hash();
+            let target_hash = target_header.hash_slow();
+            let snap = snapshot_provider.snapshot_by_hash(&parent_hash).ok_or(
+                ParliaConsensusError::SnapshotNotFound { block_hash: parent_hash },
             )?;
-            votes = fetch_vote_by_block_hash_and_source_number(
-                target_header.hash_slow(),
-                justified_number,
-            );
+            votes = fetch_vote_by_block_hash_and_source_number(target_hash, justified_number);
             let quorum = usize::div_ceil(snap.validators.len() * 2, 3);
             if votes.len() >= quorum {
                 target_header_parent_snap = Some(snap);
@@ -762,8 +761,8 @@ where
             }
 
             tracing::debug!(target: "parlia::consensus", "vote count is less than 2/3 of validators, skip assemble vote attestation, number={}, parent={:?}, vote count={}, validators count={}", 
-                target_header.number(), target_header.hash_slow(), votes.len(), snap.validators.len());
-            let block_hash = target_header.parent_hash();
+                target_header.number(), target_hash, vote_count, snap.validators.len());
+            let block_hash = parent_hash;
             if let Some(header) =
                 crate::shared::get_canonical_header_by_hash_from_provider(&block_hash)
             {

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -17,10 +17,16 @@ const LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER: u64 = 256;
 /// Size of the LRU cache for tracking finality notifications (matches geth's finalizedNotified)
 const FINALIZED_NOTIFIED_CACHE_SIZE: usize = 21;
 
+#[derive(Clone)]
+struct VoteEntry {
+    hash: B256,
+    envelope: VoteEnvelope,
+}
+
 /// Container for votes associated with a specific block hash.
 #[derive(Default)]
 struct VoteMessages {
-    vote_messages: Vec<VoteEnvelope>,
+    vote_messages: Vec<VoteEntry>,
 }
 
 /// Priority queue wrapper for vote data, ordered by target_number (ascending).
@@ -71,6 +77,8 @@ struct VotePool {
     cur_votes: HashMap<B256, VoteMessages>,
     /// Priority queue for efficiently finding votes to prune.
     cur_votes_pq: VotesPriorityQueue,
+    /// Total number of votes stored in the pool.
+    total_votes: usize,
 }
 
 impl VotePool {
@@ -79,6 +87,7 @@ impl VotePool {
             received_votes: HashSet::new(),
             cur_votes: HashMap::new(),
             cur_votes_pq: VotesPriorityQueue::new(),
+            total_votes: 0,
         }
     }
 
@@ -95,17 +104,22 @@ impl VotePool {
             if !self.cur_votes.contains_key(&block_hash) {
                 self.cur_votes_pq.push(vote.data);
             }
-
-            self.cur_votes.entry(block_hash).or_default().vote_messages.push(vote);
+            self.cur_votes
+                .entry(block_hash)
+                .or_default()
+                .vote_messages
+                .push(VoteEntry { hash: vote_hash, envelope: vote });
+            self.total_votes += 1;
         }
     }
 
     fn drain(&mut self) -> Vec<VoteEnvelope> {
         self.received_votes.clear();
         self.cur_votes_pq = VotesPriorityQueue::new();
+        self.total_votes = 0;
         let mut all_votes = Vec::new();
         for (_, vote_messages) in self.cur_votes.drain() {
-            all_votes.extend(vote_messages.vote_messages);
+            all_votes.extend(vote_messages.vote_messages.into_iter().map(|entry| entry.envelope));
         }
         all_votes
     }
@@ -113,13 +127,13 @@ impl VotePool {
     fn get_votes(&self) -> Vec<VoteEnvelope> {
         let mut all_votes = Vec::new();
         for vote_messages in self.cur_votes.values() {
-            all_votes.extend(vote_messages.vote_messages.clone());
+            all_votes.extend(vote_messages.vote_messages.iter().map(|entry| entry.envelope.clone()));
         }
         all_votes
     }
 
     fn len(&self) -> usize {
-        self.cur_votes.values().map(|vm| vm.vote_messages.len()).sum()
+        self.total_votes
     }
 
     fn len_for_block(&self, block_hash: &B256) -> usize {
@@ -128,7 +142,11 @@ impl VotePool {
 
     fn fetch_vote_by_block_hash(&self, block_hash: B256) -> Vec<VoteEnvelope> {
         if let Some(vote_messages) = self.cur_votes.get(&block_hash) {
-            vote_messages.vote_messages.clone()
+            vote_messages
+                .vote_messages
+                .iter()
+                .map(|entry| entry.envelope.clone())
+                .collect()
         } else {
             Vec::new()
         }
@@ -158,9 +176,9 @@ impl VotePool {
 
                 // Remove from votes map and received_votes set
                 if let Some(vote_box) = self.cur_votes.remove(&block_hash) {
+                    self.total_votes = self.total_votes.saturating_sub(vote_box.vote_messages.len());
                     for vote in vote_box.vote_messages {
-                        let vote_hash = vote.hash();
-                        self.received_votes.remove(&vote_hash);
+                        self.received_votes.remove(&vote.hash);
                     }
                 }
             } else {

--- a/src/node/engine_api/payload.rs
+++ b/src/node/engine_api/payload.rs
@@ -22,6 +22,7 @@ impl PayloadTypes for BscPayloadTypes {
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> Self::ExecutionData {
-        BscExecutionData(block.into_block())
+        let hash = block.hash();
+        BscExecutionData::new_with_hash(block.into_block(), hash)
     }
 }

--- a/src/node/engine_api/validator.rs
+++ b/src/node/engine_api/validator.rs
@@ -18,7 +18,7 @@ use reth_primitives::{RecoveredBlock, SealedBlock};
 use reth_primitives_traits::Block;
 use reth_trie_common::HashedPostState;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
@@ -53,20 +53,67 @@ impl BscEngineValidator {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BscExecutionData(pub BscBlock);
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BscExecutionData {
+    #[serde(flatten)]
+    pub block: BscBlock,
+    #[serde(skip, default)]
+    hash: OnceLock<B256>,
+}
+
+impl BscExecutionData {
+    pub fn new(block: BscBlock) -> Self {
+        Self { block, hash: OnceLock::new() }
+    }
+
+    pub fn new_with_hash(block: BscBlock, hash: B256) -> Self {
+        let lock = OnceLock::new();
+        let _ = lock.set(hash);
+        Self { block, hash: lock }
+    }
+
+    pub fn block_hash_cached(&self) -> B256 {
+        *self.hash.get_or_init(|| self.block.header.hash_slow())
+    }
+
+    pub fn into_block(self) -> BscBlock {
+        self.block
+    }
+}
+
+impl From<BscBlock> for BscExecutionData {
+    fn from(block: BscBlock) -> Self {
+        Self::new(block)
+    }
+}
+
+impl Default for BscExecutionData {
+    fn default() -> Self {
+        Self::new(BscBlock::default())
+    }
+}
+
+impl Clone for BscExecutionData {
+    fn clone(&self) -> Self {
+        let hash = OnceLock::new();
+        if let Some(value) = self.hash.get() {
+            let _ = hash.set(*value);
+        }
+        Self { block: self.block.clone(), hash }
+    }
+}
 
 impl ExecutionPayload for BscExecutionData {
     fn parent_hash(&self) -> B256 {
-        self.0.header.parent_hash()
+        self.block.header.parent_hash()
     }
 
     fn block_hash(&self) -> B256 {
-        self.0.header.hash_slow()
+        self.block_hash_cached()
     }
 
     fn block_number(&self) -> u64 {
-        self.0.header.number()
+        self.block.header.number()
     }
 
     fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
@@ -82,11 +129,11 @@ impl ExecutionPayload for BscExecutionData {
     }
 
     fn timestamp(&self) -> u64 {
-        self.0.header.timestamp()
+        self.block.header.timestamp()
     }
 
     fn gas_used(&self) -> u64 {
-        self.0.header.gas_used()
+        self.block.header.gas_used()
     }
 
     fn transaction_count(&self) -> usize {
@@ -137,18 +184,17 @@ where
         &self,
         payload: BscExecutionData,
     ) -> Result<SealedBlock<BscBlock>, PayloadError> {
-        let block = payload.0;
-        let expected_hash = block.header.hash_slow();
-        let sealed_block = block.seal_slow();
-
-        // Ensure the hash included in the payload matches the block hash
-        if expected_hash != sealed_block.hash() {
-            return Err(PayloadError::BlockHash {
-                execution: sealed_block.hash(),
-                consensus: expected_hash,
-            })?
+        let header_hash = payload.block.header.hash_slow();
+        if let Some(cached_hash) = payload.hash.get() {
+            if *cached_hash != header_hash {
+                return Err(PayloadError::BlockHash {
+                    execution: header_hash,
+                    consensus: *cached_hash,
+                })?
+            }
         }
 
-        Ok(sealed_block)
+        let block = payload.into_block();
+        Ok(block.seal_unchecked(header_hash))
     }
 }

--- a/src/node/engine_api/validator.rs
+++ b/src/node/engine_api/validator.rs
@@ -137,7 +137,7 @@ impl ExecutionPayload for BscExecutionData {
     }
 
     fn transaction_count(&self) -> usize {
-        self.0.body.inner.transactions.len()
+        self.block.body.inner.transactions.len()
     }
 }
 

--- a/src/node/engine_api/validator.rs
+++ b/src/node/engine_api/validator.rs
@@ -66,7 +66,8 @@ impl BscExecutionData {
         Self { block, hash: OnceLock::new() }
     }
 
-    pub fn new_with_hash(block: BscBlock, hash: B256) -> Self {
+    /// Seeds the hash cache from a trusted sealed-block source.
+    pub(crate) fn new_with_hash(block: BscBlock, hash: B256) -> Self {
         let lock = OnceLock::new();
         let _ = lock.set(hash);
         Self { block, hash: lock }
@@ -74,6 +75,10 @@ impl BscExecutionData {
 
     pub fn block_hash_cached(&self) -> B256 {
         *self.hash.get_or_init(|| self.block.header.hash_slow())
+    }
+
+    pub(crate) fn cached_hash(&self) -> Option<B256> {
+        self.hash.get().copied()
     }
 
     pub fn into_block(self) -> BscBlock {
@@ -184,15 +189,24 @@ where
         &self,
         payload: BscExecutionData,
     ) -> Result<SealedBlock<BscBlock>, PayloadError> {
-        let header_hash = payload.block.header.hash_slow();
-        if let Some(cached_hash) = payload.hash.get() {
-            if *cached_hash != header_hash {
-                return Err(PayloadError::BlockHash {
-                    execution: header_hash,
-                    consensus: *cached_hash,
-                })?
+        let header_hash = if let Some(cached_hash) = payload.cached_hash() {
+            // Cached hashes are seeded only from trusted internal sealed-block producers.
+            // Keep a debug assertion here to catch any future misuse without paying the
+            // recomputation cost on the hot path in release builds.
+            #[cfg(debug_assertions)]
+            {
+                let computed_hash = payload.block.header.hash_slow();
+                if cached_hash != computed_hash {
+                    return Err(PayloadError::BlockHash {
+                        execution: computed_hash,
+                        consensus: cached_hash,
+                    })?
+                }
             }
-        }
+            cached_hash
+        } else {
+            payload.block.header.hash_slow()
+        };
 
         let block = payload.into_block();
         Ok(block.seal_unchecked(header_hash))

--- a/src/node/engine_api/validator_tests.rs
+++ b/src/node/engine_api/validator_tests.rs
@@ -2,15 +2,18 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::node::engine_api::payload::BscPayloadTypes;
     use crate::node::engine_api::validator::{BscEngineValidator, BscExecutionData};
     use crate::chainspec::bsc::bsc_mainnet;
     use crate::{BscBlock, BscBlockBody};
     use crate::chainspec::BscChainSpec;
     use alloy_consensus::Header;
     use alloy_primitives::{Address, B256, U256};
-    use std::sync::Arc;
     use reth_ethereum_primitives::BlockBody;
     use reth_engine_primitives::ExecutionPayload;
+    use reth_payload_primitives::PayloadTypes;
+    use reth_primitives_traits::Block;
+    use std::sync::Arc;
 
     /// Helper function to create a test block
     fn create_test_block(number: u64, parent_hash: B256) -> BscBlock {
@@ -59,6 +62,35 @@ mod tests {
         let expected_hash = block.header.hash_slow();
         let execution_data = BscExecutionData::new(block);
         
+        assert_eq!(execution_data.block_hash(), expected_hash);
+    }
+
+    #[test]
+    fn test_execution_data_new_with_hash_uses_seeded_hash() {
+        let block = create_test_block(1, B256::random());
+        let expected_hash = block.header.hash_slow();
+        let execution_data = BscExecutionData::new_with_hash(block, expected_hash);
+
+        assert_eq!(execution_data.block_hash(), expected_hash);
+    }
+
+    #[test]
+    fn test_execution_data_clone_preserves_seeded_hash() {
+        let block = create_test_block(1, B256::random());
+        let expected_hash = block.header.hash_slow();
+        let execution_data = BscExecutionData::new_with_hash(block, expected_hash);
+        let cloned = execution_data.clone();
+
+        assert_eq!(cloned.block_hash(), expected_hash);
+    }
+
+    #[test]
+    fn test_block_to_payload_preserves_known_hash() {
+        let block = create_test_block(1, B256::random());
+        let expected_hash = block.header.hash_slow();
+        let sealed_block = block.seal_unchecked(expected_hash);
+        let execution_data = BscPayloadTypes::block_to_payload(sealed_block);
+
         assert_eq!(execution_data.block_hash(), expected_hash);
     }
 

--- a/src/node/engine_api/validator_tests.rs
+++ b/src/node/engine_api/validator_tests.rs
@@ -47,7 +47,7 @@ mod tests {
     fn test_execution_data_parent_hash() {
         let parent_hash = B256::random();
         let block = create_test_block(1, parent_hash);
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         assert_eq!(execution_data.parent_hash(), parent_hash);
     }
@@ -57,7 +57,7 @@ mod tests {
         let parent_hash = B256::random();
         let block = create_test_block(1, parent_hash);
         let expected_hash = block.header.hash_slow();
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         assert_eq!(execution_data.block_hash(), expected_hash);
     }
@@ -66,7 +66,7 @@ mod tests {
     fn test_execution_data_block_number() {
         let block_number = 12345;
         let block = create_test_block(block_number, B256::random());
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         assert_eq!(execution_data.block_number(), block_number);
     }
@@ -75,7 +75,7 @@ mod tests {
     fn test_execution_data_timestamp() {
         let block = create_test_block(1, B256::random());
         let expected_timestamp = block.header.timestamp;
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         assert_eq!(execution_data.timestamp(), expected_timestamp);
     }
@@ -84,7 +84,7 @@ mod tests {
     fn test_execution_data_gas_used() {
         let mut block = create_test_block(1, B256::random());
         block.header.gas_used = 1_000_000;
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         assert_eq!(execution_data.gas_used(), 1_000_000);
     }
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn test_execution_data_withdrawals_none() {
         let block = create_test_block(1, B256::random());
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         // BSC doesn't support withdrawals
         assert!(execution_data.withdrawals().is_none());
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn test_execution_data_parent_beacon_block_root_none() {
         let block = create_test_block(1, B256::random());
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         // BSC doesn't use parent beacon block root
         assert!(execution_data.parent_beacon_block_root().is_none());
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_execution_data_serialization() {
         let block = create_test_block(1, B256::random());
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         // Test that BscExecutionData can be serialized
         let serialized = serde_json::to_string(&execution_data);
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_execution_data_deserialization() {
         let block = create_test_block(1, B256::random());
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         // Serialize and then deserialize
         let serialized = serde_json::to_string(&execution_data).unwrap();
@@ -154,7 +154,7 @@ mod tests {
     fn test_execution_data_with_zero_gas() {
         let mut block = create_test_block(1, B256::random());
         block.header.gas_used = 0;
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         assert_eq!(execution_data.gas_used(), 0);
     }
@@ -164,7 +164,7 @@ mod tests {
         let mut block = create_test_block(1, B256::random());
         let gas_limit = block.header.gas_limit;
         block.header.gas_used = gas_limit;
-        let execution_data = BscExecutionData(block);
+        let execution_data = BscExecutionData::new(block);
         
         assert_eq!(execution_data.gas_used(), gas_limit);
     }
@@ -179,7 +179,7 @@ mod tests {
         for difficulty in difficulties {
             let mut block = create_test_block(1, B256::random());
             block.header.difficulty = difficulty;
-            let execution_data = BscExecutionData(block);
+            let execution_data = BscExecutionData::new(block);
             
             assert_eq!(execution_data.block_number(), 1);
         }
@@ -197,7 +197,7 @@ mod tests {
         for timestamp in timestamps {
             let mut block = create_test_block(1, B256::random());
             block.header.timestamp = timestamp;
-            let execution_data = BscExecutionData(block);
+            let execution_data = BscExecutionData::new(block);
             
             assert_eq!(execution_data.timestamp(), timestamp);
         }

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -182,7 +182,7 @@ where
                 .unwrap()
                 .get_header_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get header from global header reader"))?;
-            let parent_header = SealedHeader::seal_slow(parent_header);
+            let parent_header = SealedHeader::new(parent_header, header.parent_hash);
             let parent_snap = snapshot_provider
                 .snapshot_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
@@ -312,7 +312,7 @@ where
                 .unwrap()
                 .get_header_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get header from global header reader"))?;
-            let parent_header = SealedHeader::seal_slow(parent_header);
+            let parent_header = SealedHeader::new(parent_header, header.parent_hash);
             let parent_snap = snapshot_provider
                 .snapshot_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -182,6 +182,7 @@ where
                 .unwrap()
                 .get_header_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get header from global header reader"))?;
+            let parent_header = SealedHeader::seal_slow(parent_header);
             let parent_snap = snapshot_provider
                 .snapshot_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
@@ -311,6 +312,7 @@ where
                 .unwrap()
                 .get_header_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get header from global header reader"))?;
+            let parent_header = SealedHeader::seal_slow(parent_header);
             let parent_snap = snapshot_provider
                 .snapshot_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use alloy_consensus::{transaction::SignerRecoverable, BlockHeader, Header, TxReceipt};
 use alloy_eips::eip7840::BlobParams;
-use alloy_primitives::{Address, Log, U256};
+use alloy_primitives::{Address, BlockHash, Log, U256};
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_evm::{
@@ -72,6 +72,8 @@ pub struct BscBlockExecutionCtx<'a> {
     pub base: EthBlockExecutionCtx<'a>,
     /// Block header (optional for BSC-specific logic).
     pub header: Option<Header>,
+    /// Block hash when known (sealed block), to avoid re-hashing.
+    pub header_hash: Option<BlockHash>,
     /// Whether the block is being mined.
     pub is_miner: bool,
 }
@@ -365,6 +367,7 @@ where
                 extra_data: block.header().extra_data.clone(),
             },
             header: Some(block.header().clone()),
+            header_hash: Some(block.hash()),
             is_miner: false,
         })
     }
@@ -385,6 +388,7 @@ where
                 extra_data: attributes.extra_data,
             },
             header: None, // No header available for next block context
+            header_hash: None,
             is_miner: true,
         })
     }
@@ -429,14 +433,14 @@ where
     Self: Send + Sync + Unpin + Clone + 'static,
 {
     fn evm_env_for_payload(&self, payload: &BscExecutionData) -> Result<EvmEnv<BscHardfork>, Self::Error> {
-        self.evm_env(&payload.0.header)
+        self.evm_env(&payload.block.header)
     }
 
     fn context_for_payload<'a>(
         &self,
         payload: &'a BscExecutionData,
     ) -> Result<BscBlockExecutionCtx<'a>, Self::Error> {
-        let block = &payload.0;
+        let block = &payload.block;
         Ok(BscBlockExecutionCtx {
             base: EthBlockExecutionCtx {
                 tx_count_hint: Some(block.body.inner.transactions.len()),
@@ -447,6 +451,7 @@ where
                 extra_data: block.header.extra_data.clone(),
             },
             header: Some(block.header.clone()),
+            header_hash: Some(payload.block_hash_cached()),
             is_miner: false,
         })
     }
@@ -455,7 +460,7 @@ where
         &self,
         payload: &BscExecutionData,
     ) -> Result<impl ExecutableTxIterator<Self>, Self::Error> {
-        let txs = payload.0.body.inner.transactions.clone();
+        let txs = payload.block.body.inner.transactions.clone();
         Ok((txs, |tx: TransactionSigned| tx.try_into_recovered()))
     }
 }

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -124,7 +124,10 @@ where
         
         trace!("Succeed to new block executor, header: {:?}", ctx.header);
         if let Some(ref header) = ctx.header {
-            crate::node::evm::util::HEADER_CACHE_READER.lock().unwrap().insert_header_to_cache(header.clone());
+            crate::node::evm::util::HEADER_CACHE_READER
+                .lock()
+                .unwrap()
+                .insert_header_to_cache_with_hash(header.clone(), ctx.header_hash);
         } else if !ctx.is_miner { // miner has no current header.
             warn!("No header found in the context, block_number: {:?}", evm.block().number().to::<u64>());
         }

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -69,8 +69,12 @@ impl HeaderCacheReader {
     }
 
     pub fn insert_header_to_cache(&mut self, header: Header) {
+        self.insert_header_to_cache_with_hash(header, None);
+    }
+
+    pub fn insert_header_to_cache_with_hash(&mut self, header: Header, block_hash: Option<BlockHash>) {
         let block_number = header.number();
-        let block_hash = header.hash_slow();
+        let block_hash = block_hash.unwrap_or_else(|| header.hash_slow());
         let header_clone_for_log = header.clone();
         self.blocknumber_to_header.insert(block_number, header.clone());
         self.blockhash_to_header.insert(block_hash, header);
@@ -100,4 +104,9 @@ pub fn get_cannonical_header_from_cache(number: BlockNumber) -> Option<Header> {
 /// Insert header to cache
 pub fn insert_header_to_cache(header: Header) {
     HEADER_CACHE_READER.lock().unwrap().insert_header_to_cache(header);
+}
+
+/// Insert header with a known hash to avoid re-hashing.
+pub fn insert_header_to_cache_with_hash(header: Header, block_hash: Option<BlockHash>) {
+    HEADER_CACHE_READER.lock().unwrap().insert_header_to_cache_with_hash(header, block_hash);
 }

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -169,8 +169,7 @@ where
         let parent_hash = bid.parent_hash;
         let parent_header = match self.client.header(parent_hash) {
             Ok(Some(header)) => {
-                let hash = header.hash_slow();
-                SealedHeader::new(header, hash)
+                SealedHeader::new(header, parent_hash)
             }
             _ => {
                 debug!("Failed to get parent header for hash: {:?}", parent_hash);
@@ -362,7 +361,7 @@ where
         let pay_bid_tx = txs_except_last.pop();
 
         let state_provider =
-            match self.client.state_by_block_hash(bid_runtime.parent_header.hash_slow()) {
+            match self.client.state_by_block_hash(bid_runtime.parent_header.hash()) {
                 Ok(provider) => provider,
                 Err(e) => {
                     debug!("Failed to get state provider by block hash: {:?}", e);

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -339,7 +339,8 @@ mod tests {
         let parent_snap =
             Snapshot::new(validators, 499, B256::random(), 500, Some(vote_addresses.clone()));
 
-        let resolved = resolve_epoch_validators(&parent_snap, &parent_header).unwrap();
+        let resolved =
+            resolve_epoch_validators(&parent_snap, &SealedHeader::seal_slow(parent_header)).unwrap();
 
         assert_eq!(resolved.0, parent_snap.validators);
         assert_eq!(resolved.1.len(), parent_snap.validators.len());
@@ -368,7 +369,8 @@ mod tests {
 
         let parent_snap =
             Snapshot::new(vec![Address::with_last_byte(1)], 799, B256::random(), 500, None);
-        let resolved = resolve_epoch_validators(&parent_snap, &parent_header).unwrap();
+        let resolved =
+            resolve_epoch_validators(&parent_snap, &SealedHeader::seal_slow(parent_header)).unwrap();
 
         assert_eq!(resolved.0, cached_validators);
         assert_eq!(resolved.1, cached_vote_addresses);
@@ -379,7 +381,9 @@ mod tests {
         let parent_header = unique_parent_header(999);
         let parent_snap = Snapshot::default();
 
-        let err = resolve_epoch_validators(&parent_snap, &parent_header).unwrap_err();
+        let err =
+            resolve_epoch_validators(&parent_snap, &SealedHeader::seal_slow(parent_header))
+                .unwrap_err();
         match err {
             SignerError::SigningFailed(msg) => {
                 assert!(msg.contains("Missing epoch validators"), "unexpected message: {}", msg);

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -12,22 +12,23 @@ use crate::hardforks::BscHardforks;
 use crate::node::evm::pre_execution::VALIDATOR_CACHE;
 use crate::node::miner::bsc_miner::MiningContext;
 use crate::node::miner::signer::{seal_header_with_global_signer, SignerError};
-use alloy_consensus::Header;
+use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::{Address, Bytes, B256};
 use reth::payload::EthPayloadBuilderAttributes;
 use reth_chainspec::EthChainSpec;
+use reth_primitives::SealedHeader;
 use std::sync::Arc;
 
 fn resolve_epoch_validators(
     parent_snap: &Snapshot,
-    parent_header: &Header,
+    parent_header: &SealedHeader,
 ) -> Result<(Vec<Address>, Vec<VoteAddress>), SignerError> {
-    let parent_hash = parent_header.hash_slow();
+    let parent_hash = parent_header.hash();
     let mut cache = VALIDATOR_CACHE.lock().unwrap();
     if let Some(cached_result) = cache.get(&parent_hash) {
         tracing::debug!(
             "Succeed to query cached validator result, block_number: {}, block_hash: {}",
-            parent_header.number,
+            parent_header.number(),
             parent_hash
         );
         return Ok(cached_result.clone());
@@ -36,7 +37,7 @@ fn resolve_epoch_validators(
     if parent_snap.validators.is_empty() {
         return Err(SignerError::SigningFailed(format!(
             "Missing epoch validators for parent block {} ({})",
-            parent_header.number, parent_hash
+            parent_header.number(), parent_hash
         )));
     }
 
@@ -54,7 +55,7 @@ fn resolve_epoch_validators(
 
     tracing::warn!(
         target: "bsc::miner",
-        block_number = parent_header.number,
+        block_number = parent_header.number(),
         block_hash = %parent_hash,
         "Validator cache miss on epoch boundary, falling back to parent snapshot validators"
     );
@@ -65,11 +66,11 @@ fn resolve_epoch_validators(
 pub fn prepare_new_attributes(
     ctx: &mut MiningContext,
     parlia: Arc<Parlia<BscChainSpec>>,
-    parent_header: &Header,
+    parent_header: &SealedHeader,
     signer: Address,
 ) -> EthPayloadBuilderAttributes {
     let mut new_header = prepare_new_header(parlia.clone(), parent_header, signer);
-    parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header, &mut new_header);
+    parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header.header(), &mut new_header);
     let mut attributes = EthPayloadBuilderAttributes {
         parent: new_header.parent_hash,
         timestamp: new_header.timestamp,
@@ -91,19 +92,19 @@ pub fn prepare_new_attributes(
 /// prepare a tmp new header for preparing attributes.
 pub fn prepare_new_header<ChainSpec>(
     parlia: Arc<Parlia<ChainSpec>>,
-    parent_header: &Header,
+    parent_header: &SealedHeader,
     signer: Address,
 ) -> Header
 where
     ChainSpec: EthChainSpec + BscHardforks + 'static,
 {
     let mut timestamp = parlia.present_millis_timestamp() / 1000;
-    if parent_header.timestamp >= timestamp {
-        timestamp = parent_header.timestamp + 1;
+    if parent_header.timestamp() >= timestamp {
+        timestamp = parent_header.timestamp() + 1;
     }
     let mut new_header = Header {
-        number: parent_header.number + 1,
-        parent_hash: parent_header.hash_slow(),
+        number: parent_header.number() + 1,
+        parent_hash: parent_header.hash(),
         beneficiary: signer,
         // Set timestamp to present time (or parent + 1 if present time is not greater)
         // This avoids header.timestamp = 0 when back_off_time is called inside prepare_timestamp
@@ -120,7 +121,7 @@ where
             parlia.spec.as_ref(),
             new_header.number,
             new_header.timestamp,
-            parent_header,
+            parent_header.header(),
             blob_params,
         );
     }
@@ -132,7 +133,7 @@ where
 pub fn finalize_new_header<ChainSpec>(
     parlia: Arc<Parlia<ChainSpec>>,
     parent_snap: &Snapshot,
-    parent_header: &Header,
+    parent_header: &SealedHeader,
     new_header: &mut Header,
     snapshot_provider: &Arc<dyn SnapshotProvider + Send + Sync>,
 ) -> Result<(), crate::node::miner::signer::SignerError>
@@ -168,7 +169,7 @@ where
         .map_err(|e| SignerError::SigningFailed(format!("Failed to prepare turn length: {}", e)))?;
 
     if let Err(e) =
-        parlia.assemble_vote_attestation(parent_snap, parent_header, new_header, snapshot_provider)
+        parlia.assemble_vote_attestation(parent_snap, parent_header.header(), new_header, snapshot_provider)
     {
         tracing::warn!(
             target: "bsc::miner",

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -4,7 +4,7 @@ use crate::{
     consensus::{parlia::vote_pool, ParliaConsensusErr},
     node::{
         consensus::BscForkChoiceEngine, engine::BscBuiltPayload,
-        engine_api::payload::BscPayloadTypes, evm::util::insert_header_to_cache,
+        engine_api::payload::BscPayloadTypes, evm::util::insert_header_to_cache_with_hash,
         network::BscNewBlock,
     },
     BscBlock, BscBlockBody,
@@ -139,7 +139,8 @@ where
         let engine = self.engine.clone();
         let forkchoice_engine = self.forkchoice_engine.clone();
 
-        tracing::debug!(target: "bsc::block_import", "New payload: block = ({:?}, {:?}), peer_id = {:?}", block.block.0.block.header.number, block.block.0.block.header.hash_slow(), peer_id);
+        let block_hash = block.block.0.block.header.hash_slow();
+        tracing::debug!(target: "bsc::block_import", "New payload: block = ({:?}, {:?}), peer_id = {:?}", block.block.0.block.header.number, block_hash, peer_id);
         Box::pin(async move {
             let sealed_block = block.block.0.block.clone().seal();
             let header = sealed_block.header().clone();
@@ -152,7 +153,7 @@ where
                         if let Err(e) = forkchoice_engine.update_forkchoice(&header).await {
                             tracing::warn!(target: "bsc::block_import", "Failed to update fork choice: {}", e);
                         } else {
-                            tracing::debug!(target: "bsc::block_import", "Succeed to update fork choice for new payload: number = {:?}, hash = {:?}", header.number, header.hash_slow());
+                            tracing::debug!(target: "bsc::block_import", "Succeed to update fork choice for new payload: number = {:?}, hash = {:?}", header.number, block_hash);
                         }
                         Outcome { peer: peer_id, result: Ok(BlockValidation::ValidBlock { block }) }
                             .into()
@@ -167,7 +168,6 @@ where
                         // to avoid the engine-tree being stuck in syncing state without any driver.
                         // By calling FCU, we inform the engine about the new head block hash,
                         // which can help trigger additional sync/download activities in the engine-tree.
-                        let block_hash = header.hash_slow();
                         let block_number = header.number;
                         tracing::debug!(
                             target: "bsc::block_import",
@@ -226,7 +226,7 @@ where
     ) {
         let block = &block_msg.block.0.block;
         // insert header to cache
-        insert_header_to_cache(block.header.clone());
+        insert_header_to_cache_with_hash(block.header.clone(), Some(block_msg.hash));
         // Cache the full block body for later range responses.
         crate::shared::cache_full_block(block.clone());
         let block_hash = block_msg.hash;
@@ -260,11 +260,11 @@ where
         {
             let forkchoice_engine = self.forkchoice_engine.clone();
             tokio::spawn(async move {
-                tracing::debug!(target: "bsc::block_import", "Updating fork choice for mined block: number = {:?}, hash = {:?}", header_for_fcu.number, header_for_fcu.hash_slow());
+                tracing::debug!(target: "bsc::block_import", "Updating fork choice for mined block: number = {:?}, hash = {:?}", header_for_fcu.number, block_hash);
                 if let Err(e) = forkchoice_engine.update_forkchoice(&header_for_fcu).await {
-                    tracing::warn!(target: "bsc::block_import", "Failed to update fork choice for mined block: number = {:?}, hash = {:?}, error = {}", header_for_fcu.number, header_for_fcu.hash_slow(), e);
+                    tracing::warn!(target: "bsc::block_import", "Failed to update fork choice for mined block: number = {:?}, hash = {:?}, error = {}", header_for_fcu.number, block_hash, e);
                 } else {
-                    tracing::debug!(target: "bsc::block_import", "Succeed to update fork choice for mined block: number = {:?}, hash = {:?}", header_for_fcu.number, header_for_fcu.hash_slow());
+                    tracing::debug!(target: "bsc::block_import", "Succeed to update fork choice for mined block: number = {:?}, hash = {:?}", header_for_fcu.number, block_hash);
                 }
             });
         }

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -139,10 +139,32 @@ where
         let engine = self.engine.clone();
         let forkchoice_engine = self.forkchoice_engine.clone();
 
+        let announced_hash = block.hash;
         let block_hash = block.block.0.block.header.hash_slow();
         tracing::debug!(target: "bsc::block_import", "New payload: block = ({:?}, {:?}), peer_id = {:?}", block.block.0.block.header.number, block_hash, peer_id);
         Box::pin(async move {
-            let sealed_block = block.block.0.block.clone().seal();
+            if announced_hash != block_hash {
+                tracing::warn!(
+                    target: "bsc::block_import",
+                    number = block.block.0.block.header.number,
+                    announced_hash = %announced_hash,
+                    computed_hash = %block_hash,
+                    peer_id = %peer_id,
+                    "Rejecting new payload with mismatched announced hash"
+                );
+                return Outcome {
+                    peer: peer_id,
+                    result: Err(BlockImportError::Other(
+                        std::io::Error::other(format!(
+                            "announced block hash {announced_hash} does not match computed header hash {block_hash}"
+                        ))
+                        .into(),
+                    )),
+                }
+                .into()
+            }
+
+            let sealed_block = block.block.0.block.clone().seal_unchecked(block_hash);
             let header = sealed_block.header().clone();
             let payload = BscPayloadTypes::block_to_payload(sealed_block);
             match engine.new_payload(payload).await {
@@ -235,7 +257,7 @@ where
 
         // send to EVN peers first
         if let Err(e) = self.transfer_to_evn_peers(block_msg.clone()) {
-            tracing::warn!(target: "bsc::block_import", "Failed to transfer block to EVN peers: number = {:?}, hash = {:?}, error = {}", block.header.number, block.header.hash_slow(), e);
+            tracing::warn!(target: "bsc::block_import", "Failed to transfer block to EVN peers: number = {:?}, hash = {:?}, error = {}", block.header.number, block_hash, e);
         }
         // Send ValidHeader announcement to trigger NewBlock diffusion from few peers
         let _ =
@@ -520,6 +542,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_new_payload_with_mismatched_announced_hash() {
+        let mut fixture = TestFixture::new(EngineResponses::both_valid()).await;
+        let mut block_msg = create_test_block();
+        block_msg.hash = B256::random();
+
+        fixture
+            .assert_block_import_with_block(block_msg, |outcome| {
+                matches!(
+                    outcome,
+                    BlockImportEvent::Outcome(BlockImportOutcome {
+                        peer: _,
+                        result: Err(BlockImportError::Other(_))
+                    })
+                )
+            })
+            .await;
+    }
+
+    #[tokio::test]
     async fn deduplicates_blocks() {
         let mut fixture = TestFixture::new(EngineResponses::both_valid()).await;
 
@@ -776,6 +817,16 @@ mod tests {
             F: Fn(&BlockImportEvent<BscNewBlock>) -> bool,
         {
             let block_msg = create_test_block();
+            self.assert_block_import_with_block(block_msg, assert_fn).await;
+        }
+
+        async fn assert_block_import_with_block<F>(
+            &mut self,
+            block_msg: NewBlockMessage<BscNewBlock>,
+            assert_fn: F,
+        ) where
+            F: Fn(&BlockImportEvent<BscNewBlock>) -> bool,
+        {
             self.handle.send_block(block_msg, PeerId::random()).unwrap();
 
             let waker = futures::task::noop_waker();


### PR DESCRIPTION
Added cached vote counts and hash caching across engine/miner/EVM paths to avoid repeated hashing/cloning; refactored BscExecutionData and updated validator tests.