### PR TITLE
fix: classify FutureBlock as transient to prevent invalid_headers poisoning

### DIFF
--- a/src/node/evm/error.rs
+++ b/src/node/evm/error.rs
@@ -196,20 +196,28 @@ impl From<BscBlockExecutionError> for BlockExecutionError {
         static CONSENSUS_METRICS: Lazy<BscConsensusMetrics> = Lazy::new(BscConsensusMetrics::default);
         static EXECUTOR_METRICS: Lazy<BscExecutorMetrics> = Lazy::new(BscExecutorMetrics::default);
         EXECUTOR_METRICS.execution_errors_total.increment(1);
-        
+
         match err {
+            // Transient validation error: the block proposer is in the backoff period
+            // and the block will become valid after a short delay. Must NOT be cached
+            // in engine-tree's invalid_headers to avoid poisoning the chain.
+            BscBlockExecutionError::Validation(
+                BscBlockValidationError::FutureBlock { .. }
+            ) => Self::other(err),
+
             BscBlockExecutionError::Validation(validation_err) => {
-                // Update bad blocks metric
+                // Permanent validation errors: the block genuinely violates consensus
+                // rules and will never become valid. Safe to cache in invalid_headers.
                 CONSENSUS_METRICS.bad_blocks_total.increment(1);
-                
+
                 // TODO: now use DepositRequestDecode as the validation error carrier,
                 // but we should refine it by rewrite some validation error types in reth engine-tree.
-                // Note: Validation errors will be identified in the engine-tree and treated as invalid blocks. 
+                // Note: Validation errors will be identified in the engine-tree and treated as invalid blocks.
                 Self::Validation(BlockValidationError::DepositRequestDecode(
                     format!("BSC validation error: {}", validation_err)
                 ))
             }
-            
+
             BscBlockExecutionError::SnapshotNotFound |
             BscBlockExecutionError::EthCallFailed |
             BscBlockExecutionError::GetTopValidatorsFailed |
@@ -222,8 +230,8 @@ impl From<BscBlockExecutionError> for BlockExecutionError {
             BscBlockExecutionError::SystemContractUpgradeError |
             BscBlockExecutionError::FailedToSignSystemTransaction { .. } |
             BscBlockExecutionError::GlobalSignerNotInitializedForMiningMode => {
-                // Note: Internal errors will be identified in the engine-tree, 
-                // and the entire program will exit.
+                // Internal errors: mapped to BlockExecutionError::Internal, which
+                // engine-tree handles without caching in invalid_headers.
                 Self::other(err)
             }
         }


### PR DESCRIPTION
## Summary
- Fixes #313 (engine stalls permanently after rejecting an invalid block)
- Reclassify `BscBlockValidationError::FutureBlock` from `Validation` to `Internal` error, preventing it from being cached in engine-tree's `invalid_headers`
- Depends on companion PR bnb-chain/reth#131 which makes engine-tree handle `Internal` block execution errors gracefully (reject without caching, without crashing)

## Root cause analysis
The stall was caused by a chain of three design mismatches:

1. **Error misclassification**: `FutureBlock` (proposer in backoff period, block valid after short delay) was mapped to `BlockExecutionError::Validation`, same as permanent consensus violations like `WrongHeaderSigner`

2. **invalid_headers cache poisoning**: Engine-tree cached the block in `invalid_headers`, then cascade-rejected all descendant blocks via `find_invalid_ancestor` — even blocks from different validators at the same height

3. **No recovery path**: Subsequent gossip blocks returned `Syncing` (parent state missing) and were silently dropped. The cache eviction threshold (128 hits) was never reached because dropped blocks don't trigger cache lookups

In BSC geth, the equivalent `invalid_headers` cache (`invalidTipsets`) only exists in the Engine API path (`eth/catalyst/api.go`), NOT in the P2P gossip/fetcher path. Gossip blocks always get a fresh execution attempt. The `SetBadBlockCallback` for the downloader is even commented out (line 158).

## Changes
**`src/node/evm/error.rs`**: `FutureBlock` now maps to `Self::other(err)` → `BlockExecutionError::Internal` instead of `BlockExecutionError::Validation`

## Test plan
- [x] `cargo check` passes
- [x] All block_import tests pass
- [ ] Integration test: node receives FutureBlock → rejects without stalling, next valid block at same height succeeds
- [ ] Validator test: node recovers from FutureBlock without missing turns or being slashed