### PR TITLE
chore: some script/metrics fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: ## Build the reth binary into `target` directory.
 
 .PHONY: maxperf
 maxperf: ## Builds `reth-bsc` with the most aggressive optimisations.
-	RUSTFLAGS="-C target-cpu=native" cargo build --bin reth-bsc --profile maxperf --features jemalloc,asm-keccak,io-uring
+	RUSTFLAGS="-C target-cpu=native" cargo build --bin reth-bsc --profile maxperf --features jemalloc,asm-keccak
 
 .PHONY: bench-test
 bench-test: ## Builds `reth-bsc` with the bench-test feature.

--- a/src/node/miner/bsc_miner.rs
+++ b/src/node/miner/bsc_miner.rs
@@ -1082,6 +1082,7 @@ where
         MINER_METRICS
             .block_trie_root_duration_seconds
             .record(payload.trie_root_duration.as_secs_f64());
+        MINER_METRICS.blocks_produced_total.increment(1);
 
         let gas_used_mgas = sealed_block.gas_used() as f64 / 1_000_000.0;
         MINER_METRICS.best_work_gas_used_mgas.set(gas_used_mgas);

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -740,7 +740,6 @@ where
         let finalize_elapsed = finalize_start.elapsed();
         let finalize_duration = finalize_elapsed.as_secs_f64();
         MINER_METRICS.block_finalize_duration_seconds.record(finalize_duration);
-        MINER_METRICS.blocks_produced_total.increment(1);
 
         // set sidecars to seal block
         let mut blob_sidecars: Vec<BscBlobTransactionSidecar> = Vec::new();
@@ -924,7 +923,6 @@ where
         // Update miner metrics
         let finalize_duration = finalize_start.elapsed().as_secs_f64();
         MINER_METRICS.block_finalize_duration_seconds.record(finalize_duration);
-        MINER_METRICS.blocks_produced_total.increment(1);
 
         let build_duration = build_start.elapsed();
 


### PR DESCRIPTION
### Description

Fix `blocks_produced_total` metric placement and remove unused `io-uring` build feature.

### Rationale

`blocks_produced_total` was previously incremented on every successful build candidate,
leading to over-counting — internal rebuild retries and out-of-turn block attempts were
all counted, not just blocks actually submitted to the network.

### Changes

* **fix**: move `blocks_produced_total.increment(1)` from `build_payload` /
  `build_empty_payload` into `submit_payload`, after stale/reorg/double-sign guards
* **chore**: remove `io-uring` from `maxperf` build features in `Makefile`

### Potential Impacts

* `blocks_produced_total` counter value will be lower and more accurate going
  forward — only blocks actually submitted to the network are counted.