### PR TITLE
fix: eth_getLogs RPC filters system tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e56cae3909bcb2347f77c0f318ef5eb7e131ea6d0a94d31f8bfb6e4c5e3c7c7"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4394690a8a64757316c57c57f2c663bf8395febb4c4baa049a058ebd122b668"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b97433ffdb356d11b6c89b08c69a787b9f55d787cdeee733c12fdf85d465ef1"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6173ced325833e40ccb781bb372c720df638a966bad6ed6733682b6bff63d855"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae95062f48461967424eecb1e1ab703e493b6a7aca7f9c327cc1c06758eb6ec2"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464d9c2c5bca3ff3f020f2ab502629043486a1b3645c5c11613c1dade4eb6f5e"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2158d382ef9743ae7185c9fcd33cd9a99967419fdcd5eebc83ff7c0e79cad2bc"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b08405e82effb4985f7cbe83d5067730e79893c8699793c1e113043ffeac9d"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f39b713fb8fd7abb6ee7601d467f71d2c2541b7799dd02d3a8f9f650d1d3f6d"
+checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96846729dd095dd5a87bf5bd8efea2345ca41ceab6dda212c49f5c8ca6e2a536"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f20059ff046049aae59f6e19d96462214ad3290cf9920394309dd7ffc284390"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3468c7d973491c4c02a373a29273cb747aa4a99cf2e54a6178b564d97462db50"
+checksum = "b38080c2b01ad1bacbd3583cf7f6f800e5e0ffc11eaddaad7321225733a2d818"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aca954ee74bb38b24399da5bd861a2511fb76d40cca7ae700d2289ff96fb90"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b71da7e5cdd0d5ffebc459f5987888fd3380969c2f94f8cb652ad91ae51bba"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3569433bc2cddd4f00b1dd533a38a07512b55e62d11f662fde20930b613b57"
+checksum = "f526dbd7bb039327cfd0ccf18c8a29ffd7402616b0c7a0239512bf8417d544c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d9d9a32059dff4809fe4db016db13ba1a20babf767c4cd26e97c93ee9efe4c"
+checksum = "2145138f3214928f08cd13da3cb51ef7482b5920d8ac5a02ecd4e38d1a8f6d1e"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f083328dbf7aa5abfe5c0a7758ec9acc86a45bfbcfb45c54186c6caa78036f2a"
+checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1641df7ef4d15cd43843d399252c90a95abf465a67e2a2b2fd76f4e93cc60e15"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b6ca72affc6669e0a456af7d3c15d6b2edf75797d7906bc3900a8b1e094348"
+checksum = "8eae9c65ff60dcc262247b6ebb5ad391ddf36d09029802c1768c5723e0cfa2f4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00e2d5ab1f7310c7ecd69962af8c99d2557335ff8cf1baf39c8ff6eec9c171d"
+checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154695f4a24dd749368fd46a4bdac1ec806b4376abc40112e3028018fee5b593"
+checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1c2c0b5f024814f1c04ae76ff71862d06c836e7d67102daf8a557e5056be68"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f59de30d9d3b13ce6a1b90e85270dc086e4e4733aaa12b250fb30e1eb35849"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e64733ea58cfb393c901047638e9ff6890c0a45dc5855bfa077f8bace0f9f9"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9c680a7ee0879aa27ea2e347f14e3a973a262e4325964fa1ab062b8a796064"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -829,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9abaedb9123ebe4b1527bc88a0409d65b2727c3de89a289284ba91ad70ae99"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74911eda4fd7ef12f446b1661f11787f9fb31bde4ab4a0a68efcac9b98cfdf"
+checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130762ef3e6c0fb7dc1b855d4f359eb8ea6f2df2f800f40aa52d27737bf640f1"
+checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -904,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3684226a2220bb6e84a5ab74877e66628882336ecfba97482c9d473aa2b1cc"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1477,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1762,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc119a5ad34c3f459062a96907f53358989b173d104258891bb74f95d93747e8"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
  "bitflags 2.11.0",
  "boa_interner",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "boa_engine"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e637ec52ea66d76b0ca86180c259d6c7bb6e6a6e14b2f36b85099306d8b00cc3"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1179f690cbfcbe5364cceee5f1cb577265bb6f07b0be6f210aabe270adcf9da"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
 dependencies = [
  "boa_macros",
  "boa_string",
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "boa_interner"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9626505d33dc63d349662437297df1d3afd9d5fc4a2b3ad34e5e1ce879a78848"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
 dependencies = [
  "boa_gc",
  "boa_macros",
@@ -1857,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36418a46544b152632c141b0a0b7a453cd69ca150caeef83aee9e2f4b48b7d"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
 dependencies = [
  "cfg-if",
  "cow-utils",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f99bf5b684f0de946378fcfe5f38c3a0fbd51cbf83a0f39ff773a0e218541f"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
  "bitflags 2.11.0",
  "boa_ast",
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ce9d7aa5563a2e14eab111e2ae1a06a69a812f6c0c3d843196c9d03fbef440"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
 dependencies = [
  "fast-float2",
  "itoa",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -4877,9 +4877,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -5007,10 +5007,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -5654,9 +5656,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -7419,7 +7421,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7465,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7489,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7521,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7541,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7555,7 +7557,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7641,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7651,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7669,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7689,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7699,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7715,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7728,7 +7730,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7740,7 +7742,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7766,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7792,7 +7794,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7820,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7854,7 +7856,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7869,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7894,7 +7896,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7918,7 +7920,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7942,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7977,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8005,7 +8007,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8028,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8053,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "futures",
  "pin-project",
@@ -8076,7 +8078,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8139,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8167,7 +8169,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8182,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8198,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8220,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8231,7 +8233,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8260,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8284,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "clap",
  "eyre",
@@ -8306,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8322,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8340,7 +8342,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8354,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8383,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8403,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8413,7 +8415,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8438,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8460,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8473,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8491,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8529,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8543,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "serde",
  "serde_json",
@@ -8553,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8581,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8601,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8617,7 +8619,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8626,7 +8628,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "futures",
  "metrics",
@@ -8650,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8659,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8673,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8729,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8754,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8777,7 +8779,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8792,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8806,7 +8808,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8823,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8847,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8917,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8973,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9011,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9035,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9059,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9083,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9095,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9131,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9143,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9166,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9176,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9190,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9223,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9295,7 +9297,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9310,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9329,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9356,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9369,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9452,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9482,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9523,7 +9525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9545,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9575,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9621,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9669,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -9683,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9699,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9751,7 +9753,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9778,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9792,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9812,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9825,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9849,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9866,7 +9868,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9884,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9900,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9910,7 +9912,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "clap",
  "eyre",
@@ -9925,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "clap",
  "eyre",
@@ -9943,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9984,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10010,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10039,7 +10041,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10060,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10085,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10104,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10122,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#798291c9041a5401ef8b94cb3ce6c41cf3e86d3c"
 dependencies = [
  "zstd",
 ]
@@ -10712,9 +10714,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -11979,7 +11981,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -12833,9 +12834,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12846,23 +12847,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12870,9 +12867,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12883,9 +12880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -12953,9 +12950,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13718,18 +13715,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,23 +1975,23 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "rayon",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
+ "reth-ethereum-consensus",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-tracing",
+ "reth-trie",
+ "reth-trie-db",
  "reth_bsc",
  "revm",
  "serde",
@@ -7419,22 +7419,22 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
  "clap",
  "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-db",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-evm",
  "reth-network",
  "reth-network-api",
  "reth-node-api",
@@ -7443,12 +7443,12 @@ dependencies = [
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-provider",
  "reth-ress-protocol",
  "reth-ress-provider",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7473,14 +7473,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "metrics",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-storage-api",
  "reth-tasks",
  "tokio",
  "tracing",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7501,45 +7501,14 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm-database",
- "revm-state",
- "rust-eth-triedb-common",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-chain-state"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
- "derive_more 2.1.1",
- "metrics",
- "parking_lot",
- "pin-project",
- "rand 0.9.2",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-trie",
  "revm-database",
  "revm-state",
  "rust-eth-triedb-common",
@@ -7552,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7563,42 +7532,22 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "derive_more 2.1.1",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde_json",
-]
-
-[[package]]
-name = "reth-chainspec"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "auto_impl",
- "derive_more 2.1.1",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-primitives-traits",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-genesis",
  "clap",
  "eyre",
  "reth-cli-runner",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db",
  "serde_json",
  "shellexpand",
 ]
@@ -7606,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7630,16 +7579,16 @@ dependencies = [
  "proptest-arbitrary-interop",
  "ratatui",
  "reqwest 0.12.28",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
  "reth-discv4",
  "reth-discv5",
  "reth-downloaders",
@@ -7648,34 +7597,34 @@ dependencies = [
  "reth-era-downloader",
  "reth-era-utils",
  "reth-eth-wire",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-etl",
+ "reth-evm",
  "reth-exex",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util",
+ "reth-libmdbx",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-provider",
  "reth-prune",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types",
+ "reth-revm",
  "reth-stages",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types",
  "reth-static-file",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types",
  "reth-tasks",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
  "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde",
@@ -7692,7 +7641,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7702,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7710,7 +7659,7 @@ dependencies = [
  "eyre",
  "libc",
  "rand 0.8.5",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
@@ -7720,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7731,28 +7680,8 @@ dependencies = [
  "bytes 1.11.1",
  "modular-bitfield",
  "op-alloy-consensus",
- "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "visibility",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "arbitrary",
- "bytes 1.11.1",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs-derive",
+ "reth-zstd-compressors",
  "serde",
  "visibility",
 ]
@@ -7760,17 +7689,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7780,27 +7699,14 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "eyre",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "url",
-]
-
-[[package]]
-name = "reth-config"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "eyre",
  "humantime-serde",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-types",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
  "serde",
  "toml 0.8.23",
  "url",
@@ -7809,57 +7715,32 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-consensus"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "auto_impl",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types",
+ "reth-primitives-traits",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
-]
-
-[[package]]
-name = "reth-consensus-common"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7874,8 +7755,8 @@ dependencies = [
  "futures",
  "reqwest 0.12.28",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-tracing",
  "ringbuffer",
  "serde",
  "serde_json",
@@ -7885,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7893,40 +7774,14 @@ dependencies = [
  "metrics",
  "page_size",
  "parking_lot",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "rustc-hash",
- "strum 0.27.2",
- "sysinfo",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-db"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "eyre",
- "metrics",
- "page_size",
- "parking_lot",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api",
+ "reth-fs-util",
+ "reth-libmdbx",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-nippy-jar",
+ "reth-static-file-types",
+ "reth-storage-errors",
+ "reth-tracing",
  "rustc-hash",
  "strum 0.27.2",
  "sysinfo",
@@ -7937,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7949,43 +7804,15 @@ dependencies = [
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-optimism-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "roaring",
- "serde",
-]
-
-[[package]]
-name = "reth-db-api"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-genesis",
- "alloy-primitives",
- "arbitrary",
- "bytes 1.11.1",
- "derive_more 2.1.1",
- "metrics",
- "modular-bitfield",
- "parity-scale-codec",
- "proptest",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-optimism-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
+ "reth-db-models",
+ "reth-ethereum-primitives",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
  "roaring",
  "serde",
 ]
@@ -7993,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8001,54 +7828,20 @@ dependencies = [
  "alloy-trie",
  "boyer-moore-magiclen",
  "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-state-trie",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "reth-db-common"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "boyer-moore-magiclen",
- "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-config",
+ "reth-db-api",
+ "reth-etl",
+ "reth-execution-errors",
+ "reth-fs-util",
+ "reth-node-types",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-stages-types",
+ "reth-static-file-types",
+ "reth-trie",
+ "reth-trie-db",
  "rust-eth-triedb",
  "rust-eth-triedb-common",
  "rust-eth-triedb-state-trie",
@@ -8061,37 +7854,22 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bytes 1.11.1",
  "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
-]
-
-[[package]]
-name = "reth-db-models"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "arbitrary",
- "bytes 1.11.1",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
+ "reth-primitives-traits",
  "serde",
 ]
 
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8100,10 +7878,10 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "rand 0.8.5",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks",
+ "reth-net-banlist",
  "reth-net-nat",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8116,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8127,10 +7905,10 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rand 0.9.2",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-ethereum-forks",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
  "tokio",
@@ -8140,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8148,8 +7926,8 @@ dependencies = [
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks",
+ "reth-network-peers",
  "reth-tokio-util",
  "schnellru",
  "secp256k1 0.30.0",
@@ -8164,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8177,15 +7955,15 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config",
+ "reth-consensus",
+ "reth-ethereum-primitives",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-storage-api",
  "reth-tasks",
  "reth-testing-utils",
  "tempfile",
@@ -8199,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8214,7 +7992,7 @@ dependencies = [
  "hmac",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -8227,20 +8005,20 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-ethereum-engine-primitives",
  "reth-payload-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
@@ -8250,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8258,40 +8036,15 @@ dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
  "futures",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "reth-engine-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "futures",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -8300,30 +8053,30 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "futures",
  "pin-project",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-engine-primitives",
  "reth-engine-tree",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-evm",
  "reth-network-p2p",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-node-types",
  "reth-payload-builder",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider",
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8341,34 +8094,34 @@ dependencies = [
  "moka",
  "parking_lot",
  "rayon",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-db",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-execution-types",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
  "reth-payload-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
  "reth-prune",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types",
+ "reth-revm",
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
  "reth-tasks",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing",
+ "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
  "reth-trie-parallel",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-sparse",
  "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
@@ -8386,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8394,16 +8147,16 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "pin-project",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-engine-primitives",
  "reth-engine-tree",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors",
+ "reth-evm",
+ "reth-fs-util",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-storage-api",
  "serde",
  "serde_json",
  "tokio",
@@ -8414,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8429,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8437,7 +8190,7 @@ dependencies = [
  "futures-util",
  "reqwest 0.12.28",
  "reth-era",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util",
  "sha2 0.10.9",
  "tokio",
 ]
@@ -8445,21 +8198,21 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "eyre",
  "futures-util",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api",
  "reth-era",
  "reth-era-downloader",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-etl",
+ "reth-fs-util",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-stages-types",
+ "reth-storage-api",
  "tokio",
  "tracing",
 ]
@@ -8467,29 +8220,18 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-errors"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-storage-errors",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8499,13 +8241,13 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "pin-project",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
+ "reth-primitives-traits",
  "serde",
  "snap",
  "thiserror 2.0.18",
@@ -8518,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8531,10 +8273,10 @@ dependencies = [
  "derive_more 2.1.1",
  "proptest",
  "proptest-arbitrary-interop",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-codecs-derive",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -8542,88 +8284,54 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "clap",
  "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-rpc-server-types",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "tracing",
-]
-
-[[package]]
-name = "reth-ethereum-consensus"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-execution-types",
+ "reth-primitives-traits",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "sha2 0.10.9",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-ethereum-engine-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives",
+ "reth-ethereum-primitives",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -8632,20 +8340,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
- "rustc-hash",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8659,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8667,19 +8362,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-consensus-common",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
  "reth-payload-validator",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-storage-api",
  "reth-transaction-pool",
  "revm",
  "tracing",
@@ -8688,7 +8383,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8698,29 +8393,9 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "arbitrary",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "reth-zstd-compressors",
  "serde",
  "serde_with",
 ]
@@ -8728,50 +8403,17 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "rayon",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "tempfile",
-]
-
-[[package]]
-name = "reth-etl"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "rayon",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api",
  "tempfile",
 ]
 
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "auto_impl",
- "derive_more 2.1.1",
- "futures-util",
- "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm",
- "rust-eth-triedb-common",
-]
-
-[[package]]
-name = "reth-evm"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8782,13 +8424,13 @@ dependencies = [
  "futures-util",
  "metrics",
  "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors",
+ "reth-execution-types",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie-common",
  "revm",
  "rust-eth-triedb-common",
 ]
@@ -8796,28 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "derive_more 2.1.1",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm",
-]
-
-[[package]]
-name = "reth-evm-ethereum"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8826,73 +8447,42 @@ dependencies = [
  "alloy-rpc-types-engine",
  "derive_more 2.1.1",
  "parking_lot",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-storage-errors",
  "revm",
 ]
 
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-execution-errors"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-evm",
- "alloy-primitives",
- "alloy-rlp",
- "nybbles",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "derive_more 2.1.1",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-execution-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "derive_more 2.1.1",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "revm",
  "serde",
  "serde_with",
@@ -8901,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8911,24 +8501,24 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-config",
+ "reth-ethereum-primitives",
+ "reth-evm",
  "reth-exex-types",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-revm",
  "reth-stages-api",
  "reth-tasks",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing",
  "rmp-serde",
  "thiserror 2.0.18",
  "tokio",
@@ -8939,13 +8529,13 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-execution-types",
+ "reth-primitives-traits",
  "serde",
  "serde_with",
 ]
@@ -8953,17 +8543,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-fs-util"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "serde",
  "serde_json",
@@ -8973,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8983,14 +8563,14 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "pretty_assertions",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
  "reth-rpc-api",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing",
+ "reth-trie",
  "revm",
  "revm-bytecode",
  "revm-database",
@@ -9001,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -9021,30 +8601,14 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "dashmap 6.1.0",
  "derive_more 2.1.1",
  "parking_lot",
- "reth-mdbx-sys 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "reth-libmdbx"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "bitflags 2.11.0",
- "byteorder",
- "dashmap 6.1.0",
- "derive_more 2.1.1",
- "parking_lot",
- "reth-mdbx-sys 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-mdbx-sys",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
@@ -9053,16 +8617,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "bindgen 0.71.1",
- "cc",
-]
-
-[[package]]
-name = "reth-mdbx-sys"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9071,16 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "metrics",
- "metrics-derive",
-]
-
-[[package]]
-name = "reth-metrics"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "futures",
  "metrics",
@@ -9104,16 +8650,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-primitives",
- "ipnet",
-]
-
-[[package]]
-name = "reth-net-banlist"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9122,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9136,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9155,25 +8692,25 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-consensus",
  "reth-discv4",
  "reth-discv5",
  "reth-dns-discovery",
  "reth-ecies",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
+ "reth-fs-util",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-primitives-traits",
+ "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9192,7 +8729,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9203,10 +8740,10 @@ dependencies = [
  "enr",
  "futures",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
+ "reth-network-types",
  "reth-tokio-util",
  "serde",
  "thiserror 2.0.18",
@@ -9217,7 +8754,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9226,13 +8763,13 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "parking_lot",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus",
  "reth-eth-wire-types",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-primitives-traits",
+ "reth-storage-errors",
  "tokio",
  "tracing",
 ]
@@ -9240,20 +8777,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "secp256k1 0.30.0",
- "serde_with",
- "thiserror 2.0.18",
- "url",
-]
-
-[[package]]
-name = "reth-network-peers"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9268,24 +8792,12 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-eip2124",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde_json",
- "tracing",
-]
-
-[[package]]
-name = "reth-network-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-net-banlist",
+ "reth-network-peers",
  "serde",
  "serde_json",
  "tracing",
@@ -9294,31 +8806,14 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "anyhow",
  "bincode",
  "derive_more 2.1.1",
  "lz4_flex",
  "memmap2",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "thiserror 2.0.18",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "reth-nippy-jar"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "anyhow",
- "bincode",
- "derive_more 2.1.1",
- "lz4_flex",
- "memmap2",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -9328,22 +8823,22 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "reth-basic-payload-builder",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-evm",
  "reth-network-api",
  "reth-node-core",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-node-types",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-provider",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9352,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9368,23 +8863,23 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-config",
+ "reth-consensus",
  "reth-consensus-debug-client",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
  "reth-downloaders",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives",
  "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm",
  "reth-exex",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util",
  "reth-invalid-block-hooks",
  "reth-network",
  "reth-network-api",
@@ -9395,8 +8890,8 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-provider",
  "reth-prune",
  "reth-rpc",
  "reth-rpc-api",
@@ -9408,9 +8903,9 @@ dependencies = [
  "reth-static-file",
  "reth-tasks",
  "reth-tokio-util",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db",
  "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde_json",
@@ -9422,7 +8917,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9436,32 +8931,32 @@ dependencies = [
  "humantime",
  "ipnet",
  "rand 0.9.2",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
  "reth-cli-util",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
  "reth-discv4",
  "reth-discv5",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives",
+ "reth-ethereum-forks",
+ "reth-net-banlist",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune-types",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-tracing",
+ "reth-tracing-otlp",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
@@ -9478,36 +8973,36 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "eyre",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives",
+ "reth-ethereum-consensus",
+ "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing",
  "reth-transaction-pool",
  "revm",
  "tokio",
@@ -9516,16 +9011,16 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "chrono",
  "futures-util",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
  "reth-network-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-storage-api",
  "reth-transaction-pool",
  "serde",
  "serde_json",
@@ -9540,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9550,13 +9045,13 @@ dependencies = [
  "futures",
  "humantime",
  "pin-project",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives",
  "reth-network-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-prune-types",
  "reth-stages",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types",
+ "reth-storage-api",
  "tokio",
  "tracing",
 ]
@@ -9564,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9588,53 +9083,26 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
-]
-
-[[package]]
-name = "reth-node-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "op-alloy-consensus",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-optimism-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "op-alloy-consensus",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
  "serde",
  "serde_with",
 ]
@@ -9642,19 +9110,19 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-ethereum-engine-primitives",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9663,22 +9131,10 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "pin-project",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-payload-builder-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "pin-project",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9687,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9696,35 +9152,12 @@ dependencies = [
  "auto_impl",
  "either",
  "op-alloy-rpc-types-engine",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "reth-payload-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "either",
- "op-alloy-rpc-types-engine",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -9733,77 +9166,31 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
  "once_cell",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "c-kzg",
- "once_cell",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-static-file-types",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "arbitrary",
- "auto_impl",
- "byteorder",
- "bytes 1.11.1",
- "derive_more 2.1.1",
- "modular-bitfield",
- "once_cell",
- "op-alloy-consensus",
- "proptest",
- "proptest-arbitrary-interop",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9823,7 +9210,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rayon",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
@@ -9836,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9849,70 +9236,26 @@ dependencies = [
  "notify",
  "parking_lot",
  "rayon",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm-database",
- "revm-state",
- "rust-eth-triedb",
- "strum 0.27.2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-provider"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "dashmap 6.1.0",
- "eyre",
- "itertools 0.14.0",
- "metrics",
- "notify",
- "parking_lot",
- "rayon",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-db",
+ "reth-db-api",
+ "reth-errors",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-nippy-jar",
+ "reth-node-types",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-db",
  "revm-database",
  "revm-state",
  "rust-eth-triedb",
@@ -9924,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9932,16 +9275,16 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config",
+ "reth-db-api",
+ "reth-errors",
  "reth-exex-types",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
  "reth-tokio-util",
  "rustc-hash",
  "thiserror 2.0.18",
@@ -9952,28 +9295,13 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
  "derive_more 2.1.1",
  "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
- "strum 0.27.2",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-primitives",
- "arbitrary",
- "derive_more 2.1.1",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.18",
@@ -9982,17 +9310,17 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
  "reth-network",
  "reth-network-api",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10001,25 +9329,25 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "eyre",
  "futures",
  "parking_lot",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-evm",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
  "reth-ress-protocol",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm",
+ "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie",
  "schnellru",
  "tokio",
  "tracing",
@@ -10028,32 +9356,20 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm",
-]
-
-[[package]]
-name = "reth-revm"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-primitives",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie",
  "revm",
 ]
 
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10090,34 +9406,34 @@ dependencies = [
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-execution-types",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
+ "reth-network-types",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-revm",
  "reth-rpc-api",
  "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -10136,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10155,18 +9471,18 @@ dependencies = [
  "alloy-rpc-types-txpool",
  "alloy-serde",
  "jsonrpsee",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-engine-primitives",
+ "reth-network-peers",
  "reth-rpc-eth-api",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10175,23 +9491,23 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "pin-project",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-engine-primitives",
+ "reth-evm",
  "reth-ipc",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "reth-node-core",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -10207,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10219,9 +9535,9 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-primitives-traits",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -10229,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10238,16 +9554,16 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-engine-primitives",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "reth-payload-builder",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
  "reth-rpc-api",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
@@ -10259,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10279,22 +9595,22 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-evm",
  "reth-network-api",
  "reth-node-api",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common",
  "revm",
  "revm-inspectors",
  "rust-eth-triedb",
@@ -10305,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10324,21 +9640,21 @@ dependencies = [
  "metrics",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-execution-types",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "schnellru",
@@ -10353,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10367,14 +9683,14 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors",
  "reth-network-api",
  "serde",
  "strum 0.27.2",
@@ -10383,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10396,35 +9712,35 @@ dependencies = [
  "num-traits",
  "rayon",
  "reqwest 0.12.28",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
  "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-etl",
+ "reth-evm",
+ "reth-execution-types",
  "reth-exex",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-provider",
  "reth-prune",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types",
+ "reth-revm",
  "reth-stages-api",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types",
+ "reth-storage-api",
+ "reth-storage-errors",
  "reth-testing-utils",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
  "rust-eth-triedb",
  "tempfile",
  "thiserror 2.0.18",
@@ -10435,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10443,16 +9759,16 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "metrics",
- "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus",
+ "reth-errors",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-provider",
  "reth-prune",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types",
  "reth-static-file",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types",
  "reth-tokio-util",
  "thiserror 2.0.18",
  "tokio",
@@ -10462,47 +9778,33 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes 1.11.1",
  "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "serde",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-primitives",
- "arbitrary",
- "bytes 1.11.1",
- "modular-bitfield",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
+ "reth-trie-common",
  "serde",
 ]
 
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
  "rayon",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
+ "reth-db-api",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
+ "reth-storage-errors",
  "reth-tokio-util",
  "tracing",
 ]
@@ -10510,19 +9812,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "fixed-map",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10535,47 +9825,23 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm-database",
- "serde_json",
-]
-
-[[package]]
-name = "reth-storage-api"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-db-models",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
  "revm-database",
  "serde_json",
 ]
@@ -10583,32 +9849,15 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.1.1",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm-database-interface",
- "revm-state",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.1.1",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-static-file-types",
  "revm-database-interface",
  "revm-state",
  "thiserror 2.0.18",
@@ -10617,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10635,7 +9884,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10643,15 +9892,15 @@ dependencies = [
  "alloy-primitives",
  "rand 0.8.5",
  "rand 0.9.2",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
  "secp256k1 0.30.0",
 ]
 
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10661,26 +9910,11 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "clap",
  "eyre",
- "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "rolling-file",
- "tracing",
- "tracing-appender",
- "tracing-journald",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
-name = "reth-tracing"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "clap",
- "eyre",
- "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing-otlp",
  "rolling-file",
  "tracing",
  "tracing-appender",
@@ -10691,24 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "clap",
- "eyre",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber 0.3.23",
- "url",
-]
-
-[[package]]
-name = "reth-tracing-otlp"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "clap",
  "eyre",
@@ -10726,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10741,15 +9958,15 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.9.2",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
  "reth-eth-wire-types",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
+ "reth-fs-util",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-storage-api",
  "reth-tasks",
  "revm-interpreter",
  "revm-primitives",
@@ -10767,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10778,39 +9995,13 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm-database",
- "tracing",
- "triehash",
-]
-
-[[package]]
-name = "reth-trie"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "itertools 0.14.0",
- "metrics",
- "parking_lot",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "reth-trie-sparse",
  "revm-database",
  "tracing",
  "triehash",
@@ -10819,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10836,37 +10027,8 @@ dependencies = [
  "nybbles",
  "plain_hasher",
  "rayon",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "revm-database",
- "rust-eth-triedb",
- "rust-eth-triedb-state-trie",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-trie-common"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-trie",
- "arbitrary",
- "arrayvec",
- "bytes 1.11.1",
- "derive_more 2.1.1",
- "hash-db",
- "itertools 0.14.0",
- "nybbles",
- "plain_hasher",
- "rayon",
- "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs",
+ "reth-primitives-traits",
  "revm-database",
  "rust-eth-triedb",
  "rust-eth-triedb-state-trie",
@@ -10877,41 +10039,20 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "rust-eth-triedb",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-db"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
-dependencies = [
- "alloy-primitives",
- "metrics",
- "parking_lot",
- "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api",
+ "reth-execution-errors",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-stages-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-common",
  "rust-eth-triedb",
  "tracing",
 ]
@@ -10919,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10929,13 +10070,13 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-common",
+ "reth-trie-sparse",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10944,24 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-sparse"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10969,10 +10093,10 @@ dependencies = [
  "auto_impl",
  "metrics",
  "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "smallvec",
  "tracing",
 ]
@@ -10980,17 +10104,17 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
  "metrics",
  "rayon",
- "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common",
+ "reth-trie-sparse",
  "smallvec",
  "tracing",
 ]
@@ -10998,15 +10122,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
-dependencies = [
- "zstd",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
 dependencies = [
  "zstd",
 ]
@@ -11070,38 +10186,40 @@ dependencies = [
  "rand 0.9.2",
  "reth",
  "reth-basic-payload-builder",
- "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chain-state",
+ "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-util",
- "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db",
  "reth-discv4",
  "reth-engine-local",
- "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives",
+ "reth-engine-tree",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-forks",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-execution-types",
  "reth-ipc",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers",
+ "reth-node-builder",
  "reth-node-core",
  "reth-node-ethereum",
- "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
@@ -11109,8 +10227,8 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common",
+ "reth-trie-db",
  "revm",
  "revm-context-interface",
  "revm-database",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
+checksum = "1e56cae3909bcb2347f77c0f318ef5eb7e131ea6d0a94d31f8bfb6e4c5e3c7c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
+checksum = "f4394690a8a64757316c57c57f2c663bf8395febb4c4baa049a058ebd122b668"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -176,7 +176,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
+checksum = "7b97433ffdb356d11b6c89b08c69a787b9f55d787cdeee733c12fdf85d465ef1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -262,7 +262,6 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -288,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9cf3b99f46615fbf7dc1add0c96553abb7bf88fc9ec70dfbe7ad0b47ba7fe8"
+checksum = "6173ced325833e40ccb781bb372c720df638a966bad6ed6733682b6bff63d855"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -329,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
+checksum = "ae95062f48461967424eecb1e1ab703e493b6a7aca7f9c327cc1c06758eb6ec2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -344,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
+checksum = "464d9c2c5bca3ff3f020f2ab502629043486a1b3645c5c11613c1dade4eb6f5e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -370,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
+checksum = "2158d382ef9743ae7185c9fcd33cd9a99967419fdcd5eebc83ff7c0e79cad2bc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -395,7 +394,7 @@ dependencies = [
  "derive_more 2.1.1",
  "fixed-cache",
  "foldhash 0.2.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -414,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d181c8cc7cf4805d7e589bf4074d56d55064fa1a979f005a45a62b047616d870"
+checksum = "09b08405e82effb4985f7cbe83d5067730e79893c8699793c1e113043ffeac9d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -446,7 +445,7 @@ dependencies = [
  "lru 0.16.3",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -458,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bd82953194dec221aa4cbbbb0b1e2df46066fe9d0333ac25b43a311e122d13"
+checksum = "9f39b713fb8fd7abb6ee7601d467f71d2c2541b7799dd02d3a8f9f650d1d3f6d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -502,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2792758a93ae32a32e9047c843d536e1448044f78422d71bf7d7c05149e103f"
+checksum = "96846729dd095dd5a87bf5bd8efea2345ca41ceab6dda212c49f5c8ca6e2a536"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -515,7 +514,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",
@@ -528,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
+checksum = "4f20059ff046049aae59f6e19d96462214ad3290cf9920394309dd7ffc284390"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -541,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42325c117af3a9e49013f881c1474168db57978e02085fc9853a1c89e0562740"
+checksum = "3468c7d973491c4c02a373a29273cb747aa4a99cf2e54a6178b564d97462db50"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -553,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a3100b76987c1b1dc81f3abe592b7edc29e92b1242067a69d65e0030b35cf9"
+checksum = "e9aca954ee74bb38b24399da5bd861a2511fb76d40cca7ae700d2289ff96fb90"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -565,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
+checksum = "89b71da7e5cdd0d5ffebc459f5987888fd3380969c2f94f8cb652ad91ae51bba"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -576,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a22e13215866f5dfd5d3278f4c41f1fad9410dc68ce39022f58593c873c26f8"
+checksum = "6a3569433bc2cddd4f00b1dd533a38a07512b55e62d11f662fde20930b613b57"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -596,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b21e1ad18ff1b31ff1030e046462ab8168cf8894e6778cd805c8bdfe2bd649"
+checksum = "30d9d9a32059dff4809fe4db016db13ba1a20babf767c4cd26e97c93ee9efe4c"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -608,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ac61f03f1edabccde1c687b5b25fff28f183afee64eaa2e767def3929e4457"
+checksum = "f083328dbf7aa5abfe5c0a7758ec9acc86a45bfbcfb45c54186c6caa78036f2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -628,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
+checksum = "1641df7ef4d15cd43843d399252c90a95abf465a67e2a2b2fd76f4e93cc60e15"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -650,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe85bf3be739126aa593dca9fb3ab13ca93fa7873e6f2247be64d7f2cb15f34a"
+checksum = "23b6ca72affc6669e0a456af7d3c15d6b2edf75797d7906bc3900a8b1e094348"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -665,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad79f1e27e161943b5a4f99fe5534ef0849876214be411e0032c12f38e94daa"
+checksum = "b00e2d5ab1f7310c7ecd69962af8c99d2557335ff8cf1baf39c8ff6eec9c171d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -679,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d459f902a2313737bc66d18ed094c25d2aeb268b74d98c26bbbda2aa44182ab0"
+checksum = "154695f4a24dd749368fd46a4bdac1ec806b4376abc40112e3028018fee5b593"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -691,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
+checksum = "8f1c2c0b5f024814f1c04ae76ff71862d06c836e7d67102daf8a557e5056be68"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -703,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
+checksum = "e0f59de30d9d3b13ce6a1b90e85270dc086e4e4733aaa12b250fb30e1eb35849"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -718,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
+checksum = "d3e64733ea58cfb393c901047638e9ff6890c0a45dc5855bfa077f8bace0f9f9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -790,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -807,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
+checksum = "ec9c680a7ee0879aa27ea2e347f14e3a973a262e4325964fa1ab062b8a796064"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -830,14 +829,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
+checksum = "ae9abaedb9123ebe4b1527bc88a0409d65b2727c3de89a289284ba91ad70ae99"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde_json",
  "tower",
  "tracing",
@@ -846,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ef85688e5ac2da72afc804e0a1f153a1f309f05a864b1998bbbed7804dbaab"
+checksum = "1c74911eda4fd7ef12f446b1661f11787f9fb31bde4ab4a0a68efcac9b98cfdf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -866,31 +865,32 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f00445db69d63298e2b00a0ea1d859f00e6424a3144ffc5eba9c31da995e16"
+checksum = "130762ef3e6c0fb7dc1b855d4f359eb8ea6f2df2f800f40aa52d27737bf640f1"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.4.0",
+ "rustls 0.23.37",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "arrayvec",
  "derive_arbitrary",
  "derive_more 2.1.1",
  "nybbles",
@@ -904,11 +904,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
+checksum = "1a3684226a2220bb6e84a5ab74877e66628882336ecfba97482c9d473aa2b1cc"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -949,15 +949,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1378,9 +1378,9 @@ checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1464,6 +1464,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backon"
@@ -1560,7 +1582,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1578,7 +1600,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1881,19 +1903,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes 1.11.1",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1952,23 +1975,23 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "rayon",
- "reth-chainspec",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
- "reth-ethereum-consensus",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
- "reth-tracing",
- "reth-trie",
- "reth-trie-db",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth_bsc",
  "revm",
  "serde",
@@ -2066,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2152,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2191,9 +2214,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2226,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2236,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2248,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2260,9 +2283,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "coins-bip32"
@@ -2317,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2453,7 +2485,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid 1.21.0",
+ "uuid 1.23.0",
  "walkdir",
 ]
 
@@ -2513,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2721,7 +2753,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winapi",
 ]
 
@@ -2837,16 +2869,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -2871,21 +2893,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "serde",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -2893,6 +2900,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
  "syn 2.0.117",
 ]
@@ -2904,17 +2912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -3012,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3033,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3200,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f170f4f6ed0e1df52bf43b403899f0081917ecf1500bfe312505cc3b515a8899"
+checksum = "4c7999df38d0bd8f688212e1a4fae31fd2fea6d218649b9cd7c40bf3ec1318fc"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3218,13 +3215,12 @@ dependencies = [
  "hkdf",
  "lazy_static",
  "libp2p-identity",
- "lru 0.12.5",
  "more-asserts",
  "multiaddr",
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -3244,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -3807,6 +3803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,20 +4006,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -4184,9 +4186,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4214,11 +4213,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4496,7 +4495,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "log",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -4535,7 +4534,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -4792,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
  "bitflags 2.11.0",
  "inotify-sys",
@@ -4822,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -4835,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -4859,27 +4858,28 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -4947,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -4960,7 +4960,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -4969,9 +4969,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -4985,9 +5007,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5024,7 +5046,7 @@ dependencies = [
  "http 1.4.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
@@ -5077,7 +5099,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -5206,9 +5228,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5248,9 +5270,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
@@ -5312,13 +5334,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -5339,9 +5362,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
 dependencies = [
  "cc",
  "libc",
@@ -5373,9 +5396,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -5450,9 +5473,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "mach2"
@@ -5664,9 +5687,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5676,7 +5699,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid 1.21.0",
+ "uuid 1.23.0",
 ]
 
 [[package]]
@@ -5817,9 +5840,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -5896,9 +5919,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -5906,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5951,9 +5974,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -6128,7 +6151,7 @@ dependencies = [
  "opentelemetry",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -6146,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -6476,18 +6499,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6496,9 +6519,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -6521,6 +6544,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -6615,11 +6644,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -6675,7 +6704,7 @@ checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.11.0",
  "procfs-core 0.18.0",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6701,9 +6730,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
@@ -6826,7 +6855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6904,8 +6933,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.36",
- "socket2 0.6.2",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6914,9 +6943,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes 1.11.1",
  "getrandom 0.3.4",
@@ -6924,7 +6953,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6942,16 +6971,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6961,6 +6990,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -7166,9 +7201,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -7246,9 +7281,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regress"
@@ -7323,7 +7358,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -7345,6 +7380,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.11.1",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7353,22 +7419,22 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
  "clap",
  "eyre",
- "reth-chainspec",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network",
  "reth-network-api",
  "reth-node-api",
@@ -7377,12 +7443,12 @@ dependencies = [
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-provider",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ress-protocol",
  "reth-ress-provider",
- "reth-revm",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
@@ -7399,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7407,14 +7473,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "metrics",
- "reth-chain-state",
- "reth-metrics 1.10.2",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-payload-builder",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-revm",
- "reth-storage-api",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "tokio",
  "tracing",
@@ -7423,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7435,17 +7501,47 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "reth-chainspec",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-trie",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "revm-database",
  "revm-state",
- "rust-eth-triedb-common",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-chain-state"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "derive_more 2.1.1",
+ "metrics",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.2",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "revm-database",
+ "revm-state",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7455,7 +7551,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7466,22 +7562,42 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "derive_more 2.1.1",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-primitives-traits",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-chainspec"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-genesis",
  "clap",
  "eyre",
  "reth-cli-runner",
- "reth-db",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde_json",
  "shellexpand",
 ]
@@ -7489,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7513,16 +7629,16 @@ dependencies = [
  "proptest-arbitrary-interop",
  "ratatui",
  "reqwest 0.12.28",
- "reth-chainspec",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-cli",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-codecs",
- "reth-config",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-discv4",
  "reth-discv5",
  "reth-downloaders",
@@ -7531,35 +7647,35 @@ dependencies = [
  "reth-era-downloader",
  "reth-era-utils",
  "reth-eth-wire",
- "reth-ethereum-primitives",
- "reth-etl",
- "reth-evm",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-exex",
- "reth-fs-util",
- "reth-libmdbx",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-primitives-traits",
- "reth-provider",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-prune",
- "reth-prune-types",
- "reth-revm",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-stages",
- "reth-stages-types",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-static-file",
- "reth-static-file-types",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
- "reth-trie",
- "reth-trie-common",
- "reth-trie-db",
- "rust-eth-triedb",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -7575,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7585,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7593,7 +7709,7 @@ dependencies = [
  "eyre",
  "libc",
  "rand 0.8.5",
- "reth-fs-util",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
@@ -7603,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7614,8 +7730,28 @@ dependencies = [
  "bytes 1.11.1",
  "modular-bitfield",
  "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
+ "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "visibility",
+]
+
+[[package]]
+name = "reth-codecs"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "arbitrary",
+ "bytes 1.11.1",
+ "modular-bitfield",
+ "op-alloy-consensus",
+ "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "visibility",
 ]
@@ -7623,7 +7759,17 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7633,14 +7779,27 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "eyre",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "url",
+]
+
+[[package]]
+name = "reth-config"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "eyre",
  "humantime-serde",
- "reth-network-types",
- "reth-prune-types",
- "reth-stages-types",
- "reth-static-file-types",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "toml 0.8.23",
  "url",
@@ -7649,32 +7808,57 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
- "reth-execution-types",
- "reth-primitives-traits",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-consensus"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "auto_impl",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "reth-chainspec",
- "reth-consensus",
- "reth-primitives-traits",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+]
+
+[[package]]
+name = "reth-consensus-common"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
 ]
 
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7689,8 +7873,8 @@ dependencies = [
  "futures",
  "reqwest 0.12.28",
  "reth-node-api",
- "reth-primitives-traits",
- "reth-tracing",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "ringbuffer",
  "serde",
  "serde_json",
@@ -7700,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7708,14 +7892,40 @@ dependencies = [
  "metrics",
  "page_size",
  "parking_lot",
- "reth-db-api",
- "reth-fs-util",
- "reth-libmdbx",
- "reth-metrics 1.10.2",
- "reth-nippy-jar",
- "reth-static-file-types",
- "reth-storage-errors",
- "reth-tracing",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "rustc-hash",
+ "strum 0.27.2",
+ "sysinfo",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-db"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-primitives",
+ "derive_more 2.1.1",
+ "eyre",
+ "metrics",
+ "page_size",
+ "parking_lot",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-libmdbx 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "rustc-hash",
  "strum 0.27.2",
  "sysinfo",
@@ -7726,7 +7936,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7738,15 +7948,43 @@ dependencies = [
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
- "reth-codecs",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-optimism-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-optimism-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "roaring",
+ "serde",
+]
+
+[[package]]
+name = "reth-db-api"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-genesis",
+ "alloy-primitives",
+ "arbitrary",
+ "bytes 1.11.1",
+ "derive_more 2.1.1",
+ "metrics",
+ "modular-bitfield",
+ "parity-scale-codec",
+ "proptest",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-optimism-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "roaring",
  "serde",
 ]
@@ -7754,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7762,23 +8000,57 @@ dependencies = [
  "alloy-trie",
  "boyer-moore-magiclen",
  "eyre",
- "reth-chainspec",
- "reth-codecs",
- "reth-config",
- "reth-db-api",
- "reth-etl",
- "reth-execution-errors",
- "reth-fs-util",
- "reth-node-types",
- "reth-primitives-traits",
- "reth-provider",
- "reth-stages-types",
- "reth-static-file-types",
- "reth-trie",
- "reth-trie-db",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-state-trie",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-db-common"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "boyer-moore-magiclen",
+ "eyre",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7788,22 +8060,37 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bytes 1.11.1",
  "modular-bitfield",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+]
+
+[[package]]
+name = "reth-db-models"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "arbitrary",
+ "bytes 1.11.1",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
 ]
 
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7812,10 +8099,10 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "rand 0.8.5",
- "reth-ethereum-forks",
- "reth-net-banlist",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-net-nat",
- "reth-network-peers",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -7828,7 +8115,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7839,10 +8126,10 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rand 0.9.2",
- "reth-chainspec",
- "reth-ethereum-forks",
- "reth-metrics 1.10.2",
- "reth-network-peers",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
  "tokio",
@@ -7852,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7860,8 +8147,8 @@ dependencies = [
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "reth-ethereum-forks",
- "reth-network-peers",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tokio-util",
  "schnellru",
  "secp256k1 0.30.0",
@@ -7876,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7889,15 +8176,15 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-config",
- "reth-consensus",
- "reth-ethereum-primitives",
- "reth-metrics 1.10.2",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
- "reth-network-peers",
- "reth-primitives-traits",
- "reth-provider",
- "reth-storage-api",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-testing-utils",
  "tempfile",
@@ -7911,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7926,7 +8213,7 @@ dependencies = [
  "hmac",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -7939,20 +8226,20 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "reth-chainspec",
- "reth-engine-primitives",
- "reth-ethereum-engine-primitives",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-payload-builder",
- "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-storage-api",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
@@ -7962,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7970,15 +8257,40 @@ dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
  "futures",
- "reth-chain-state",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "reth-engine-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "futures",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -7987,30 +8299,30 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "futures",
  "pin-project",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-engine-tree",
- "reth-ethereum-primitives",
- "reth-evm",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
- "reth-node-types",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-payload-builder",
- "reth-provider",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "reth-trie-db",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8028,41 +8340,38 @@ dependencies = [
  "moka",
  "parking_lot",
  "rayon",
- "reth-chain-state",
- "reth-chainspec",
- "reth-consensus",
- "reth-db",
- "reth-engine-primitives",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-metrics 1.10.2",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
  "reth-payload-builder",
- "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-provider",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-prune",
- "reth-prune-types",
- "reth-revm",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
  "reth-tasks",
- "reth-tracing",
- "reth-trie",
- "reth-trie-common",
- "reth-trie-db",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-parallel",
- "reth-trie-sparse",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
- "rust-eth-triedb-state-trie",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "schnellru",
  "smallvec",
  "thiserror 2.0.18",
@@ -8073,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8081,16 +8390,16 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "pin-project",
- "reth-chainspec",
- "reth-engine-primitives",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-engine-tree",
- "reth-errors",
- "reth-evm",
- "reth-fs-util",
- "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-revm",
- "reth-storage-api",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "serde_json",
  "tokio",
@@ -8101,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8116,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8124,7 +8433,7 @@ dependencies = [
  "futures-util",
  "reqwest 0.12.28",
  "reth-era",
- "reth-fs-util",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "sha2 0.10.9",
  "tokio",
 ]
@@ -8132,21 +8441,21 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "eyre",
  "futures-util",
- "reth-db-api",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-era",
  "reth-era-downloader",
- "reth-etl",
- "reth-fs-util",
- "reth-primitives-traits",
- "reth-provider",
- "reth-stages-types",
- "reth-storage-api",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tokio",
  "tracing",
 ]
@@ -8154,18 +8463,29 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
- "reth-consensus",
- "reth-execution-errors",
- "reth-storage-errors",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-errors"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8175,13 +8495,13 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "pin-project",
- "reth-codecs",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ecies",
  "reth-eth-wire-types",
- "reth-ethereum-forks",
- "reth-metrics 1.10.2",
- "reth-network-peers",
- "reth-primitives-traits",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "snap",
  "thiserror 2.0.18",
@@ -8194,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8207,10 +8527,10 @@ dependencies = [
  "derive_more 2.1.1",
  "proptest",
  "proptest-arbitrary-interop",
- "reth-chainspec",
- "reth-codecs-derive",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs-derive 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -8218,54 +8538,88 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "clap",
  "eyre",
- "reth-chainspec",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
- "reth-db",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-rpc-server-types",
- "reth-tracing",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "reth-chainspec",
- "reth-consensus",
- "reth-consensus-common",
- "reth-execution-types",
- "reth-primitives-traits",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "tracing",
+]
+
+[[package]]
+name = "reth-ethereum-consensus"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "reth-engine-primitives",
- "reth-ethereum-primitives",
- "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-ethereum-engine-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -8274,7 +8628,20 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+ "once_cell",
+ "rustc-hash",
+]
+
+[[package]]
+name = "reth-ethereum-forks"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8288,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8296,19 +8663,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
- "reth-chainspec",
- "reth-consensus-common",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-payload-builder",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-payload-validator",
- "reth-primitives-traits",
- "reth-revm",
- "reth-storage-api",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-transaction-pool",
  "revm",
  "tracing",
@@ -8317,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8327,9 +8694,29 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "modular-bitfield",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-zstd-compressors",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-ethereum-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "arbitrary",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-zstd-compressors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "serde_with",
 ]
@@ -8337,17 +8724,50 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "rayon",
- "reth-db-api",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "tempfile",
+]
+
+[[package]]
+name = "reth-etl"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "rayon",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tempfile",
 ]
 
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-util",
+ "rayon",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+]
+
+[[package]]
+name = "reth-evm"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8358,21 +8778,41 @@ dependencies = [
  "futures-util",
  "metrics",
  "rayon",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie-common",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
- "rust-eth-triedb-common",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "derive_more 2.1.1",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm",
+]
+
+[[package]]
+name = "reth-evm-ethereum"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8381,42 +8821,73 @@ dependencies = [
  "alloy-rpc-types-engine",
  "derive_more 2.1.1",
  "parking_lot",
- "reth-chainspec",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-storage-errors",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
 ]
 
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
- "reth-storage-errors",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-execution-errors"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rlp",
+ "nybbles",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "derive_more 2.1.1",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-execution-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "derive_more 2.1.1",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
  "serde",
  "serde_with",
@@ -8425,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8435,24 +8906,24 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "reth-chain-state",
- "reth-chainspec",
- "reth-config",
- "reth-ethereum-primitives",
- "reth-evm",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-exex-types",
- "reth-fs-util",
- "reth-metrics 1.10.2",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune-types",
- "reth-revm",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-stages-api",
  "reth-tasks",
- "reth-tracing",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "rmp-serde",
  "thiserror 2.0.18",
  "tokio",
@@ -8463,13 +8934,13 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "reth-chain-state",
- "reth-execution-types",
- "reth-primitives-traits",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "serde_with",
 ]
@@ -8477,7 +8948,17 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-fs-util"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "serde",
  "serde_json",
@@ -8487,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8497,14 +8978,14 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "pretty_assertions",
- "reth-engine-primitives",
- "reth-evm",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-api",
- "reth-tracing",
- "reth-trie",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
  "revm-bytecode",
  "revm-database",
@@ -8515,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8535,14 +9016,30 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "dashmap 6.1.0",
  "derive_more 2.1.1",
  "parking_lot",
- "reth-mdbx-sys",
+ "reth-mdbx-sys 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-libmdbx"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "dashmap 6.1.0",
+ "derive_more 2.1.1",
+ "parking_lot",
+ "reth-mdbx-sys 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
@@ -8551,7 +9048,16 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "bindgen 0.71.1",
+ "cc",
+]
+
+[[package]]
+name = "reth-mdbx-sys"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8559,8 +9065,17 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.7.0"
-source = "git+https://github.com/bnb-chain/reth.git#012ffc045031c923a757444f6cdbc1e72fa0c269"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "metrics",
+ "metrics-derive",
+]
+
+[[package]]
+name = "reth-metrics"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "futures",
  "metrics",
@@ -8572,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git#b02940f65fe1e12a4224452c7cdfaa9e56ce8f0f"
 dependencies = [
  "futures",
  "metrics",
@@ -8584,7 +9099,16 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-primitives",
+ "ipnet",
+]
+
+[[package]]
+name = "reth-net-banlist"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8593,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8607,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8626,25 +9150,25 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
- "reth-chainspec",
- "reth-consensus",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-discv4",
  "reth-discv5",
  "reth-dns-discovery",
  "reth-ecies",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-fs-util",
- "reth-metrics 1.10.2",
- "reth-net-banlist",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers",
- "reth-network-types",
- "reth-primitives-traits",
- "reth-storage-api",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -8663,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8674,10 +9198,10 @@ dependencies = [
  "enr",
  "futures",
  "reth-eth-wire-types",
- "reth-ethereum-forks",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
- "reth-network-peers",
- "reth-network-types",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tokio-util",
  "serde",
  "thiserror 2.0.18",
@@ -8688,7 +9212,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8697,13 +9221,13 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "parking_lot",
- "reth-consensus",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-eth-wire-types",
- "reth-ethereum-primitives",
- "reth-network-peers",
- "reth-network-types",
- "reth-primitives-traits",
- "reth-storage-errors",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tokio",
  "tracing",
 ]
@@ -8711,7 +9235,20 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "secp256k1 0.30.0",
+ "serde_with",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "reth-network-peers"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8726,12 +9263,24 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-eip2124",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "reth-network-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
- "reth-net-banlist",
- "reth-network-peers",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "serde_json",
  "tracing",
@@ -8740,14 +9289,31 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "anyhow",
  "bincode",
  "derive_more 2.1.1",
  "lz4_flex",
  "memmap2",
- "reth-fs-util",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "reth-nippy-jar"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "derive_more 2.1.1",
+ "lz4_flex",
+ "memmap2",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -8757,22 +9323,22 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "reth-basic-payload-builder",
- "reth-consensus",
- "reth-db-api",
- "reth-engine-primitives",
- "reth-evm",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "reth-node-core",
- "reth-node-types",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-payload-builder",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
- "reth-provider",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -8781,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8797,23 +9363,23 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
- "reth-chain-state",
- "reth-chainspec",
- "reth-config",
- "reth-consensus",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-consensus-debug-client",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-downloaders",
  "reth-engine-local",
- "reth-engine-primitives",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
- "reth-evm",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-exex",
- "reth-fs-util",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-invalid-block-hooks",
  "reth-network",
  "reth-network-api",
@@ -8824,8 +9390,8 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives-traits",
- "reth-provider",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-prune",
  "reth-rpc",
  "reth-rpc-api",
@@ -8837,10 +9403,10 @@ dependencies = [
  "reth-static-file",
  "reth-tasks",
  "reth-tokio-util",
- "reth-tracing",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-transaction-pool",
- "reth-trie-db",
- "rust-eth-triedb",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -8851,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8865,32 +9431,32 @@ dependencies = [
  "humantime",
  "ipnet",
  "rand 0.9.2",
- "reth-chainspec",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-cli-util",
- "reth-config",
- "reth-consensus",
- "reth-db",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-discv4",
  "reth-discv5",
  "reth-engine-local",
- "reth-engine-primitives",
- "reth-ethereum-forks",
- "reth-net-banlist",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-net-banlist 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune-types",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-stages-types",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-tracing",
- "reth-tracing-otlp",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
@@ -8907,36 +9473,36 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "eyre",
- "reth-chainspec",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-engine-local",
- "reth-engine-primitives",
- "reth-ethereum-consensus",
- "reth-ethereum-engine-primitives",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
- "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-tracing",
+ "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-transaction-pool",
  "revm",
  "tokio",
@@ -8945,23 +9511,23 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "chrono",
  "futures-util",
- "reth-chain-state",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
- "reth-primitives-traits",
- "reth-storage-api",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-transaction-pool",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "url",
 ]
@@ -8969,7 +9535,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8979,13 +9545,13 @@ dependencies = [
  "futures",
  "humantime",
  "pin-project",
- "reth-engine-primitives",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
- "reth-primitives-traits",
- "reth-prune-types",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-stages",
- "reth-static-file-types",
- "reth-storage-api",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tokio",
  "tracing",
 ]
@@ -8993,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9006,7 +9572,7 @@ dependencies = [
  "metrics-util",
  "procfs 0.17.0",
  "reqwest 0.12.28",
- "reth-metrics 1.10.2",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9017,26 +9583,53 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
- "reth-chainspec",
- "reth-db-api",
- "reth-engine-primitives",
- "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+]
+
+[[package]]
+name = "reth-node-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
 ]
 
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "op-alloy-consensus",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-optimism-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "op-alloy-consensus",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "serde_with",
 ]
@@ -9044,19 +9637,19 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
- "reth-chain-state",
- "reth-ethereum-engine-primitives",
- "reth-metrics 1.10.2",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9065,10 +9658,22 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "pin-project",
- "reth-payload-primitives",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-payload-builder-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "pin-project",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9077,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9086,12 +9691,35 @@ dependencies = [
  "auto_impl",
  "either",
  "op-alloy-rpc-types-engine",
- "reth-chain-state",
- "reth-chainspec",
- "reth-errors",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "reth-payload-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "either",
+ "op-alloy-rpc-types-engine",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -9100,31 +9728,77 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
 ]
 
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
  "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+]
+
+[[package]]
+name = "reth-primitives"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "c-kzg",
+ "once_cell",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie",
+ "arbitrary",
+ "auto_impl",
+ "byteorder",
+ "bytes 1.11.1",
+ "derive_more 2.1.1",
+ "modular-bitfield",
+ "once_cell",
+ "op-alloy-consensus",
+ "proptest",
+ "proptest-arbitrary-interop",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm-bytecode",
+ "revm-primitives",
+ "revm-state",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9144,7 +9818,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rayon",
- "reth-codecs",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
@@ -9157,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9170,29 +9844,73 @@ dependencies = [
  "notify",
  "parking_lot",
  "rayon",
- "reth-chain-state",
- "reth-chainspec",
- "reth-codecs",
- "reth-db",
- "reth-db-api",
- "reth-errors",
- "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-metrics 1.10.2",
- "reth-nippy-jar",
- "reth-node-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-static-file-types",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-db",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "revm-database",
  "revm-state",
- "rust-eth-triedb",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "strum 0.27.2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-provider"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "dashmap 6.1.0",
+ "eyre",
+ "itertools 0.14.0",
+ "metrics",
+ "notify",
+ "parking_lot",
+ "rayon",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-nippy-jar 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-node-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "revm-database",
+ "revm-state",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -9201,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9209,16 +9927,16 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-config",
- "reth-db-api",
- "reth-errors",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-exex-types",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune-types",
- "reth-stages-types",
- "reth-static-file-types",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tokio-util",
  "rustc-hash",
  "thiserror 2.0.18",
@@ -9229,13 +9947,28 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
  "derive_more 2.1.1",
  "modular-bitfield",
- "reth-codecs",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-prune-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-primitives",
+ "arbitrary",
+ "derive_more 2.1.1",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.18",
@@ -9244,17 +9977,17 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network",
  "reth-network-api",
- "reth-storage-errors",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9263,25 +9996,25 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "eyre",
  "futures",
  "parking_lot",
- "reth-chain-state",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-node-api",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ress-protocol",
- "reth-revm",
- "reth-storage-api",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-tokio-util",
- "reth-trie",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "schnellru",
  "tokio",
  "tracing",
@@ -9290,20 +10023,32 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm",
+]
+
+[[package]]
+name = "reth-revm"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-primitives",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
 ]
 
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9340,38 +10085,38 @@ dependencies = [
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
- "reth-chain-state",
- "reth-chainspec",
- "reth-consensus",
- "reth-consensus-common",
- "reth-engine-primitives",
- "reth-errors",
- "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
- "reth-execution-types",
- "reth-metrics 1.10.2",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
- "reth-network-peers",
- "reth-network-types",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-node-api",
- "reth-primitives-traits",
- "reth-revm",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-api",
  "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-storage-api",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
- "rust-eth-triedb",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -9386,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9405,18 +10150,18 @@ dependencies = [
  "alloy-rpc-types-txpool",
  "alloy-serde",
  "jsonrpsee",
- "reth-chain-state",
- "reth-engine-primitives",
- "reth-network-peers",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-eth-api",
- "reth-trie-common",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9425,23 +10170,23 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "pin-project",
- "reth-chain-state",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
- "reth-evm",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ipc",
- "reth-metrics 1.10.2",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "reth-node-core",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
  "reth-rpc-server-types",
- "reth-storage-api",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9457,7 +10202,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9469,9 +10214,9 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-primitives-traits",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -9479,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9488,16 +10233,16 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "reth-chainspec",
- "reth-engine-primitives",
- "reth-metrics 1.10.2",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "reth-payload-builder",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-api",
- "reth-storage-api",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
@@ -9509,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9529,25 +10274,24 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot",
- "reth-chain-state",
- "reth-chainspec",
- "reth-engine-primitives",
- "reth-errors",
- "reth-evm",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "reth-node-api",
- "reth-primitives-traits",
- "reth-revm",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-storage-api",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
  "revm-inspectors",
- "rust-eth-triedb",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "tokio",
  "tracing",
 ]
@@ -9555,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9574,21 +10318,21 @@ dependencies = [
  "metrics",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "reth-chain-state",
- "reth-chainspec",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-revm",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-storage-api",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
  "revm-inspectors",
  "schnellru",
@@ -9603,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -9617,14 +10361,14 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
  "serde",
  "strum 0.27.2",
@@ -9633,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9646,36 +10390,36 @@ dependencies = [
  "num-traits",
  "rayon",
  "reqwest 0.12.28",
- "reth-chainspec",
- "reth-codecs",
- "reth-config",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-config 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
- "reth-ethereum-primitives",
- "reth-etl",
- "reth-evm",
- "reth-execution-types",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-etl 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-exex",
- "reth-fs-util",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
- "reth-primitives-traits",
- "reth-provider",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-prune",
- "reth-prune-types",
- "reth-revm",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-stages-api",
- "reth-static-file-types",
- "reth-storage-api",
- "reth-storage-errors",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-testing-utils",
- "reth-trie",
- "reth-trie-common",
- "reth-trie-db",
- "rust-eth-triedb",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -9685,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9693,16 +10437,16 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "metrics",
- "reth-consensus",
- "reth-errors",
- "reth-metrics 1.10.2",
+ "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-p2p",
- "reth-primitives-traits",
- "reth-provider",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-prune",
- "reth-stages-types",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-static-file",
- "reth-static-file-types",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tokio-util",
  "thiserror 2.0.18",
  "tokio",
@@ -9712,33 +10456,47 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes 1.11.1",
  "modular-bitfield",
- "reth-codecs",
- "reth-trie-common",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "serde",
+]
+
+[[package]]
+name = "reth-stages-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-primitives",
+ "arbitrary",
+ "bytes 1.11.1",
+ "modular-bitfield",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "serde",
 ]
 
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
  "rayon",
- "reth-codecs",
- "reth-db-api",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune-types",
- "reth-stages-types",
- "reth-static-file-types",
- "reth-storage-errors",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tokio-util",
  "tracing",
 ]
@@ -9746,7 +10504,19 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-primitives",
+ "derive_more 2.1.1",
+ "fixed-map",
+ "serde",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "reth-static-file-types"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9759,23 +10529,47 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "reth-chainspec",
- "reth-db-api",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm-database",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-storage-api"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-db-models 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm-database",
  "serde_json",
 ]
@@ -9783,15 +10577,32 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.1.1",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-static-file-types",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm-database-interface",
+ "revm-state",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-storage-errors"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 2.1.1",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-prune-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm-database-interface",
  "revm-state",
  "thiserror 2.0.18",
@@ -9800,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9808,7 +10619,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.2",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9818,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9826,15 +10637,15 @@ dependencies = [
  "alloy-primitives",
  "rand 0.8.5",
  "rand 0.9.2",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "secp256k1 0.30.0",
 ]
 
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9844,22 +10655,54 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "clap",
  "eyre",
- "reth-tracing-otlp",
+ "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "rolling-file",
  "tracing",
  "tracing-appender",
  "tracing-journald",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "reth-tracing"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "clap",
+ "eyre",
+ "reth-tracing-otlp 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "rolling-file",
+ "tracing",
+ "tracing-appender",
+ "tracing-journald",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "clap",
+ "eyre",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.23",
+ "url",
+]
+
+[[package]]
+name = "reth-tracing-otlp"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "clap",
  "eyre",
@@ -9870,14 +10713,14 @@ dependencies = [
  "opentelemetry_sdk",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9892,15 +10735,15 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.9.2",
- "reth-chain-state",
- "reth-chainspec",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-eth-wire-types",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-fs-util",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-storage-api",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-fs-util 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-tasks",
  "revm-interpreter",
  "revm-primitives",
@@ -9918,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9929,13 +10772,39 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "reth-execution-errors",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "reth-trie-sparse",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "revm-database",
+ "tracing",
+ "triehash",
+]
+
+[[package]]
+name = "reth-trie"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "itertools 0.14.0",
+ "metrics",
+ "parking_lot",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm-database",
  "tracing",
  "triehash",
@@ -9944,7 +10813,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9961,11 +10830,40 @@ dependencies = [
  "nybbles",
  "plain_hasher",
  "rayon",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "revm-database",
- "rust-eth-triedb",
- "rust-eth-triedb-state-trie",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-trie-common"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-trie",
+ "arbitrary",
+ "arrayvec",
+ "bytes 1.11.1",
+ "derive_more 2.1.1",
+ "hash-db",
+ "itertools 0.14.0",
+ "nybbles",
+ "plain_hasher",
+ "rayon",
+ "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "revm-database",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "serde",
  "serde_with",
 ]
@@ -9973,28 +10871,49 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
- "reth-db-api",
- "reth-execution-errors",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-stages-types",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-common",
- "rust-eth-triedb",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie-db"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+dependencies = [
+ "alloy-primitives",
+ "metrics",
+ "parking_lot",
+ "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-stages-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10004,13 +10923,13 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-execution-errors",
- "reth-metrics 1.10.2",
- "reth-provider",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-common",
- "reth-trie-sparse",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10019,7 +10938,24 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "rayon",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie-sparse"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10027,10 +10963,10 @@ dependencies = [
  "auto_impl",
  "metrics",
  "rayon",
- "reth-execution-errors",
- "reth-metrics 1.10.2",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "smallvec",
  "tracing",
 ]
@@ -10038,17 +10974,17 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
  "metrics",
  "rayon",
- "reth-execution-errors",
- "reth-metrics 1.10.2",
- "reth-trie-common",
- "reth-trie-sparse",
+ "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-sparse 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "smallvec",
  "tracing",
 ]
@@ -10056,7 +10992,15 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#23d41a871d77310bb9011aa6ab19832bb58fd1f2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
+dependencies = [
+ "zstd",
+]
+
+[[package]]
+name = "reth-zstd-compressors"
+version = "1.10.2"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
 dependencies = [
  "zstd",
 ]
@@ -10120,54 +11064,50 @@ dependencies = [
  "rand 0.9.2",
  "reth",
  "reth-basic-payload-builder",
- "reth-chain-state",
- "reth-chainspec",
+ "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-util",
- "reth-db",
+ "reth-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-discv4",
  "reth-engine-local",
- "reth-engine-primitives",
- "reth-engine-tree",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-engine-primitives",
- "reth-ethereum-forks",
+ "reth-ethereum-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-ethereum-forks 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
- "reth-execution-types",
+ "reth-ethereum-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-evm-ethereum 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-execution-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-ipc",
- "reth-metrics 1.10.2",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers",
- "reth-node-builder",
+ "reth-network-peers 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-node-core",
  "reth-node-ethereum",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
+ "reth-payload-builder-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-provider 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-revm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common",
- "reth-trie-db",
+ "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
  "revm-context-interface",
  "revm-database",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
  "schnellru",
  "scrypt 0.11.0",
  "secp256k1 0.30.0",
@@ -10183,7 +11123,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "uuid 1.21.0",
+ "uuid 1.23.0",
  "zeroize",
 ]
 
@@ -10318,9 +11258,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e435414e9de50a1b930da602067c76365fea2fea11e80ceb50783c94ddd127f"
+checksum = "e341d9777b1903a8428bc6f8fe7a8f80671d2249837c9749566e61328ef14125"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10351,9 +11291,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.0.0"
+version = "32.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-bn254",
@@ -10375,9 +11315,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10570,17 +11510,17 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 [[package]]
 name = "rust-eth-triedb"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "metrics",
  "once_cell",
  "rayon",
- "reth-metrics 1.7.0",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
- "rust-eth-triedb-state-trie",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "schnellru",
  "serde",
  "thiserror 1.0.69",
@@ -10589,9 +11529,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-eth-triedb"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#cc5c8e2322329df69f65f2d689d8cd98baa2228e"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "metrics",
+ "once_cell",
+ "rayon",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "schnellru",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "rust-eth-triedb-common"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -10600,17 +11560,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-eth-triedb-common"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#cc5c8e2322329df69f65f2d689d8cd98baa2228e"
+dependencies = [
+ "alloy-primitives",
+ "auto_impl",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "rust-eth-triedb-pathdb"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "metrics",
- "mini-moka",
- "reth-metrics 1.7.0",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
  "rocksdb",
- "rust-eth-triedb-common",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "schnellru",
  "tempfile",
  "thiserror 1.0.69",
@@ -10619,9 +11588,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-eth-triedb-pathdb"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#cc5c8e2322329df69f65f2d689d8cd98baa2228e"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "metrics",
+ "mini-moka",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
+ "rocksdb",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "schnellru",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "rust-eth-triedb-state-trie"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10630,10 +11617,28 @@ dependencies = [
  "hex 0.4.3",
  "rand 0.8.5",
  "rayon",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "thiserror 1.0.69",
  "tikv-jemallocator",
+ "tracing",
+]
+
+[[package]]
+name = "rust-eth-triedb-state-trie"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#cc5c8e2322329df69f65f2d689d8cd98baa2228e"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "hex 0.4.3",
+ "rand 0.8.5",
+ "rayon",
+ "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -10700,14 +11705,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -10725,15 +11730,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -10792,10 +11798,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -10820,10 +11826,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -10879,9 +11886,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -11206,9 +12213,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -11225,11 +12232,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11317,9 +12324,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
 dependencies = [
  "cc",
  "cfg-if",
@@ -11336,9 +12343,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
@@ -11398,9 +12405,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -11437,9 +12444,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -11484,12 +12491,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11726,9 +12733,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -11737,14 +12744,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -11949,9 +12956,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -11964,9 +12971,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes 1.11.1",
  "libc",
@@ -11974,16 +12981,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12006,7 +13013,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -12030,12 +13037,27 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -12086,9 +13108,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -12104,28 +13126,28 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -12219,7 +13241,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.21.0",
+ "uuid 1.23.0",
 ]
 
 [[package]]
@@ -12255,7 +13277,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -12297,7 +13319,7 @@ checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -12323,7 +13345,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -12348,9 +13370,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -12424,7 +13446,26 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.36",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes 1.11.1",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -12487,9 +13528,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -12591,11 +13632,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -12730,9 +13771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12743,9 +13784,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -12757,9 +13798,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12767,9 +13808,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12780,9 +13821,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -12850,9 +13891,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13066,6 +14107,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -13403,9 +14455,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -13555,7 +14616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -13595,18 +14656,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7419,7 +7419,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7474,7 +7474,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "reth-chain-state",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7505,7 +7505,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7541,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7641,7 +7641,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7689,7 +7689,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7699,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7715,7 +7715,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7728,7 +7728,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7766,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7777,7 +7777,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7907,7 +7907,7 @@ dependencies = [
  "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7942,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7958,7 +7958,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8005,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8028,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "futures",
  "pin-project",
@@ -8076,7 +8076,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8103,7 +8103,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8139,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8167,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8220,7 +8220,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8231,7 +8231,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8245,7 +8245,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8284,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "clap",
  "eyre",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8322,7 +8322,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8340,7 +8340,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8354,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8383,7 +8383,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8426,7 +8426,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8460,7 +8460,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8473,7 +8473,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8491,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8508,7 +8508,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8529,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "serde",
  "serde_json",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8617,7 +8617,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "futures",
  "metrics",
@@ -8650,7 +8650,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8673,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8703,7 +8703,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8729,7 +8729,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8754,7 +8754,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8777,7 +8777,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8806,7 +8806,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8847,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8917,7 +8917,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8973,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9035,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9072,7 +9072,7 @@ dependencies = [
  "metrics-util",
  "procfs 0.17.0",
  "reqwest 0.12.28",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9119,7 +9119,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9131,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9143,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9166,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9190,7 +9190,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,7 +9279,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9295,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9329,7 +9329,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9369,7 +9369,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9417,7 +9417,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9497,7 +9497,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-api",
  "reth-node-core",
  "reth-primitives-traits",
@@ -9523,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9556,7 +9556,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9646,7 +9646,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9669,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9751,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9761,7 +9761,7 @@ dependencies = [
  "metrics",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9778,7 +9778,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9792,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9812,7 +9812,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9825,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9849,7 +9849,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9874,7 +9874,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9884,7 +9884,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9900,7 +9900,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9910,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "clap",
  "eyre",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "clap",
  "eyre",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9964,7 +9964,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9996,7 +9996,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10039,14 +10039,14 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
@@ -10060,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10071,7 +10071,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10094,7 +10094,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits",
  "reth-trie-common",
  "smallvec",
@@ -10104,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10112,7 +10112,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-trie-common",
  "reth-trie-sparse",
  "smallvec",
@@ -10122,7 +10122,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#5a2356094f3ae137527c5f403db2d213116c37a6"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#aeb5f0e18f2d780bc96f69249b8ace5d894874b6"
 dependencies = [
  "zstd",
 ]
@@ -10206,7 +10206,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7419,7 +7419,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7511,7 +7511,7 @@ dependencies = [
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "revm-database",
  "revm-state",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-common",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7520,7 +7520,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7542,6 +7542,7 @@ dependencies = [
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm-database",
  "revm-state",
+ "rust-eth-triedb-common",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7571,7 +7572,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7591,7 +7592,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7605,7 +7606,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7675,7 +7676,7 @@ dependencies = [
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -7691,7 +7692,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7701,7 +7702,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7739,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7769,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7792,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7821,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7846,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7858,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7910,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7964,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8014,9 +8015,9 @@ dependencies = [
  "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
- "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8026,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8048,9 +8049,9 @@ dependencies = [
  "reth-static-file-types 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8075,7 +8076,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8090,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8115,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8139,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8163,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8198,7 +8199,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8226,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8274,7 +8275,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8299,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "futures",
  "pin-project",
@@ -8322,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8371,7 +8372,10 @@ dependencies = [
  "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "rust-eth-triedb-state-trie",
  "schnellru",
  "smallvec",
  "thiserror 2.0.18",
@@ -8382,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8410,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8425,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8441,7 +8445,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8474,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "reth-consensus 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-execution-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
@@ -8485,7 +8489,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8514,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8538,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "clap",
  "eyre",
@@ -8576,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8610,7 +8614,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8641,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8655,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8704,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8734,7 +8738,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "rayon",
  "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
@@ -8761,13 +8765,13 @@ dependencies = [
  "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "revm",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-common",
 ]
 
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8786,6 +8790,7 @@ dependencies = [
  "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
+ "rust-eth-triedb-common",
 ]
 
 [[package]]
@@ -8812,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8847,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8878,7 +8883,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8896,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8934,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8958,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "serde",
  "serde_json",
@@ -8968,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8996,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -9032,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9057,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9075,7 +9080,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "futures",
  "metrics",
@@ -9108,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9117,7 +9122,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9131,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9212,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9248,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9275,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9306,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9323,7 +9328,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9347,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9406,7 +9411,7 @@ dependencies = [
  "reth-tracing 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-transaction-pool",
  "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9417,7 +9422,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9473,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9511,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9535,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9559,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9595,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-db-api 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
@@ -9622,7 +9627,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9637,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9670,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
@@ -9705,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9728,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9752,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9798,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9866,7 +9871,7 @@ dependencies = [
  "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "revm-database",
  "revm-state",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -9875,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9910,7 +9915,7 @@ dependencies = [
  "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm-database",
  "revm-state",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -9919,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9962,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9977,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9996,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10035,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
@@ -10048,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10116,7 +10121,7 @@ dependencies = [
  "revm",
  "revm-inspectors",
  "revm-primitives",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -10131,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10161,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10202,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10224,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10254,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10276,6 +10281,7 @@ dependencies = [
  "parking_lot",
  "reth-chain-state 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-chainspec 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
+ "reth-engine-primitives 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-evm 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-network-api",
@@ -10291,7 +10297,7 @@ dependencies = [
  "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm",
  "revm-inspectors",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
  "tokio",
  "tracing",
 ]
@@ -10299,7 +10305,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10347,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10361,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10377,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10419,7 +10425,7 @@ dependencies = [
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-db 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -10429,7 +10435,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10470,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10484,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10516,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10553,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10594,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10611,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10629,7 +10635,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10645,7 +10651,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10670,7 +10676,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "clap",
  "eyre",
@@ -10702,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "clap",
  "eyre",
@@ -10720,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10787,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10833,8 +10839,8 @@ dependencies = [
  "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "revm-database",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
- "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_with",
 ]
@@ -10842,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10862,8 +10868,8 @@ dependencies = [
  "reth-codecs 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-primitives-traits 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "revm-database",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_with",
 ]
@@ -10885,14 +10891,14 @@ dependencies = [
  "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
  "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=develop)",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10906,14 +10912,14 @@ dependencies = [
  "reth-storage-errors 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
  "reth-trie-common 1.10.2 (git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs)",
- "rust-eth-triedb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
+ "rust-eth-triedb",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10955,7 +10961,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10974,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11000,7 +11006,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#6303dbf57757118d3a854513b25d4dcff6979dce"
+source = "git+https://github.com/bnb-chain/reth.git?branch=fix-getlogs#0efdfaa4ae236f59c814f7de7f36cbdffbfc0dc4"
 dependencies = [
  "zstd",
 ]
@@ -11108,6 +11114,9 @@ dependencies = [
  "revm",
  "revm-context-interface",
  "revm-database",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
  "schnellru",
  "scrypt 0.11.0",
  "secp256k1 0.30.0",
@@ -11510,27 +11519,6 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 [[package]]
 name = "rust-eth-triedb"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
-dependencies = [
- "alloy-primitives",
- "alloy-trie",
- "metrics",
- "once_cell",
- "rayon",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "schnellru",
- "serde",
- "thiserror 1.0.69",
- "tikv-jemallocator",
- "tracing",
-]
-
-[[package]]
-name = "rust-eth-triedb"
-version = "0.1.0"
 source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#cc5c8e2322329df69f65f2d689d8cd98baa2228e"
 dependencies = [
  "alloy-primitives",
@@ -11539,24 +11527,14 @@ dependencies = [
  "once_cell",
  "rayon",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
- "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
- "rust-eth-triedb-state-trie 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "rust-eth-triedb-state-trie",
  "schnellru",
  "serde",
  "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "rust-eth-triedb-common"
-version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
-dependencies = [
- "alloy-primitives",
- "auto_impl",
- "thiserror 1.0.69",
  "tikv-jemallocator",
+ "tracing",
 ]
 
 [[package]]
@@ -11567,24 +11545,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "rust-eth-triedb-pathdb"
-version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
-dependencies = [
- "alloy-primitives",
- "alloy-trie",
- "metrics",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
- "rocksdb",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "schnellru",
- "tempfile",
- "thiserror 1.0.69",
  "tikv-jemallocator",
- "tracing",
 ]
 
 [[package]]
@@ -11598,27 +11559,9 @@ dependencies = [
  "mini-moka",
  "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git)",
  "rocksdb",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-common",
  "schnellru",
  "tempfile",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "rust-eth-triedb-state-trie"
-version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "hex 0.4.3",
- "rand 0.8.5",
- "rayon",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
- "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1)",
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tracing",
@@ -11636,9 +11579,10 @@ dependencies = [
  "hex 0.4.3",
  "rand 0.8.5",
  "rayon",
- "rust-eth-triedb-common 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
- "rust-eth-triedb-pathdb 0.1.0 (git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop)",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,9 @@ reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getl
 reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 
 # triedb dependencies
-rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "fix-getlogs" }
-rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "fix-getlogs", package = "rust-eth-triedb-common" }
-rust-eth-triedb-pathdb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "fix-getlogs", package = "rust-eth-triedb-pathdb" }
+rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop" }
+rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-common" }
+rust-eth-triedb-pathdb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-pathdb" }
 
 revm = "34.0.0"
 revm-context-interface = "14.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,12 @@ reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "fi
 reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+
+# triedb dependencies
+rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "fix-getlogs" }
+rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "fix-getlogs", package = "rust-eth-triedb-common" }
+rust-eth-triedb-pathdb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "fix-getlogs", package = "rust-eth-triedb-pathdb" }
+
 revm = "34.0.0"
 revm-context-interface = "14.0.0"
 revm-database = "10.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "f
 reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,66 +16,59 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-
-# triedb dependencies
-rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop" }
-rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-common" }
-rust-eth-triedb-pathdb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-pathdb" }
-
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-rpc-eth-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 revm = "34.0.0"
 revm-context-interface = "14.0.0"
 revm-database = "10.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,61 +16,61 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = [
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-rpc-eth-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-rpc-eth-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
 
 # triedb dependencies
 rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop" }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -186,17 +186,19 @@ where
     }
 
     fn add_ons(&self) -> Self::AddOns {
-        BscNodeAddOns::default().extend_rpc_modules(
-            |ctx: RpcContext<'_, NodeAdapter<N>, <BscEthApiBuilder as EthApiBuilder<NodeAdapter<N>>>::EthApi>| {
-                let eth_config = EthConfigHandler::new(
-                    ctx.node().provider().clone(),
-                    ctx.node().evm_config().clone(),
-                );
-            ctx.modules
-                .merge_if_module_configured(RethRpcModule::Eth, eth_config.into_rpc())?;
-            Ok(())
-            },
-        )
+        BscNodeAddOns::default()
+            .with_receipt_filter(Arc::new(crate::rpc::BscReceiptFilter))
+            .extend_rpc_modules(
+                |ctx: RpcContext<'_, NodeAdapter<N>, <BscEthApiBuilder as EthApiBuilder<NodeAdapter<N>>>::EthApi>| {
+                    let eth_config = EthConfigHandler::new(
+                        ctx.node().provider().clone(),
+                        ctx.node().evm_config().clone(),
+                    );
+                ctx.modules
+                    .merge_if_module_configured(RethRpcModule::Eth, eth_config.into_rpc())?;
+                Ok(())
+                },
+            )
     }
 }
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -3,9 +3,11 @@ pub mod eth_ext;
 pub mod mev;
 pub mod miner;
 pub mod parlia;
+pub mod receipt_filter;
 
 pub use blob::*;
 pub use eth_ext::*;
 pub use mev::*;
 pub use miner::*;
 pub use parlia::*;
+pub use receipt_filter::*;

--- a/src/rpc/receipt_filter.rs
+++ b/src/rpc/receipt_filter.rs
@@ -37,7 +37,7 @@ impl ReceiptFilter for BscReceiptFilter {
         // Check if this is a system transaction:
         // signer == coinbase && to is system contract && max_fee_per_gas == 0
         let is_system_tx = tx_signer == beneficiary
-            && tx_to.map_or(false, |to| SYSTEM_CONTRACTS_SET.contains(&to))
+            && tx_to.is_some_and(|to| SYSTEM_CONTRACTS_SET.contains(&to))
             && tx_max_fee_per_gas == 0;
 
         // Include the receipt only if it's NOT a system transaction

--- a/src/rpc/receipt_filter.rs
+++ b/src/rpc/receipt_filter.rs
@@ -1,0 +1,46 @@
+//! BSC Receipt Filter for excluding system transaction logs from RPC responses.
+//!
+//! BSC system transactions (validator rewards, cross-chain operations, etc.) are
+//! consensus-internal transactions injected by the Parlia engine. Their receipts
+//! are included in the receipt trie root (for block validation), but their logs
+//! should be excluded from `eth_getLogs`, `eth_getFilterChanges`, and
+//! `eth_subscribe("logs")` RPC responses to match BSC geth behavior.
+
+use alloy_eips::BlockNumHash;
+use alloy_primitives::Address;
+use reth_rpc_eth_types::logs_utils::ReceiptFilter;
+
+use crate::system_contracts::SYSTEM_CONTRACTS_SET;
+
+/// BSC receipt filter that excludes system transaction logs from RPC responses.
+///
+/// A system transaction is identified by three criteria:
+/// 1. The transaction signer equals the block's beneficiary (coinbase/validator)
+/// 2. The transaction recipient is a BSC system contract
+/// 3. The transaction's max_fee_per_gas is 0
+///
+/// This filter is applied during log retrieval to match BSC geth's behavior of
+/// not returning system transaction logs in `eth_getLogs` and subscriptions.
+#[derive(Debug, Clone, Default)]
+pub struct BscReceiptFilter;
+
+impl ReceiptFilter for BscReceiptFilter {
+    fn should_include(
+        &self,
+        _block_num_hash: BlockNumHash,
+        _receipt_idx: usize,
+        beneficiary: Address,
+        tx_signer: Address,
+        tx_to: Option<Address>,
+        tx_max_fee_per_gas: u128,
+    ) -> bool {
+        // Check if this is a system transaction:
+        // signer == coinbase && to is system contract && max_fee_per_gas == 0
+        let is_system_tx = tx_signer == beneficiary
+            && tx_to.map_or(false, |to| SYSTEM_CONTRACTS_SET.contains(&to))
+            && tx_max_fee_per_gas == 0;
+
+        // Include the receipt only if it's NOT a system transaction
+        !is_system_tx
+    }
+}

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,23 +14,23 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate branch to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = ["mdbx", "test-utils", "disable-lock"] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = ["test-utils"] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = ["std"] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = ["mdbx", "test-utils", "disable-lock"] }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = ["test-utils"] }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = ["std"] }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
 
 # revm
 revm = { version = "34.0.0", features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,23 +14,23 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate branch to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = ["mdbx", "test-utils", "disable-lock"] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = ["test-utils"] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = ["std"] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = ["mdbx", "test-utils", "disable-lock"] }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = ["test-utils"] }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs", features = ["std"] }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "fix-getlogs" }
 
 # revm
 revm = { version = "34.0.0", features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }


### PR DESCRIPTION
### Description

`eth_getLogs` RPC filters system tx which solves [263](https://github.com/bnb-chain/reth-bsc/issues/263) issue.

### Rationale

To keep the same style as geth for `eth_getLogs` .

### Example

N/A

### Changes

Notable changes: 
* N/A

### Potential Impacts
* N/A
