### PR TITLE
fix(trace): classify BSC system txs before replay validation

### DIFF
--- a/src/evm/api/exec.rs
+++ b/src/evm/api/exec.rs
@@ -32,6 +32,8 @@ where
     }
 
     fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+        let mut tx = tx;
+        self.prepare_tx_for_execution(&mut tx);
         self.inner.ctx.set_tx(tx);
         BscHandler::new().run(self)
     }
@@ -41,6 +43,7 @@ where
     }
 
     fn replay(&mut self) -> Result<ResultAndState, Self::Error> {
+        self.prepare_current_tx_for_execution();
         BscHandler::new().run(self).map(|result| {
             let state = self.finalize();
             ResultAndState::new(result, state)
@@ -69,6 +72,8 @@ where
     }
 
     fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+        let mut tx = tx;
+        self.prepare_tx_for_execution(&mut tx);
         self.inner.ctx.set_tx(tx);
         BscHandler::new().inspect_run(self)
     }

--- a/src/evm/api/mod.rs
+++ b/src/evm/api/mod.rs
@@ -80,6 +80,25 @@ impl<DB: Database, I> BscEvm<DB, I> {
     pub fn ctx_mut(&mut self) -> &mut BscContext<DB> {
         &mut self.inner.ctx
     }
+
+    fn detect_system_transaction(&self, tx: &BscTxEnv) -> bool {
+        use crate::system_contracts::is_invoke_system_contract;
+        use revm::primitives::TxKind;
+
+        matches!(tx.base.kind, TxKind::Call(to)
+            if tx.base.caller == self.block.beneficiary
+                && is_invoke_system_contract(&to)
+                && tx.base.gas_price == 0)
+    }
+
+    pub(crate) fn prepare_tx_for_execution(&self, tx: &mut BscTxEnv) {
+        tx.is_system_transaction = self.detect_system_transaction(tx);
+    }
+
+    pub(crate) fn prepare_current_tx_for_execution(&mut self) {
+        let is_system_transaction = self.detect_system_transaction(&self.inner.ctx.tx);
+        self.inner.ctx.tx.is_system_transaction = is_system_transaction;
+    }
 }
 
 impl<DB: Database, I> Deref for BscEvm<DB, I> {
@@ -235,7 +254,7 @@ mod tests {
     use reth_evm::EvmEnv;
     use revm::{
         context::{BlockEnv, CfgEnv, TxEnv},
-        context_interface::result::{ExecutionResult, HaltReason},
+        context_interface::result::{ExecutionResult, HaltReason, InvalidTransaction},
         handler::instructions::EthInstructions,
         inspector::NoOpInspector,
         primitives::{hardfork::SpecId, Address, Bytes, TxKind, U256},
@@ -343,6 +362,61 @@ mod tests {
         assert!(
             mismatched_result.is_success(),
             "latest-spec instruction table should succeed with this gas limit"
+        );
+    }
+
+    #[test]
+    fn replay_marks_system_tx_before_validation() {
+        use crate::hardforks::bsc::BscHardfork;
+
+        let spec = BscHardfork::Osaka;
+        let mut cfg_env = CfgEnv::new_with_spec(spec).with_chain_id(56);
+        cfg_env.tx_gas_limit_cap = Some(2u64.pow(24));
+
+        let beneficiary = Address::from([0x10; 20]);
+        let system_contract = Address::from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00]);
+
+        let block_env = BlockEnv {
+            beneficiary,
+            prevrandao: Some(U256::from(1).into()),
+            ..Default::default()
+        };
+        let env = EvmEnv::new(cfg_env, block_env);
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            beneficiary,
+            AccountInfo { balance: U256::from(1_000_000_000_000u64), ..AccountInfo::default() },
+        );
+        db.insert_account_info(system_contract, AccountInfo::default());
+
+        let tx = BscTxEnv::new(
+            TxEnv::builder()
+                .caller(beneficiary)
+                .chain_id(Some(56))
+                .gas_limit(i64::MAX as u64)
+                .gas_price(0)
+                .kind(TxKind::Call(system_contract))
+                .build()
+                .expect("tx env should build"),
+        );
+
+        let mut evm = BscEvm::new(env, db, NoOpInspector, false, true);
+        evm.inner.ctx.tx = tx;
+        evm.prepare_current_tx_for_execution();
+
+        let result = evm.replay();
+        match result {
+            Err(revm::context::result::EVMError::Transaction(
+                InvalidTransaction::TxGasLimitGreaterThanCap { .. },
+            )) => panic!("system transaction was not classified before validation"),
+            _ => {}
+        }
+
+        assert!(
+            evm.inner.ctx.tx.is_system_transaction,
+            "system transaction should be classified before replay validation"
         );
     }
 }


### PR DESCRIPTION
### Description

Classify BSC system transactions before entering `BscHandler::run()` for replay and trace execution paths.

This fixes `trace_transaction` returning `-32000 intrinsic gas too high` for valid mined BSC system transactions, including validator reward/finality transactions to `0x0000000000000000000000000000000000001000`.

### Rationale

`is_system_transaction` was being set too late for the replay path. Validation runs inside `BscHandler::run()`, so replayed system transactions could still be treated as normal user transactions and fail gas-limit validation before execution began.

By marking system transactions before `run()` starts, replay validation sees the correct transaction type and the existing system-tx bypass applies as intended.

### Example

Before this change, the following mined BSC transactions failed on `trace_transaction` with `-32000 intrinsic gas too high`:

- `0x149f35718b0bb4b84ddba78b437e41ddd98635faac70e96ef32152295a75d407`
- `0x8951fb7ba554066c70e1986ab5cfa9095a213a0a016ceb8a9fb87cc5f436a003`
- `0xf3b90e75a74dbf9fb3cab7dd46aaf4170a2cc596febb6334f3da8671bcca3f62`
- `0x3a16d430edf504f66cbb83e91f9962e76a5375ebf3ff36917f0101f14945131f`

After building this patch into a test image and deploying it to a live archive node, all 4 returned normal trace data successfully.

### Changes

Notable changes:
* add early BSC system-transaction detection helpers on `BscEvm`
* call that detection before `run()` in `transact_one`, `inspect_one_tx`, and `replay`
* add a regression test covering replay validation for a system transaction shape

### Potential Impacts
* replay and trace execution now classify system transactions earlier, which changes validation behavior only for transactions that already match BSC system-tx criteria
* no expected behavior change for normal user transactions
