### PR TITLE
fix: resolve some issues in cross region test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project shape
+
+`reth-bsc` is **not** a fork of Reth. It is a downstream crate that re-uses Reth's `NodeBuilder` API to assemble a BSC-compatible client. Everything BSC-specific (Parlia consensus, BSC hardforks, system contracts, PoSA mining, MEV/Parlia/Miner RPCs, EVN peer features, BSC precompiles) lives here; generic EL behavior comes from upstream Reth pinned by git `rev` in `Cargo.toml`.
+
+- Workspace members: the root crate (binary `reth-bsc`, library `reth_bsc`) and `testing/bsc-ef-tests` (execution-spec tests harness).
+- All `reth-*` deps are pinned to one commit in `Cargo.toml` (currently `bnb-chain/reth` rev `ef46a48…`). If you change the Reth rev, update **every** `reth-*` line — a mismatched rev produces duplicate-crate build failures. The `testing/bsc-ef-tests/Cargo.toml` uses `branch = "develop"` of the same fork; that's intentional but keep it aligned when bumping.
+- Triedb backend (`--statedb.triedb`) pulls `rust-eth-triedb*` from `bnb-chain/reth-bsc-triedb` on the `develop` branch.
+- `build.rs` scans `src/system_contracts/<hardfork>/{mainnet,chapel,rialto}/*` at build time and emits `src/system_contracts/embedded_contracts.rs` (a `phf_map` keyed as `"<hardfork>_<network>_<contract>"`). It also records the git SHA into `RETH_BSC_GIT_SHA` / `RETH_BSC_GIT_SHA_LONG` used at startup and in the P2P client string. If you add a new hardfork directory with system contracts, add it to the `hardforks` list in `build.rs` so cargo rebuilds when those files change.
+
+## Common commands
+
+Build:
+```bash
+cargo build                               # debug
+cargo build --release                     # plain release
+make build                                # release + jemalloc,asm-keccak + target-cpu=native
+make maxperf                              # LTO=fat, single codegen-unit release
+make bench-test                           # maxperf + `bench-test` feature (exposes engine_forkchoiceUpdatedV1)
+```
+The `jemalloc` feature is enabled by default and requires `tikv-jemallocator` on Unix; do not build with `--no-default-features` casually.
+
+Lint / hygiene (match CI in `.github/workflows/ci.yml`):
+```bash
+cargo check
+cargo clippy --workspace --tests --all-features     # CI runs with RUSTFLAGS="-D warnings"
+cargo +nightly udeps --workspace --lib --examples --tests --benches --all-features --locked
+cargo fmt                                           # nightly rustfmt settings in rustfmt.toml
+```
+
+Tests:
+```bash
+cargo test --all -- --test-threads=1                 # CI setting; many tests touch global OnceLocks / env
+cargo test -p reth_bsc <test_name>                   # run a single test (substring match)
+cargo test -p reth_bsc module::path::test_fn -- --exact --nocapture
+```
+
+Execution-spec tests (network-download fixtures):
+```bash
+make download-eest      # pulls EEST v5.4.0 fixtures into testing/bsc-ef-tests/execution-spec-tests
+make ef-tests           # cargo test -p bsc-ef-tests --release --features ef-tests,jemalloc,asm-keccak
+make ef-tests-nextest   # same, via cargo-nextest
+make clean-eest
+```
+
+Run (binary is `reth-bsc`, chain ids `bsc`, `bsc-testnet`; optional `--statedb.triedb`):
+```bash
+./target/release/reth-bsc node --chain bsc --datadir ./data_dir
+./target/release/reth-bsc node --full --chain bsc --datadir ./data_dir            # full node
+./target/release/reth-bsc node --chain bsc --datadir ./data_dir --statedb.triedb  # triedb backend
+```
+
+## Where the wiring lives
+
+The non-obvious cross-cutting pieces — read these together when anything spans components:
+
+- **`src/main.rs`** is the integration point. It parses `BscCliArgs`, then uses `Cli::<BscChainSpecParser, BscCliArgs>::parse().run_with_components::<BscNode>(...)`. The async closure:
+  1. applies the genesis-hash override,
+  2. hydrates the global `MiningConfig` (CLI > env > defaults) and loads the signing key from keystore / hex,
+  3. initializes the global BLS signer (CLI > env),
+  4. builds and stores `EvnConfig` (EVN peer-tx-broadcast policy),
+  5. parses proxyed peer IDs,
+  6. calls `.extend_rpc_modules(...)` to register BSC-only RPC namespaces (`parlia`, `mev`, `miner`, BSC eth-extensions, blob). It **removes** reth's built-ins `miner_setExtra`/`setGasPrice`/`setGasLimit` and `eth_coinbase` before registering our versions — don't re-add them upstream-style,
+  7. sends the beacon engine handle back to the network via a oneshot and stores the engine-API mpsc sender globally.
+
+- **`src/shared.rs`** holds nearly all cross-component globals as `OnceLock`s + a few `RwLock`s: snapshot provider, header/block-number accessors, engine-API sender, network handle, payload-events broadcast, bid-package queue, proxyed peer IDs, IPC client, miner runtime knobs, etc. Components register into these from different phases of startup (consensus module publishes the snapshot provider, then the miner waits up to ~10s for it — see `node::engine::BscPayloadServiceBuilder`). When adding a cross-phase dependency, extend `shared.rs` rather than threading handles through builders.
+
+- **`src/node/mod.rs` → `BscNode`** composes: `BscPoolBuilder` (pool), `BscExecutorBuilder` (EVM), `BscPayloadServiceBuilder` (payload + miner bootstrap), `BscNetworkBuilder`, `BscConsensusBuilder`. `BscNodeAddOns` wires `BscEthApiBuilder` plus engine/payload validators (`src/node/engine_api/`).
+
+- **Consensus (`src/consensus/parlia/`)** is PoA via Parlia: `consensus.rs` is the main engine, `snapshot.rs` maintains validator-set history at epoch boundaries, `provider.rs` exposes `SnapshotProvider` (published to `shared::SNAPSHOT_PROVIDER`), `vote_pool.rs` + `vote.rs` + `bls_signer.rs` implement BLS vote attestation, `forkchoice_rule.rs` is the BSC-specific fork-choice rule, `go_rng.rs` reproduces Go's RNG for validator-order determinism.
+
+- **EVM extensions (`src/evm/` and `src/node/evm/`)**: `src/evm/handler.rs` and `src/evm/precompiles/*` add BSC-specific precompiles (BLS, CometBFT/Tendermint light-client, IAVL, double-sign, `tm_secp256k1`). `src/node/evm/{pre_execution,post_execution}.rs` implement BSC's pre/post-block hooks (system-contract calls for epoch transitions, fee distribution, validator updates). `src/evm/blacklist.rs` is the BSC transaction blacklist.
+
+- **PoSA mining (`src/node/miner/`)**: optional; started by `BscPayloadServiceBuilder` only when `MiningConfig::is_mining_enabled()` is true. Entry point `BscMiner::start` runs the build-loop; `payload.rs` builds blocks, `bid_simulator.rs` runs MEV bid simulation, `signer.rs` wraps the validator signing key, `util.rs` has timing/turn/backoff helpers. The miner waits for the snapshot provider to be published by consensus before starting. Configuration flows: CLI `--mining.*` → env `BSC_MINING_*` / `BSC_PRIVATE_KEY` / `BSC_GAS_LIMIT` / `BSC_MINING_INTERVAL_MS` → `MiningConfig::from_env()` → `set_global_mining_config`. See `MINING.md` and `MINING_QUICKSTART.md` for user-facing docs.
+
+- **Hardforks (`src/hardforks/bsc.rs`)** defines the full BSC hardfork schedule (Ramanujan → Niels → MirrorSync → Bruno → Euler → Gibbs → Nano → Moran → Planck → Luban → Plato → Hertz → Kepler → Feynman → FeynmanFix → HaberFix → Bohr → Pascal → Prague → Lorentz → Maxwell → Fermi …). BSC timestamps are real block timestamps (not EL post-merge seconds-since-unix-epoch) and many system-contract behaviors are keyed to them. When touching fork gating, check both this file and `src/chainspec/{bsc,bsc_chapel,bsc_rialto}.rs`.
+
+- **Network (`src/node/network/`)**: `bsc_protocol/` is the custom BSC sub-protocol, `handshake.rs` / `upgrade_status.rs` implement BSC's upgrade-status handshake extension (and signal the EVN intent). `evn.rs` + `evn_peers.rs` implement the Enhanced Validator Network behavior (disable incoming tx broadcast from flagged peers; activates only after head-timestamp lag < `BSC_EVN_SYNC_LAG_SECS`, default 30s). `block_import/` is the BSC block-import service (separate `IncomingBlock` vs `IncomingMinedBlock` channels).
+
+- **Chainspec (`src/chainspec/`)**: `BscChainSpec` wraps reth's `ChainSpec`. `genesis_override.rs` lets `--genesis-hash` inject a custom genesis hash (the miner/consensus must treat it consistently — consult both sides before changing). Supported chains: `bsc` (mainnet, genesis.json), `bsc-testnet` / `chapel`, `bsc-rialto`, `local` (local.rs, uses `genesis_local.json` which is gitignored).
+
+- **RPC namespaces (`src/rpc/`)**: `parlia.rs` (validator/snapshot queries), `mev.rs` (bid submission + MEV APIs), `miner.rs` (BSC redefinitions of `miner_set*`), `eth_ext.rs` (`eth_coinbase`, `eth_health`), `blob.rs` (blob fetching from pool/provider). All are merged in `main.rs`'s `.extend_rpc_modules` closure.
+
+## Things that commonly bite
+
+- **Global `OnceLock`s in `shared.rs`**: tests that instantiate a node or publish into globals must run single-threaded (`--test-threads=1`, as CI does). Don't `expect` on `set_*` globals — every setter returns `Err` if already initialized; real callers log a warning and continue.
+- **Pinned Reth rev**: bump every `reth-*` entry in `Cargo.toml` together. The ef-tests crate uses `branch = "develop"`; if you bump the rev, also verify its compatibility with whatever `develop` resolves to that day.
+- **Auto-generated file**: `src/system_contracts/embedded_contracts.rs` is written by `build.rs` — don't edit by hand; add/modify under `src/system_contracts/<hardfork>/<network>/` and extend the `hardforks` list in `build.rs` if a new hardfork is introduced.
+- **IPC is required**: `main.rs` panics if `--ipc.disable` is set; many BSC features (local mining RPC bridge, engine-API plumbing) assume IPC is available.
+- **EVN is off by default, activates late**: even with `--evn.enabled`, behavior is gated on head-timestamp lag (`BSC_EVN_SYNC_LAG_SECS`, default 30s) so it won't kick in mid-sync.
+- **CI runs cargo test with `--test-threads=1`**: parallel runs will flake because of the globals above.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7420,7 +7420,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7466,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7475,7 +7475,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "reth-chain-state",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7490,7 +7490,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7506,7 +7506,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7542,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7642,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7690,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7767,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7778,7 +7778,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7895,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7908,7 +7908,7 @@ dependencies = [
  "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7943,7 +7943,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7959,7 +7959,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -7978,7 +7978,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8006,7 +8006,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "futures",
  "pin-project",
@@ -8077,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8104,7 +8104,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8140,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8168,7 +8168,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8199,7 +8199,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8232,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8246,7 +8246,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8261,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8285,7 +8285,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "clap",
  "eyre",
@@ -8307,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8323,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8355,7 +8355,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8427,7 +8427,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8461,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8509,7 +8509,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "serde",
  "serde_json",
@@ -8554,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "futures",
  "metrics",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8660,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8674,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8704,7 +8704,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8755,7 +8755,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8793,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8824,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8919,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8975,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9037,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9074,7 +9074,7 @@ dependencies = [
  "metrics-util",
  "procfs 0.17.0",
  "reqwest 0.12.28",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9085,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9097,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9121,7 +9121,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9178,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9192,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9247,7 +9247,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9282,7 +9282,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9359,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9420,7 +9420,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9455,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9485,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9500,7 +9500,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-api",
  "reth-node-core",
  "reth-primitives-traits",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9548,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9559,7 +9559,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9578,7 +9578,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9624,7 +9624,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9649,7 +9649,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -9686,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9754,7 +9754,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9764,7 +9764,7 @@ dependencies = [
  "metrics",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9852,7 +9852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9877,7 +9877,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9903,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9913,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "clap",
  "eyre",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "clap",
  "eyre",
@@ -9946,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9967,7 +9967,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10042,14 +10042,14 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10074,7 +10074,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10097,7 +10097,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-primitives-traits",
  "reth-trie-common",
  "smallvec",
@@ -10107,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10115,7 +10115,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-trie-common",
  "reth-trie-sparse",
  "smallvec",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
+source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
 dependencies = [
  "zstd",
 ]
@@ -10209,7 +10209,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7420,7 +7420,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7466,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7475,7 +7475,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "reth-chain-state",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7490,7 +7490,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7506,7 +7506,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7542,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7642,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7690,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7767,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7778,7 +7778,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7895,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7908,7 +7908,7 @@ dependencies = [
  "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7943,7 +7943,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7959,7 +7959,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -7978,7 +7978,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8006,7 +8006,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "futures",
  "pin-project",
@@ -8077,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8104,7 +8104,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8140,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8168,7 +8168,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8199,7 +8199,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8232,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8246,7 +8246,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8261,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8285,7 +8285,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "clap",
  "eyre",
@@ -8307,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8323,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8355,7 +8355,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8427,7 +8427,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8461,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8509,7 +8509,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "serde",
  "serde_json",
@@ -8554,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "futures",
  "metrics",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8660,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8674,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8704,7 +8704,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8755,7 +8755,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8793,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8824,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8919,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8975,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9037,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9074,7 +9074,7 @@ dependencies = [
  "metrics-util",
  "procfs 0.17.0",
  "reqwest 0.12.28",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9085,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9097,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9121,7 +9121,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9178,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9192,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9247,7 +9247,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9282,7 +9282,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9359,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9420,7 +9420,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9455,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9485,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9500,7 +9500,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-api",
  "reth-node-core",
  "reth-primitives-traits",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9548,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9559,7 +9559,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9578,7 +9578,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9624,7 +9624,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9649,7 +9649,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -9686,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9754,7 +9754,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9764,7 +9764,7 @@ dependencies = [
  "metrics",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9852,7 +9852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9877,7 +9877,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9903,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9913,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "clap",
  "eyre",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "clap",
  "eyre",
@@ -9946,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9967,7 +9967,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10042,14 +10042,14 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10074,7 +10074,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10097,7 +10097,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-primitives-traits",
  "reth-trie-common",
  "smallvec",
@@ -10107,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10115,7 +10115,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-trie-common",
  "reth-trie-sparse",
  "smallvec",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c#232a9a41efd5c228647a4b4dced54d5528090f1c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928#ed59a0985b62f4964b389b1666b73b03b39b6928"
 dependencies = [
  "zstd",
 ]
@@ -10209,7 +10209,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=232a9a41efd5c228647a4b4dced54d5528090f1c)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=ed59a0985b62f4964b389b1666b73b03b39b6928)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7420,7 +7420,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7466,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7475,7 +7475,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "reth-chain-state",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7490,7 +7490,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7506,7 +7506,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7542,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7642,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7690,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7767,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7778,7 +7778,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7895,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7908,7 +7908,7 @@ dependencies = [
  "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7943,7 +7943,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7959,7 +7959,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -7978,7 +7978,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8006,7 +8006,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "futures",
  "pin-project",
@@ -8077,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8104,7 +8104,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8140,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8168,7 +8168,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8199,7 +8199,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8232,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8246,7 +8246,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8261,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8285,7 +8285,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "clap",
  "eyre",
@@ -8307,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8323,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8355,7 +8355,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8427,7 +8427,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8461,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8509,7 +8509,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8544,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "serde",
  "serde_json",
@@ -8554,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "futures",
  "metrics",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8660,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8674,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8704,7 +8704,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8755,7 +8755,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8793,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8824,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8861,6 +8861,7 @@ dependencies = [
  "fdlimit",
  "futures",
  "jsonrpsee",
+ "metrics",
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
@@ -8918,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8974,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9012,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9036,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9060,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9073,7 +9074,7 @@ dependencies = [
  "metrics-util",
  "procfs 0.17.0",
  "reqwest 0.12.28",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9084,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9096,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9111,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9120,7 +9121,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9132,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9144,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9167,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9177,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9191,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9224,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9246,7 +9247,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9260,6 +9261,7 @@ dependencies = [
  "revm-database",
  "revm-state",
  "rust-eth-triedb",
+ "rust-eth-triedb-common",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -9268,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9280,7 +9282,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9296,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9311,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9330,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9357,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9370,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9418,7 +9420,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9453,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9483,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9498,7 +9500,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-api",
  "reth-node-core",
  "reth-primitives-traits",
@@ -9524,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9546,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9557,7 +9559,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9576,7 +9578,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9622,7 +9624,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9647,7 +9649,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9670,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -9684,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9700,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9752,7 +9754,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9762,7 +9764,7 @@ dependencies = [
  "metrics",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9779,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9793,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9813,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9826,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9850,7 +9852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9867,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9875,7 +9877,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9885,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9901,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9911,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "clap",
  "eyre",
@@ -9926,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "clap",
  "eyre",
@@ -9944,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9965,7 +9967,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -9985,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9999,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10011,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10040,14 +10042,14 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
@@ -10061,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10072,7 +10074,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
@@ -10086,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10095,7 +10097,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-primitives-traits",
  "reth-trie-common",
  "smallvec",
@@ -10105,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10113,7 +10115,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-trie-common",
  "reth-trie-sparse",
  "smallvec",
@@ -10123,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.9#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
+source = "git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a#dc3ef30890d06057867da6ea93102478ac63737a"
 dependencies = [
  "zstd",
 ]
@@ -10207,7 +10209,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?tag=v0.0.9)",
+ "reth-metrics 1.10.2 (git+https://github.com/bnb-chain/reth.git?rev=dc3ef30890d06057867da6ea93102478ac63737a)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
 
 # triedb dependencies
 rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = [
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
 
 # triedb dependencies
 rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = [
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
 
 # triedb dependencies
 rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.2" }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,26 @@
-use std::{collections::BTreeMap, fs};
+use std::{collections::BTreeMap, fs, process::Command};
 
 fn main() {
+    // Emit reth-bsc git SHA for startup version logging.
+    let git_sha_short = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| if o.status.success() { String::from_utf8(o.stdout).ok() } else { None })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let git_sha_long = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| if o.status.success() { String::from_utf8(o.stdout).ok() } else { None })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=RETH_BSC_GIT_SHA={git_sha_short}");
+    println!("cargo:rustc-env=RETH_BSC_GIT_SHA_LONG={git_sha_long}");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
+
     // Define hardforks that contain system contracts (matching hardfork_to_dir_name function)
     let hardforks = vec![
         "bruno",

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -617,12 +617,17 @@ where
         )
     }
 
+    /// Set `new_header.timestamp` (seconds) and `mix_hash` (Lorentz-era ms) based on
+    /// `parent + block_interval + back_off_time` (with a wall-clock ceiling fallback).
+    /// Returns the computed millisecond timestamp so callers can cache it and feed the
+    /// same value back into `finalize_new_header`, avoiding the seconds/ms drift bug
+    /// triggered when the ceiling path fires again at sealing time.
     pub fn prepare_timestamp(
         &self,
         parent_snap: &Snapshot,
         parent_header: &Header,
         new_header: &mut Header,
-    ) {
+    ) -> u64 {
         let millisecond_timestamp =
             self.block_time_for_ramanujan_fork(parent_snap, parent_header, new_header);
         new_header.timestamp = millisecond_timestamp / 1000;
@@ -631,6 +636,7 @@ where
         } else {
             new_header.mix_hash = B256::ZERO;
         }
+        millisecond_timestamp
     }
 
     pub fn prepare_validators(

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -620,8 +620,7 @@ where
     /// Set `new_header.timestamp` (seconds) and `mix_hash` (Lorentz-era ms) based on
     /// `parent + block_interval + back_off_time` (with a wall-clock ceiling fallback).
     /// Returns the computed millisecond timestamp so callers can cache it and feed the
-    /// same value back into `finalize_new_header`, avoiding the seconds/ms drift bug
-    /// triggered when the ceiling path fires again at sealing time.
+    /// same value back into `finalize_new_header`.
     pub fn prepare_timestamp(
         &self,
         parent_snap: &Snapshot,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
 use clap::{Args, Parser};
-use reth::{builder::NodeHandle, cli::Cli, consensus::FullConsensus};
+use reth::{
+    builder::NodeHandle,
+    cli::Cli,
+    consensus::FullConsensus,
+    version::{default_reth_version_metadata, try_init_version_metadata},
+};
 use reth_bsc::consensus::parlia::bls_signer;
 use reth_bsc::node::consensus::BscConsensus;
 use reth_bsc::{
@@ -109,6 +114,26 @@ pub struct BscCliArgs {
 }
 
 fn main() -> eyre::Result<()> {
+    // Override reth's global version metadata so startup/P2P logs identify
+    // this binary as Reth-BSC with its own version + commit.
+    {
+        use std::borrow::Cow;
+        let pkg_version = env!("CARGO_PKG_VERSION");
+        let git_sha_short = env!("RETH_BSC_GIT_SHA");
+        let git_sha_long = env!("RETH_BSC_GIT_SHA_LONG");
+        let mut md = default_reth_version_metadata();
+        md.name_client = Cow::Borrowed("Reth-BSC");
+        md.cargo_pkg_version = Cow::Borrowed(pkg_version);
+        md.vergen_git_sha = Cow::Borrowed(git_sha_short);
+        md.vergen_git_sha_long = Cow::Borrowed(git_sha_long);
+        md.short_version = Cow::Owned(format!("{pkg_version} ({git_sha_short})"));
+        md.p2p_client_version = Cow::Owned(format!(
+            "reth-bsc/v{pkg_version}-{git_sha_short}/{}",
+            std::env::consts::OS,
+        ));
+        let _ = try_init_version_metadata(md);
+    }
+
     reth_cli_util::sigsegv_handler::install();
 
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -306,9 +306,9 @@ where
                 .snapshot_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
             // `assemble_block` is not used by the miner pipeline (see note above). No
-            // cached planned ms is available here, so compute one locally via the same
+            // cached block timestamp is available here, so compute one locally via the same
             // formula prepare_timestamp uses.
-            let planned_block_ts_ms = self.parlia.block_time_for_ramanujan_fork(
+            let block_timestamp_ms = self.parlia.block_time_for_ramanujan_fork(
                 &parent_snap,
                 parent_header.header(),
                 &header,
@@ -319,7 +319,7 @@ where
                 &parent_header,
                 &mut header,
                 &snapshot_provider,
-                planned_block_ts_ms,
+                block_timestamp_ms,
             ).map_err(|e| BlockExecutionError::msg(format!("Failed to finalize header: {}", e)))?;
 
             let header_hash = keccak256(alloy_rlp::encode(&header));

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -305,9 +305,6 @@ where
             let parent_snap = snapshot_provider
                 .snapshot_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
-            // `assemble_block` is not used by the miner pipeline (see note above). No
-            // cached block timestamp is available here, so compute one locally via the same
-            // formula prepare_timestamp uses.
             let block_timestamp_ms = self.parlia.block_time_for_ramanujan_fork(
                 &parent_snap,
                 parent_header.header(),

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -305,12 +305,21 @@ where
             let parent_snap = snapshot_provider
                 .snapshot_by_hash(&header.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
+            // `assemble_block` is not used by the miner pipeline (see note above). No
+            // cached planned ms is available here, so compute one locally via the same
+            // formula prepare_timestamp uses.
+            let planned_block_ts_ms = self.parlia.block_time_for_ramanujan_fork(
+                &parent_snap,
+                parent_header.header(),
+                &header,
+            );
             finalize_new_header(
-                self.parlia.clone(), 
-                &parent_snap, 
-                &parent_header, 
+                self.parlia.clone(),
+                &parent_snap,
+                &parent_header,
                 &mut header,
                 &snapshot_provider,
+                planned_block_ts_ms,
             ).map_err(|e| BlockExecutionError::msg(format!("Failed to finalize header: {}", e)))?;
 
             let header_hash = keccak256(alloy_rlp::encode(&header));

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -196,7 +196,6 @@ where
             header: None,
             is_inturn: true,
             cached_reads: None,
-            // Both populated by prepare_new_attributes below.
             block_timestamp_ms: 0,
             end_mining_timestamp_ms: 0,
         };

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -196,6 +196,8 @@ where
             header: None,
             is_inturn: true,
             cached_reads: None,
+            // Populated by prepare_new_attributes below.
+            planned_block_ts_ms: 0,
         };
         let parent_snapshot = mining_ctx.parent_snapshot.clone();
         let attributes = prepare_new_attributes(
@@ -592,7 +594,7 @@ where
         }
 
         let mut plain = sealed_block.clone_block();
-        plain.body.sidecars = Some(bid_runtime.blob_sidecars.clone());
+        plain.body.sidecars = if bid_runtime.blob_sidecars.is_empty() { None } else { Some(bid_runtime.blob_sidecars.clone()) };
         sealed_block = Arc::new(plain.into());
 
         let requests = execution_result.requests.clone();

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -196,8 +196,9 @@ where
             header: None,
             is_inturn: true,
             cached_reads: None,
-            // Populated by prepare_new_attributes below.
-            planned_block_ts_ms: 0,
+            // Both populated by prepare_new_attributes below.
+            block_timestamp_ms: 0,
+            end_mining_timestamp_ms: 0,
         };
         let parent_snapshot = mining_ctx.parent_snapshot.clone();
         let attributes = prepare_new_attributes(

--- a/src/node/miner/bsc_miner.rs
+++ b/src/node/miner/bsc_miner.rs
@@ -86,49 +86,8 @@ pub struct NewWorkWorker<Provider> {
     last_triggered_tip: Option<alloy_primitives::B256>,
 }
 
-/// Returns `true` when network conditions allow block production.
-///
-/// One semantic gate plus a startup-safety skip. Each early-return emits
-/// a `DEBUG` log naming the specific path so a stuck validator can be
-/// diagnosed from logs alone.
-///
-/// **No connected peers.** Mining while alone produces a fork chain
-/// that the rest of the network cannot accept back after reconnect:
-/// the remote peer's pathdb disk layer is pinned at its own tip with no
-/// diff layers retained, so it cannot execute blocks built on an older
-/// common ancestor. See
-/// `docs/superpowers/specs/2026-04-18-pathdb-gap-fork-livelock-scenario.md`
-/// for the full scenario analysis.
-///
-/// Intentional limitations:
-///
-/// - A fresh-genesis bootstrap where no peers exist anywhere yet will
-///   skip mining forever. Bootstrapping a brand-new network with this
-///   code is **not supported today**; revisit if/when an explicit
-///   bootstrap mode is added.
-///
-/// - This function intentionally does **not** gate on
-///   `NetworkHandle::is_syncing()`. That flag is set to `Syncing` at
-///   process start (`reth/crates/node/builder/src/launch/engine.rs:165`)
-///   and is only cleared to `Idle` on a `CanonicalChainCommitted`
-///   event — i.e., after a block has been committed to the canonical
-///   chain. In a small-validator-count network (e.g. `N = 2` on
-///   qanet) where all validators restart together and the backends
-///   are already aligned, no backfill is kicked off and no block is
-///   committed post-startup, so the flag never flips back. Combined
-///   with the peer gate above, that produced a hard deadlock: miner
-///   waits on `is_syncing == false`, which needs a committed block,
-///   which needs a miner to run — circular. The trade-off of removing
-///   the gate: during a *real* backfill window the miner may briefly
-///   produce blocks on a stale tip; peers will reject them as
-///   out-of-date, so the cost is wasted work rather than a
-///   correctness issue. See the "Non-Goals" section of
-///   `docs/superpowers/specs/2026-04-20-peer-gated-mining-design.md`.
-///
-/// Also returns `false` (skip) when the network handle is not yet
-/// installed. That window exists briefly at startup; skipping during
-/// it is safer than defaulting to "allow mining" when we cannot even
-/// check peer count.
+/// Skip mining when isolated (no peers or network handle not yet installed) to avoid
+/// producing a small fork-chain that peers can't reconcile after reconnect.
 fn is_network_ready_to_mine(tip_number: u64) -> bool {
     let Some(network) = crate::shared::get_network_handle() else {
         debug!(
@@ -769,7 +728,9 @@ where
             config: PayloadConfig::new(Arc::new(mining_ctx.parent_header.clone()), attributes),
             cancel: ManualCancel::default(),
             trace_id: crate::node::miner::payload::generate_trace_id(),
-            min_gas_tip: self.desired_min_gas_tip,
+            min_gas_tip: crate::shared::get_miner_gas_tip()
+                .map(|v| v as u128)
+                .unwrap_or(self.desired_min_gas_tip),
             parent_difflayers: None, // populated once at job start via fetch_triedb_difflayers
         };
 

--- a/src/node/miner/bsc_miner.rs
+++ b/src/node/miner/bsc_miner.rs
@@ -58,13 +58,12 @@ pub struct MiningContext {
     pub parent_snapshot: Arc<crate::consensus::parlia::snapshot::Snapshot>,
     pub is_inturn: bool,
     pub cached_reads: Option<reth_revm::cached::CachedReads>,
-    /// Millisecond timestamp fixed by `prepare_timestamp` for this block. `finalize_new_header`
-    /// uses this cached value instead of re-running `block_time_for_ramanujan_fork` — the
-    /// recomputation at sealing time can fall into the wall-clock ceiling branch, cross a
-    /// second boundary, and desync `header.timestamp` (seconds) from the mix_hash ms, producing
-    /// a header that fails `block_time_verify_for_ramanujan_fork` on every peer.
-    /// Populated by `prepare_new_attributes`.
-    pub planned_block_ts_ms: u64,
+    /// Block timestamp in milliseconds, computed via `block_time_for_ramanujan_fork`
+    /// during mining context initialization.
+    pub block_timestamp_ms: u64,
+    /// End timestamp of the mining job (UNIX epoch ms), computed via `delay_for_ramanujan_fork`
+    /// during mining context initialization.
+    pub end_mining_timestamp_ms: u128,
 }
 
 #[derive(Clone)]
@@ -581,8 +580,9 @@ where
             parent_snapshot: Arc::new(parent_snapshot),
             is_inturn,
             cached_reads: self.maybe_pre_cached(parent_hash),
-            // Populated by prepare_new_attributes once the payload job starts.
-            planned_block_ts_ms: 0,
+            // Both populated by prepare_new_attributes once the payload job starts.
+            block_timestamp_ms: 0,
+            end_mining_timestamp_ms: 0,
         };
 
         debug!("Queuing mining context, next_block: {}", tip.number() + 1);

--- a/src/node/miner/bsc_miner.rs
+++ b/src/node/miner/bsc_miner.rs
@@ -41,8 +41,8 @@ use reth_provider::{
 use reth_revm::cancelled::ManualCancel;
 use reth_tasks::TaskExecutor;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
@@ -51,16 +51,6 @@ use tracing::{debug, error, info, trace, warn};
 /// Maximum number of recently mined blocks to track for double signing prevention
 const RECENT_MINED_BLOCKS_CACHE_SIZE: usize = 100;
 
-/// After this many seconds of `is_syncing() == true` with no canonical events, allow mining
-/// anyway. This breaks the deadlock that occurs when all validators restart simultaneously:
-/// no one produces blocks → no FCU → is_syncing never clears → no mining → deadlock.
-/// 5s ≈ 11 Fermi slots (450 ms each), enough time for a peer to send FCU if any are running.
-const SYNC_GATE_TIMEOUT_SECS: u64 = 5;
-
-/// Tracks when the miner first encountered the sync gate. Used for timeout-based deadlock
-/// recovery when all validators restart simultaneously.
-static SYNC_GATE_FIRST_HIT: OnceLock<Instant> = OnceLock::new();
-
 #[derive(Clone, Debug)]
 pub struct MiningContext {
     pub header: Option<reth_primitives::Header>, // tmp header for payload building.
@@ -68,6 +58,13 @@ pub struct MiningContext {
     pub parent_snapshot: Arc<crate::consensus::parlia::snapshot::Snapshot>,
     pub is_inturn: bool,
     pub cached_reads: Option<reth_revm::cached::CachedReads>,
+    /// Millisecond timestamp fixed by `prepare_timestamp` for this block. `finalize_new_header`
+    /// uses this cached value instead of re-running `block_time_for_ramanujan_fork` — the
+    /// recomputation at sealing time can fall into the wall-clock ceiling branch, cross a
+    /// second boundary, and desync `header.timestamp` (seconds) from the mix_hash ms, producing
+    /// a header that fails `block_time_verify_for_ramanujan_fork` on every peer.
+    /// Populated by `prepare_new_attributes`.
+    pub planned_block_ts_ms: u64,
 }
 
 #[derive(Clone)]
@@ -88,6 +85,72 @@ pub struct NewWorkWorker<Provider> {
     /// Hash of the tip block for which mining was last triggered, used to suppress
     /// periodic-tick retries when no new canonical head has arrived.
     last_triggered_tip: Option<alloy_primitives::B256>,
+}
+
+/// Returns `true` when network conditions allow block production.
+///
+/// One semantic gate plus a startup-safety skip. Each early-return emits
+/// a `DEBUG` log naming the specific path so a stuck validator can be
+/// diagnosed from logs alone.
+///
+/// **No connected peers.** Mining while alone produces a fork chain
+/// that the rest of the network cannot accept back after reconnect:
+/// the remote peer's pathdb disk layer is pinned at its own tip with no
+/// diff layers retained, so it cannot execute blocks built on an older
+/// common ancestor. See
+/// `docs/superpowers/specs/2026-04-18-pathdb-gap-fork-livelock-scenario.md`
+/// for the full scenario analysis.
+///
+/// Intentional limitations:
+///
+/// - A fresh-genesis bootstrap where no peers exist anywhere yet will
+///   skip mining forever. Bootstrapping a brand-new network with this
+///   code is **not supported today**; revisit if/when an explicit
+///   bootstrap mode is added.
+///
+/// - This function intentionally does **not** gate on
+///   `NetworkHandle::is_syncing()`. That flag is set to `Syncing` at
+///   process start (`reth/crates/node/builder/src/launch/engine.rs:165`)
+///   and is only cleared to `Idle` on a `CanonicalChainCommitted`
+///   event — i.e., after a block has been committed to the canonical
+///   chain. In a small-validator-count network (e.g. `N = 2` on
+///   qanet) where all validators restart together and the backends
+///   are already aligned, no backfill is kicked off and no block is
+///   committed post-startup, so the flag never flips back. Combined
+///   with the peer gate above, that produced a hard deadlock: miner
+///   waits on `is_syncing == false`, which needs a committed block,
+///   which needs a miner to run — circular. The trade-off of removing
+///   the gate: during a *real* backfill window the miner may briefly
+///   produce blocks on a stale tip; peers will reject them as
+///   out-of-date, so the cost is wasted work rather than a
+///   correctness issue. See the "Non-Goals" section of
+///   `docs/superpowers/specs/2026-04-20-peer-gated-mining-design.md`.
+///
+/// Also returns `false` (skip) when the network handle is not yet
+/// installed. That window exists briefly at startup; skipping during
+/// it is safer than defaulting to "allow mining" when we cannot even
+/// check peer count.
+fn is_network_ready_to_mine(tip_number: u64) -> bool {
+    let Some(network) = crate::shared::get_network_handle() else {
+        debug!(
+            target: "bsc::miner",
+            tip_number,
+            "Skip mining: network handle not yet available"
+        );
+        return false;
+    };
+
+    use reth_network::PeersInfo;
+    if network.num_connected_peers() == 0 {
+        debug!(
+            target: "bsc::miner",
+            tip_number,
+            "Skip mining: no peers connected"
+        );
+        return false;
+    }
+
+    true
 }
 
 impl<Provider> NewWorkWorker<Provider>
@@ -435,31 +498,8 @@ where
             return;
         }
 
-        // Gate mining on live sync: skip if the node is still backfill-syncing.
-        // Exception: if all validators restart simultaneously, is_syncing() never clears
-        // because no FCU arrives. After SYNC_GATE_TIMEOUT_SECS we allow mining to break
-        // the deadlock.
-        if let Some(network) = crate::shared::get_network_handle() {
-            use reth_network_p2p::sync::SyncStateProvider;
-            if network.is_syncing() {
-                let first_hit = SYNC_GATE_FIRST_HIT.get_or_init(Instant::now);
-                let elapsed = first_hit.elapsed();
-                if elapsed < Duration::from_secs(SYNC_GATE_TIMEOUT_SECS) {
-                    debug!(
-                        target: "bsc::miner",
-                        tip_number = tip.number(),
-                        elapsed_secs = elapsed.as_secs(),
-                        "Skip mining: node is syncing (backfill active)"
-                    );
-                    return;
-                }
-                warn!(
-                    target: "bsc::miner",
-                    tip_number = tip.number(),
-                    elapsed_secs = elapsed.as_secs(),
-                    "Sync gate timeout reached, allowing mining to break potential all-validators-restart deadlock"
-                );
-            }
+        if !is_network_ready_to_mine(tip.number()) {
+            return;
         }
 
         let parent_header = match self.provider.sealed_header_by_hash(tip.hash()) {
@@ -541,6 +581,8 @@ where
             parent_snapshot: Arc::new(parent_snapshot),
             is_inturn,
             cached_reads: self.maybe_pre_cached(parent_hash),
+            // Populated by prepare_new_attributes once the payload job starts.
+            planned_block_ts_ms: 0,
         };
 
         debug!("Queuing mining context, next_block: {}", tip.number() + 1);
@@ -727,9 +769,7 @@ where
             config: PayloadConfig::new(Arc::new(mining_ctx.parent_header.clone()), attributes),
             cancel: ManualCancel::default(),
             trace_id: crate::node::miner::payload::generate_trace_id(),
-            min_gas_tip: crate::shared::get_miner_gas_tip()
-                .map(|v| v as u128)
-                .unwrap_or(self.desired_min_gas_tip),
+            min_gas_tip: self.desired_min_gas_tip,
             parent_difflayers: None, // populated once at job start via fetch_triedb_difflayers
         };
 

--- a/src/node/miner/bsc_miner.rs
+++ b/src/node/miner/bsc_miner.rs
@@ -58,11 +58,9 @@ pub struct MiningContext {
     pub parent_snapshot: Arc<crate::consensus::parlia::snapshot::Snapshot>,
     pub is_inturn: bool,
     pub cached_reads: Option<reth_revm::cached::CachedReads>,
-    /// Block timestamp in milliseconds, computed via `block_time_for_ramanujan_fork`
-    /// during mining context initialization.
+    /// Block timestamp in milliseconds, computed via `block_time_for_ramanujan_fork`.
     pub block_timestamp_ms: u64,
-    /// End timestamp of the mining job (UNIX epoch ms), computed via `delay_for_ramanujan_fork`
-    /// during mining context initialization.
+    /// End timestamp of the mining job (UNIX epoch ms), computed via `delay_for_ramanujan_fork`.
     pub end_mining_timestamp_ms: u128,
 }
 
@@ -87,13 +85,13 @@ pub struct NewWorkWorker<Provider> {
 }
 
 /// Skip mining when isolated (no peers or network handle not yet installed) to avoid
-/// producing a small fork-chain that peers can't reconcile after reconnect.
+/// producing a small fork-chain that peers do not know about after reconnect.
 fn is_network_ready_to_mine(tip_number: u64) -> bool {
     let Some(network) = crate::shared::get_network_handle() else {
         debug!(
             target: "bsc::miner",
             tip_number,
-            "Skip mining: network handle not yet available"
+            "Skip mining due to network handle not yet available"
         );
         return false;
     };
@@ -103,7 +101,7 @@ fn is_network_ready_to_mine(tip_number: u64) -> bool {
         debug!(
             target: "bsc::miner",
             tip_number,
-            "Skip mining: no peers connected"
+            "Skip mining due to no peers connected"
         );
         return false;
     }
@@ -539,7 +537,6 @@ where
             parent_snapshot: Arc::new(parent_snapshot),
             is_inturn,
             cached_reads: self.maybe_pre_cached(parent_hash),
-            // Both populated by prepare_new_attributes once the payload job starts.
             block_timestamp_ms: 0,
             end_mining_timestamp_ms: 0,
         };

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -1110,10 +1110,6 @@ where
     builder: Arc<BscPayloadBuilder<Pool, Client, EvmConfig>>,
     /// Timeout for payload building
     timeout: std::time::Duration,
-    /// Expected end timestamp (milliseconds since UNIX epoch).
-    ///
-    /// Initialized in `new()` as: `now_ms + parlia.delay_for_ramanujan_fork(... )`.
-    expected_end_timestamp_ms: u128,
     /// Message queue for processing build arguments
     try_build_rx: mpsc::UnboundedReceiver<()>,
     /// Sender for sending arguments back to queue
@@ -1193,16 +1189,6 @@ where
         );
         let pending_basefee = builder.pool.block_info().pending_basefee;
 
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis();
-        let expected_end_delay_ms = parlia.delay_for_ramanujan_fork(
-            &mining_ctx.parent_snapshot,
-            mining_ctx.header.as_ref().unwrap(),
-        );
-        let expected_end_timestamp_ms = now_ms + expected_end_delay_ms as u128;
-
         // Spawn a background task to listen for new transactions from pool
         // When tx_listener_rx is dropped (job ends), tx_listener_tx.send() will fail,
         // causing this task to exit and pool_listener to be dropped,
@@ -1222,7 +1208,6 @@ where
             mining_ctx,
             builder: Arc::new(builder),
             timeout: std::time::Duration::from_millis(mining_delay),
-            expected_end_timestamp_ms,
             try_build_rx,
             try_build_tx: try_build_tx.clone(),
             tx_listener: tx_listener_rx,
@@ -1251,7 +1236,7 @@ where
             block_number = job.mining_ctx.parent_header.number() + 1,
             is_inturn = job.mining_ctx.is_inturn,
             timeout = ?job.timeout,
-            expected_end_timestamp_ms = job.expected_end_timestamp_ms,
+            end_mining_timestamp_ms = job.mining_ctx.end_mining_timestamp_ms,
             "Succeed to new payload job"
         );
         (job, handle)
@@ -1774,7 +1759,7 @@ where
     /// build and block until its result (or an abort signal) arrives.
     ///
     /// Phase 2 — collect better candidates: loop over remaining background builds in 50 ms slices
-    /// until the pre-computed `expected_end_timestamp_ms` deadline (+ 150 ms grace) is reached or
+    /// until the pre-computed `end_mining_timestamp_ms` deadline (+ 150 ms grace) is reached or
     /// all background tasks finish, whichever comes first.
     fn collect_payload_candidates(&mut self) -> Result<(), Box<BscPayloadJobError>> {
         // Phase 1: guarantee at least one candidate.
@@ -1885,7 +1870,7 @@ where
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis();
-            if now_ms >= self.expected_end_timestamp_ms + 150 {
+            if now_ms >= self.mining_ctx.end_mining_timestamp_ms + 150 {
                 debug!(
                     target: "bsc::miner::payload",
                     trace_id = self.trace_id,
@@ -1893,7 +1878,7 @@ where
                     is_inturn = self.mining_ctx.is_inturn,
                     bg_tasks = self.join_handle.len(),
                     now_ms,
-                    expected_end_timestamp_ms = self.expected_end_timestamp_ms,
+                    end_mining_timestamp_ms = self.mining_ctx.end_mining_timestamp_ms,
                     "Skip waiting for additional payload candidates due to timeout"
                 );
                 break;
@@ -1906,9 +1891,10 @@ where
                 .parent_snapshot
                 .last_block_in_one_turn(try_mine_block_number)
             {
-                self.expected_end_timestamp_ms.saturating_sub(now_ms) as u64
+                self.mining_ctx.end_mining_timestamp_ms.saturating_sub(now_ms) as u64
             } else {
-                (self.expected_end_timestamp_ms.saturating_sub(now_ms) as u64).saturating_mul(3)
+                (self.mining_ctx.end_mining_timestamp_ms.saturating_sub(now_ms) as u64)
+                    .saturating_mul(3)
             };
             if remaining_ms > 50 {
                 remaining_ms = 50;
@@ -1944,7 +1930,7 @@ where
                         is_inturn = self.mining_ctx.is_inturn,
                         waited_ms = waited.as_millis(),
                         bg_tasks = self.join_handle.len(),
-                        expected_end_timestamp_ms = self.expected_end_timestamp_ms,
+                        end_mining_timestamp_ms = self.mining_ctx.end_mining_timestamp_ms,
                         "No background payload candidate finished within wait slice"
                     );
                     // Keep waiting in further slices until we hit the expected end timestamp (+grace)
@@ -2043,7 +2029,7 @@ where
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
-        let delay_ms = self.expected_end_timestamp_ms.saturating_sub(now_ms) as u64;
+        let delay_ms = self.mining_ctx.end_mining_timestamp_ms.saturating_sub(now_ms) as u64;
 
         let submit_ctx = SubmitContext {
             mining_ctx: self.mining_ctx.clone(),
@@ -2152,7 +2138,7 @@ where
             self.parlia.clone(),
             &self.mining_ctx.parent_snapshot,
             &self.mining_ctx.parent_header,
-            self.mining_ctx.planned_block_ts_ms,
+            self.mining_ctx.block_timestamp_ms,
         )
         .map_err(|e| {
             warn!(
@@ -2216,7 +2202,7 @@ fn finalize_payload(
     parlia: Arc<Parlia<BscChainSpec>>,
     parent_snapshot: &Snapshot,
     parent_header: &SealedHeader<alloy_consensus::Header>,
-    planned_block_ts_ms: u64,
+    block_timestamp_ms: u64,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let snapshot_provider = crate::shared::get_snapshot_provider()
         .cloned()
@@ -2235,7 +2221,7 @@ fn finalize_payload(
         parent_header,
         &mut plain_block.header,
         &snapshot_provider,
-        planned_block_ts_ms,
+        block_timestamp_ms,
     )
     .map_err(|e| {
         Box::new(std::io::Error::other(e.to_string()))
@@ -2347,7 +2333,8 @@ mod tests {
             parent_snapshot: Arc::new(snapshot),
             is_inturn,
             cached_reads: None,
-            planned_block_ts_ms: now_ms + delay_ms,
+            block_timestamp_ms: now_ms + delay_ms,
+            end_mining_timestamp_ms: 0,
         }
     }
 

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -2354,10 +2354,7 @@ mod tests {
         let final_shot_used = false;
 
         for &(arrival_ms, estimated_fees) in tx_arrivals {
-            loop {
-                let Some(deadline_ms) = wait_deadline_ms else {
-                    break;
-                };
+            while let Some(deadline_ms) = wait_deadline_ms {
                 if deadline_ms > arrival_ms {
                     break;
                 }

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -415,7 +415,9 @@ where
                 gas_limit: self.builder_config.gas_limit(parent_header.gas_limit),
                 parent_beacon_block_root: attributes.parent_beacon_block_root(),
                 withdrawals: Some(attributes.withdrawals().clone()),
-                extra_data: self.builder_config.extra_data.clone(),
+                extra_data: crate::shared::get_miner_extra()
+                    .filter(|b| !b.is_empty())
+                    .unwrap_or_else(|| self.builder_config.extra_data.clone()),
             },
             parent_difflayers: triedb_parent_difflayers.clone(),
             triedb_prefetcher: triedb_prefetcher.clone(),
@@ -942,7 +944,9 @@ where
                         gas_limit: self.builder_config.gas_limit(parent_header.gas_limit),
                         parent_beacon_block_root: attributes.parent_beacon_block_root(),
                         withdrawals: Some(attributes.withdrawals().clone()),
-                        extra_data: self.builder_config.extra_data.clone(),
+                        extra_data: crate::shared::get_miner_extra()
+                            .filter(|b| !b.is_empty())
+                            .unwrap_or_else(|| self.builder_config.extra_data.clone()),
                     },
                     parent_difflayers: triedb_parent_difflayers.clone(),
                     triedb_prefetcher: triedb_prefetcher.clone(),

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -359,6 +359,32 @@ where
         // Parent difflayers were fetched once at job start; reuse across all retry attempts.
         let triedb_parent_difflayers = parent_difflayers;
 
+        // Safety guard: when triedb is active but no difflayers are available, verify that the
+        // parent state root matches the pathdb disk layer.  If they diverge (e.g. after a
+        // restart where in-memory difflayers were lost), building on this parent would produce
+        // a block with an incorrect state root.  Skip building to avoid polluting the network.
+        if rust_eth_triedb::triedb_manager::is_triedb_active() && triedb_parent_difflayers.is_none() {
+            let triedb = get_global_triedb();
+            let (persist_block, persist_root) = triedb
+                .latest_persist_state()
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+            if parent_header.state_root() != persist_root {
+                warn!(
+                    target: "payload_builder",
+                    trace_id,
+                    parent_hash = %parent_hash,
+                    parent_number = parent_header.number(),
+                    parent_state_root = %parent_header.state_root(),
+                    pathdb_block = persist_block,
+                    pathdb_root = %persist_root,
+                    "Skipping build_payload: no difflayers and parent state root diverges from pathdb disk layer"
+                );
+                return Err(Box::from(
+                    "triedb pathdb gap: no difflayers and parent state root != pathdb disk layer root",
+                ));
+            }
+        }
+
         let state_provider = self.client.state_by_block_hash(parent_header.hash_slow())?;
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder()
@@ -389,9 +415,7 @@ where
                 gas_limit: self.builder_config.gas_limit(parent_header.gas_limit),
                 parent_beacon_block_root: attributes.parent_beacon_block_root(),
                 withdrawals: Some(attributes.withdrawals().clone()),
-                extra_data: crate::shared::get_miner_extra()
-                    .filter(|b| !b.is_empty())
-                    .unwrap_or_else(|| self.builder_config.extra_data.clone()),
+                extra_data: self.builder_config.extra_data.clone(),
             },
             parent_difflayers: triedb_parent_difflayers.clone(),
             triedb_prefetcher: triedb_prefetcher.clone(),
@@ -813,7 +837,7 @@ where
         }
 
         let mut plain = sealed_block.clone_block();
-        plain.body.sidecars = Some(blob_sidecars);
+        plain.body.sidecars = if blob_sidecars.is_empty() { None } else { Some(blob_sidecars) };
         sealed_block = Arc::new(plain.into());
 
         let requests = execution_result.requests.clone();
@@ -861,6 +885,30 @@ where
         // Parent difflayers were fetched once at job start; reuse across all retry attempts.
         let triedb_parent_difflayers = parent_difflayers;
 
+        // Safety guard: same as build_payload — refuse to build on a parent whose state root
+        // cannot be correctly resolved by pathdb without difflayers.
+        if rust_eth_triedb::triedb_manager::is_triedb_active() && triedb_parent_difflayers.is_none() {
+            let triedb = get_global_triedb();
+            let (persist_block, persist_root) = triedb
+                .latest_persist_state()
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+            if parent_header.state_root() != persist_root {
+                warn!(
+                    target: "payload_builder",
+                    trace_id,
+                    parent_hash = %parent_hash,
+                    parent_number = parent_header.number(),
+                    parent_state_root = %parent_header.state_root(),
+                    pathdb_block = persist_block,
+                    pathdb_root = %persist_root,
+                    "Skipping build_empty_payload: no difflayers and parent state root diverges from pathdb disk layer"
+                );
+                return Err(Box::from(
+                    "triedb pathdb gap: no difflayers and parent state root != pathdb disk layer root",
+                ));
+            }
+        }
+
         let state_provider = self.client.state_by_block_hash(parent_header.hash_slow())?;
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder()
@@ -894,9 +942,7 @@ where
                         gas_limit: self.builder_config.gas_limit(parent_header.gas_limit),
                         parent_beacon_block_root: attributes.parent_beacon_block_root(),
                         withdrawals: Some(attributes.withdrawals().clone()),
-                        extra_data: crate::shared::get_miner_extra()
-                            .filter(|b| !b.is_empty())
-                            .unwrap_or_else(|| self.builder_config.extra_data.clone()),
+                        extra_data: self.builder_config.extra_data.clone(),
                     },
                     parent_difflayers: triedb_parent_difflayers.clone(),
                     triedb_prefetcher: triedb_prefetcher.clone(),
@@ -1031,7 +1077,8 @@ async fn fetch_triedb_difflayers(trace_id: u64, parent_hash: alloy_primitives::B
                 trace_id,
                 %parent_hash,
                 error = %e,
-                "Failed to fetch parent difflayers; triedb state root falls back to full trie traversal"
+                "Failed to fetch parent difflayers; triedb state root falls back to full trie traversal \
+                 (typically only seen shortly after node startup, before difflayers for recent blocks have been cached)"
             );
             None
         }
@@ -1859,9 +1906,9 @@ where
                 .parent_snapshot
                 .last_block_in_one_turn(try_mine_block_number)
             {
-                (self.expected_end_timestamp_ms - now_ms) as u64
+                self.expected_end_timestamp_ms.saturating_sub(now_ms) as u64
             } else {
-                ((self.expected_end_timestamp_ms - now_ms) as u64) * 3 // wait more when not the last block in turn
+                (self.expected_end_timestamp_ms.saturating_sub(now_ms) as u64).saturating_mul(3)
             };
             if remaining_ms > 50 {
                 remaining_ms = 50;
@@ -2105,6 +2152,7 @@ where
             self.parlia.clone(),
             &self.mining_ctx.parent_snapshot,
             &self.mining_ctx.parent_header,
+            self.mining_ctx.planned_block_ts_ms,
         )
         .map_err(|e| {
             warn!(
@@ -2168,6 +2216,7 @@ fn finalize_payload(
     parlia: Arc<Parlia<BscChainSpec>>,
     parent_snapshot: &Snapshot,
     parent_header: &SealedHeader<alloy_consensus::Header>,
+    planned_block_ts_ms: u64,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let snapshot_provider = crate::shared::get_snapshot_provider()
         .cloned()
@@ -2180,11 +2229,18 @@ fn finalize_payload(
     let mut existing_sidecars = payload.block.clone_block().body.sidecars;
     let mut plain_block = payload.executed_block.recovered_block.sealed_block().clone_block();
 
-    finalize_new_header(parlia, parent_snapshot, parent_header, &mut plain_block.header, &snapshot_provider)
-        .map_err(|e| {
-            Box::new(std::io::Error::other(e.to_string()))
-                as Box<dyn std::error::Error + Send + Sync>
-        })?;
+    finalize_new_header(
+        parlia,
+        parent_snapshot,
+        parent_header,
+        &mut plain_block.header,
+        &snapshot_provider,
+        planned_block_ts_ms,
+    )
+    .map_err(|e| {
+        Box::new(std::io::Error::other(e.to_string()))
+            as Box<dyn std::error::Error + Send + Sync>
+    })?;
 
     let final_hash = plain_block.header.hash_slow();
     if let Some((validators, vote_addresses)) = payload.pending_validators.take() {
@@ -2291,6 +2347,7 @@ mod tests {
             parent_snapshot: Arc::new(snapshot),
             is_inturn,
             cached_reads: None,
+            planned_block_ts_ms: now_ms + delay_ms,
         }
     }
 
@@ -2306,7 +2363,6 @@ mod tests {
         let final_shot_used = false;
 
         for &(arrival_ms, estimated_fees) in tx_arrivals {
-            #[allow(clippy::while_let_loop)]
             loop {
                 let Some(deadline_ms) = wait_deadline_ms else {
                     break;

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -66,6 +66,14 @@ fn resolve_epoch_validators(
     Ok((validators, vote_addresses))
 }
 
+/// Prepare a new block's header and derive the payload builder attributes.
+///
+/// Populates on `ctx`:
+/// - `header`: the freshly constructed unsealed header for this block.
+/// - `block_timestamp_ms`: block timestamp in ms fixed by `prepare_timestamp`, reused
+///   verbatim by `finalize_new_header` to avoid seconds/ms drift at sealing time.
+/// - `end_mining_timestamp_ms`: wall-clock deadline for this mining job, computed as
+///   `now_ms + parlia.delay_for_ramanujan_fork(...)`.
 pub fn prepare_new_attributes(
     ctx: &mut MiningContext,
     parlia: Arc<Parlia<BscChainSpec>>,
@@ -74,10 +82,17 @@ pub fn prepare_new_attributes(
 ) -> EthPayloadBuilderAttributes {
     let mut new_header = prepare_new_header(parlia.clone(), parent_header, signer);
     // Cache the planned millisecond timestamp so finalize_new_header can reuse it verbatim.
-    // Recomputing at sealing time can hit block_time_for_ramanujan_fork's ceiling path and
-    // desync the header's seconds/ms halves — the root cause of the 2026-04-20 qanet stall.
-    ctx.planned_block_ts_ms =
+    ctx.block_timestamp_ms =
         parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header.header(), &mut new_header);
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let end_mining_delay_ms =
+        parlia.delay_for_ramanujan_fork(&ctx.parent_snapshot, &new_header);
+    ctx.end_mining_timestamp_ms = now_ms + end_mining_delay_ms as u128;
+
     // BSC uses the PREVRANDAO opcode to return difficulty (not a random value like
     // Ethereum PoS). The validation path in BscEvmConfig::evm_env sets
     // `prevrandao = header.difficulty()`, so the building path must match.
@@ -142,7 +157,7 @@ where
 
 /// finalize a new header and seal it.
 ///
-/// `planned_block_ts_ms` is the millisecond timestamp decided by `prepare_timestamp` and
+/// `block_timestamp_ms` is the millisecond timestamp decided by `prepare_timestamp` and
 /// cached on `MiningContext`. This function never recomputes it via
 /// `block_time_for_ramanujan_fork`: recomputation at sealing time can fall into the
 /// wall-clock ceiling branch (`new_block_ts < now`) and cross a second boundary,
@@ -155,14 +170,14 @@ pub fn finalize_new_header<ChainSpec>(
     parent_header: &SealedHeader,
     new_header: &mut Header,
     snapshot_provider: &Arc<dyn SnapshotProvider + Send + Sync>,
-    planned_block_ts_ms: u64,
+    block_timestamp_ms: u64,
 ) -> Result<(), crate::node::miner::signer::SignerError>
 where
     ChainSpec: EthChainSpec + crate::hardforks::BscHardforks + 'static,
 {
     new_header.difficulty = calculate_difficulty(parent_snap, new_header.beneficiary);
     if parlia.spec.is_lorentz_active_at_timestamp(new_header.number, new_header.timestamp) {
-        set_millisecond_part_of_timestamp(planned_block_ts_ms, new_header);
+        set_millisecond_part_of_timestamp(block_timestamp_ms, new_header);
     } else {
         new_header.mix_hash = B256::ZERO;
     }

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -73,7 +73,11 @@ pub fn prepare_new_attributes(
     signer: Address,
 ) -> EthPayloadBuilderAttributes {
     let mut new_header = prepare_new_header(parlia.clone(), parent_header, signer);
-    parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header.header(), &mut new_header);
+    // Cache the planned millisecond timestamp so finalize_new_header can reuse it verbatim.
+    // Recomputing at sealing time can hit block_time_for_ramanujan_fork's ceiling path and
+    // desync the header's seconds/ms halves — the root cause of the 2026-04-20 qanet stall.
+    ctx.planned_block_ts_ms =
+        parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header.header(), &mut new_header);
     // BSC uses the PREVRANDAO opcode to return difficulty (not a random value like
     // Ethereum PoS). The validation path in BscEvmConfig::evm_env sets
     // `prevrandao = header.difficulty()`, so the building path must match.
@@ -137,33 +141,34 @@ where
 }
 
 /// finalize a new header and seal it.
+///
+/// `planned_block_ts_ms` is the millisecond timestamp decided by `prepare_timestamp` and
+/// cached on `MiningContext`. This function never recomputes it via
+/// `block_time_for_ramanujan_fork`: recomputation at sealing time can fall into the
+/// wall-clock ceiling branch (`new_block_ts < now`) and cross a second boundary,
+/// desyncing the already-fixed `header.timestamp` from `mix_hash`'s ms part. That drift
+/// was the root cause of the 2026-04-20 bsc-qanet stall. Mirrors go-bsc's
+/// `Prepare`-decides-once / `Seal`-never-recomputes discipline.
 pub fn finalize_new_header<ChainSpec>(
     parlia: Arc<Parlia<ChainSpec>>,
     parent_snap: &Snapshot,
     parent_header: &SealedHeader,
     new_header: &mut Header,
     snapshot_provider: &Arc<dyn SnapshotProvider + Send + Sync>,
+    planned_block_ts_ms: u64,
 ) -> Result<(), crate::node::miner::signer::SignerError>
 where
     ChainSpec: EthChainSpec + crate::hardforks::BscHardforks + 'static,
 {
     new_header.difficulty = calculate_difficulty(parent_snap, new_header.beneficiary);
-    // Restore correct mix_hash for the sealed header. The assembler may have set
-    // mix_hash from BlockEnv.prevrandao (which is the difficulty value for EVM
-    // execution). BSC encodes the millisecond timestamp part in mix_hash post-Lorentz,
-    // or uses B256::ZERO pre-Lorentz.
-    let millisecond_timestamp =
-        parlia.block_time_for_ramanujan_fork(parent_snap, parent_header, new_header);
     if parlia.spec.is_lorentz_active_at_timestamp(new_header.number, new_header.timestamp) {
-        set_millisecond_part_of_timestamp(millisecond_timestamp, new_header);
+        set_millisecond_part_of_timestamp(planned_block_ts_ms, new_header);
     } else {
         new_header.mix_hash = B256::ZERO;
     }
 
     if new_header.extra_data.len() < EXTRA_VANITY_LEN {
-        let mut padded = new_header.extra_data.to_vec();
-        padded.resize(EXTRA_VANITY_LEN, 0u8);
-        new_header.extra_data = Bytes::from(padded);
+        new_header.extra_data = Bytes::from(vec![0u8; EXTRA_VANITY_LEN]);
     }
     // TODO: add vanity data, and fork hash.
     // set default header extra with Reth version.
@@ -808,5 +813,88 @@ mod tests {
             header.extra_data, original_extra,
             "original extra_data must be preserved when vote re-assembly fails"
         );
+    }
+
+    // --- Tests for finalize_new_header millisecond-timestamp invariant ---
+
+    /// Post-Luban, post-Lorentz chainspec so `finalize_new_header` takes the Lorentz branch
+    /// that writes the millisecond part into `mix_hash`. Lorentz activation is gated on
+    /// `is_london_active_at_block`, so London is also forced to block 0.
+    fn lorentz_chain_spec() -> Arc<BscChainSpec> {
+        use reth_chainspec::EthereumHardfork;
+        Arc::new(BscChainSpec::from(
+            ChainSpecBuilder::mainnet()
+                .with_fork(EthereumHardfork::London, ForkCondition::Block(0))
+                .with_fork(BscHardfork::Luban, ForkCondition::Block(0))
+                .with_fork(BscHardfork::Lorentz, ForkCondition::Timestamp(0))
+                .build(),
+        ))
+    }
+
+    /// Regression for the bsc-qanet stall of 2026-04-20. When `finalize_new_header` ran
+    /// slightly past the planned block timestamp, the wall-clock ceiling branch in
+    /// `block_time_for_ramanujan_fork` recomputed a millisecond_timestamp that crossed a
+    /// second boundary, so `set_millisecond_part_of_timestamp` wrote a stale ms onto the
+    /// already-fixed `header.timestamp` (seconds). The sealed header's effective
+    /// millisecond timestamp was 1 second behind the required floor and every peer
+    /// rejected it with "Block time is too early" / "timestamp in the past".
+    ///
+    /// Fix: `finalize_new_header` takes the planned ms cached by `prepare_timestamp` and
+    /// uses it directly; it never re-runs `block_time_for_ramanujan_fork`. This matches
+    /// go-bsc where `Prepare()` decides the timestamp once and `Seal()` never recomputes.
+    #[test]
+    fn finalize_new_header_preserves_planned_ms_regardless_of_wall_clock() {
+        use crate::consensus::parlia::util::calculate_millisecond_timestamp;
+        ensure_test_signer();
+        let parlia = Arc::new(Parlia::new(lorentz_chain_spec(), 200));
+
+        // Parent: seconds 1_776_727_552, ms 500 → parent_ms = 1_776_727_552_500
+        let mut parent_hdr =
+            Header { number: 1, timestamp: 1_776_727_552, ..Default::default() };
+        set_millisecond_part_of_timestamp(1_776_727_552_500, &mut parent_hdr);
+        let parent_sealed = SealedHeader::seal_slow(parent_hdr);
+
+        let validator = Address::with_last_byte(1);
+        let mut parent_snap =
+            Snapshot::new(vec![validator], 1, parent_sealed.hash(), 500, None);
+        parent_snap.block_interval = 450; // Fermi
+
+        // Single-validator snapshot ⇒ sole validator is always in-turn ⇒ back_off_time = 0.
+        // Planned ms = parent_ms + block_interval + back_off_time.
+        let planned_ms: u64 = 1_776_727_552_500 + 450; // 1_776_727_552_950
+
+        // Simulate the header state right before finalize runs: prepare_timestamp has
+        // fixed header.timestamp (seconds) and mix_hash (ms), then the EVM assembler
+        // overwrote mix_hash with BlockEnv.prevrandao (= difficulty in BSC).
+        let mut header = Header {
+            number: 2, // <3: assemble_vote_attestation short-circuits to Ok(())
+            parent_hash: parent_sealed.hash(),
+            beneficiary: validator,
+            timestamp: planned_ms / 1000,
+            mix_hash: B256::repeat_byte(0xAB), // prevrandao garbage from assembler
+            extra_data: Bytes::from(vec![0u8; EXTRA_VANITY_LEN]),
+            ..Default::default()
+        };
+
+        let sp: Arc<dyn SnapshotProvider + Send + Sync> =
+            Arc::new(MockSnapshotProvider { snapshot: parent_snap.clone() });
+
+        finalize_new_header(
+            parlia,
+            &parent_snap,
+            &parent_sealed,
+            &mut header,
+            &sp,
+            planned_ms,
+        )
+        .expect("finalize_new_header should succeed");
+
+        assert_eq!(
+            calculate_millisecond_timestamp(&header),
+            planned_ms,
+            "finalize_new_header must preserve the planned millisecond timestamp exactly — \
+             the wall-clock ceiling path that caused the 2026-04-20 qanet stall must not apply"
+        );
+        assert_eq!(header.timestamp, planned_ms / 1000);
     }
 }

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -158,12 +158,7 @@ where
 /// finalize a new header and seal it.
 ///
 /// `block_timestamp_ms` is the millisecond timestamp decided by `prepare_timestamp` and
-/// cached on `MiningContext`. This function never recomputes it via
-/// `block_time_for_ramanujan_fork`: recomputation at sealing time can fall into the
-/// wall-clock ceiling branch (`new_block_ts < now`) and cross a second boundary,
-/// desyncing the already-fixed `header.timestamp` from `mix_hash`'s ms part. That drift
-/// was the root cause of the 2026-04-20 bsc-qanet stall. Mirrors go-bsc's
-/// `Prepare`-decides-once / `Seal`-never-recomputes discipline.
+/// cached on `MiningContext`.
 pub fn finalize_new_header<ChainSpec>(
     parlia: Arc<Parlia<ChainSpec>>,
     parent_snap: &Snapshot,
@@ -183,7 +178,9 @@ where
     }
 
     if new_header.extra_data.len() < EXTRA_VANITY_LEN {
-        new_header.extra_data = Bytes::from(vec![0u8; EXTRA_VANITY_LEN]);
+        let mut padded = new_header.extra_data.to_vec();
+        padded.resize(EXTRA_VANITY_LEN, 0u8);
+        new_header.extra_data = Bytes::from(padded);
     }
     // TODO: add vanity data, and fork hash.
     // set default header extra with Reth version.

--- a/src/node/network/block_import/fork_recover.rs
+++ b/src/node/network/block_import/fork_recover.rs
@@ -1,0 +1,918 @@
+//! Fork recovery: ancestor-aware block pull that replaces the naive
+//! batch range-request call in the import service.
+//!
+//! See `docs/superpowers/specs/2026-04-17-p2p-fork-recovery-design.md`.
+
+use std::{sync::Arc, time::Duration};
+
+use alloy_primitives::B256;
+use alloy_rpc_types::engine::PayloadStatusEnum;
+use futures::future::BoxFuture;
+use parking_lot::Mutex;
+use reth::network::cache::LruCache;
+use reth_engine_primitives::ConsensusEngineHandle;
+use reth_network_api::PeerId;
+use reth_payload_primitives::PayloadTypes;
+use reth_primitives_traits::{AlloyBlockHeader, Block as _};
+use reth_provider::{BlockHashReader, BlockNumReader, HeaderProvider};
+
+use crate::{
+    node::{consensus::BscForkChoiceEngine, engine_api::payload::BscPayloadTypes},
+    BscBlock,
+};
+
+/// Hard cap on how many blocks we will walk back from the peer's announced
+/// head before giving up.
+pub const MAX_FORK_DEPTH: u64 = 2048;
+
+/// Blocks fetched per `GetBlocksByRange` hop. Kept small because BSC blocks
+/// are large (full tx bodies + sidecars); a 64-block response is slow to
+/// transmit and wasteful when the ancestor is a handful of blocks away.
+pub const FORK_RECOVER_HOP_COUNT: u64 = 4;
+
+/// Per-hop network timeout.
+pub const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Max peer attempts per hop before `BscRangeFetcher` gives up. Attempts are
+/// sequential, so worst-case per-hop stall is
+/// `MAX_PEER_ATTEMPTS * FETCH_TIMEOUT` (~15s at current values); a full
+/// recovery is bounded by
+/// `FORK_RECOVER_HOP_COUNT * MAX_PEER_ATTEMPTS * FETCH_TIMEOUT` in adversarial
+/// conditions. The announcing peer is tried first; failover rotates through
+/// other registered BSC peers.
+pub const MAX_PEER_ATTEMPTS: usize = 3;
+
+/// How long a head stays suppressed after `recover_ancestors` fails.
+/// Prevents the 3s periodic head-announce tick from re-spawning a
+/// doomed recovery every loop.
+pub const FAILED_HEAD_COOLDOWN: Duration = Duration::from_secs(30);
+
+/// Error kinds produced by `recover_ancestors` / `discover_fork_blocks`.
+#[derive(Debug, thiserror::Error)]
+pub enum ForkRecoverError {
+    #[error("peer returned empty response at cursor ({num}, {hash})")]
+    EmptyResponse { num: u64, hash: alloy_primitives::B256 },
+
+    #[error("no common ancestor found within MAX_FORK_DEPTH={MAX_FORK_DEPTH} blocks")]
+    ForkTooDeep,
+
+    #[error("range fetch failed: {0}")]
+    FetchFailed(String),
+
+    #[error("local provider error: {0}")]
+    Provider(#[from] reth_provider::ProviderError),
+
+    #[error("engine new_payload returned Invalid for block {num}: {reason}")]
+    ImportInvalid { num: u64, reason: String },
+
+    #[error("engine new_payload returned Syncing mid-chain for block {num} (parent should have been Valid)")]
+    ImportSyncingMidChain { num: u64 },
+
+    #[error("engine call failed: {0}")]
+    EngineCall(String),
+
+    #[error("head header {hash} not in provider after recovery")]
+    HeadHeaderMissing { hash: alloy_primitives::B256 },
+}
+
+/// Abstraction over `GetBlocksByRange`. Tests substitute a fake; production
+/// forwards to `bsc_protocol::registry::request_blocks_by_range_with_failover`,
+/// which rotates through registered BSC peers on empty/error responses.
+pub trait RangeFetcher: Send + Sync {
+    /// Fetch up to `count` blocks starting at `(start_num, start_hash)` and
+    /// walking backwards via `parent_hash`. Response is ordered
+    /// **newest -> oldest**.
+    fn fetch<'a>(
+        &'a self,
+        peer: PeerId,
+        start_num: u64,
+        start_hash: B256,
+        count: u64,
+    ) -> BoxFuture<'a, Result<Vec<BscBlock>, String>>;
+}
+
+/// Production fetcher that calls into the BSC sub-protocol registry.
+#[derive(Clone, Default)]
+pub struct BscRangeFetcher;
+
+impl RangeFetcher for BscRangeFetcher {
+    fn fetch<'a>(
+        &'a self,
+        peer: PeerId,
+        start_num: u64,
+        start_hash: B256,
+        count: u64,
+    ) -> BoxFuture<'a, Result<Vec<BscBlock>, String>> {
+        Box::pin(async move {
+            let resp = crate::node::network::bsc_protocol::registry::request_blocks_by_range_with_failover(
+                peer,
+                start_num,
+                start_hash,
+                count,
+                FETCH_TIMEOUT,
+                MAX_PEER_ATTEMPTS,
+            )
+            .await?;
+            Ok(resp.blocks)
+        })
+    }
+}
+
+/// Outcome classification from `discover_fork_blocks`.
+#[derive(Debug)]
+pub enum DiscoveryOutcome {
+    /// Peer's head hash (or a prefix of its chain) is already present in our
+    /// local provider. No Phase-2 import is required, but Phase 3 (FCU) still
+    /// runs in the caller so engine-tree can re-evaluate the chain.
+    Shortcircuit,
+    /// Fetched fork blocks up to but not including the common ancestor; the
+    /// caller must import them oldest-first and then FCU.
+    AncestorFound,
+}
+
+/// Result of Phase 1.
+#[derive(Debug)]
+pub struct Discovery {
+    /// Fork blocks **newest -> oldest**. Empty on `Shortcircuit`.
+    pub fork_blocks: Vec<crate::BscBlock>,
+    pub outcome: DiscoveryOutcome,
+}
+
+/// Walk backwards from `(head_num, head_hash)` via `parent_hash`-walked
+/// `GetBlocksByRange` hops until a local-chain match is found or
+/// `MAX_FORK_DEPTH` is exhausted.
+pub async fn discover_fork_blocks<
+    P: BlockHashReader + HeaderProvider<Header = alloy_consensus::Header>,
+>(
+    peer: PeerId,
+    head_hash: B256,
+    head_num: u64,
+    provider: &P,
+    fetcher: &dyn RangeFetcher,
+) -> Result<Discovery, ForkRecoverError> {
+    let mut fork_blocks: Vec<crate::BscBlock> = Vec::new();
+    let mut cursor_num = head_num;
+    let mut cursor_hash = head_hash;
+    let mut walked: u64 = 0;
+
+    loop {
+        // Pre-hop local checks: if this cursor is already local, we've
+        // reached the common ancestor (or short-circuited on an already-known
+        // head).
+        //
+        // The side-chain hit (`provider.header(cursor_hash).is_some()`) is
+        // safe to treat as "ancestor reached" because engine-tree only stores
+        // a header when its parent was already Valid via a prior new_payload.
+        // Transitively, any side-block in our provider is rooted at the
+        // canonical chain, so no further walking is required.
+        let cursor_is_local = provider.block_hash(cursor_num)? == Some(cursor_hash)
+            || provider.header(cursor_hash)?.is_some();
+        if cursor_is_local {
+            let outcome = if fork_blocks.is_empty() {
+                DiscoveryOutcome::Shortcircuit
+            } else {
+                DiscoveryOutcome::AncestorFound
+            };
+            return Ok(Discovery { fork_blocks, outcome });
+        }
+
+        if walked >= MAX_FORK_DEPTH {
+            return Err(ForkRecoverError::ForkTooDeep);
+        }
+
+        let remaining = MAX_FORK_DEPTH - walked;
+        let count = FORK_RECOVER_HOP_COUNT.min(remaining);
+
+        let resp = fetcher
+            .fetch(peer, cursor_num, cursor_hash, count)
+            .await
+            .map_err(ForkRecoverError::FetchFailed)?;
+        if resp.is_empty() {
+            return Err(ForkRecoverError::EmptyResponse { num: cursor_num, hash: cursor_hash });
+        }
+
+        // Iterate newest -> oldest (the order we got them in).
+        let mut found_ancestor = false;
+        for b in &resp {
+            if provider.block_hash(b.header.number)? == Some(b.header.hash_slow()) {
+                found_ancestor = true;
+                break;
+            }
+            // Side-chain already present: skip adding to fork_blocks, but keep walking.
+            if provider.header(b.header.hash_slow())?.is_some() {
+                continue;
+            }
+            fork_blocks.push(b.clone());
+        }
+        if found_ancestor {
+            return Ok(Discovery { fork_blocks, outcome: DiscoveryOutcome::AncestorFound });
+        }
+
+        // Advance cursor to the block just below the oldest in this response.
+        // saturating_sub: if we're already at block 0 with no match, the next
+        // pre-hop check fails and `walked >= MAX_FORK_DEPTH` eventually trips
+        // ForkTooDeep rather than panicking on underflow.
+        let oldest = resp.last().unwrap();
+        walked += resp.len() as u64;
+        cursor_num = oldest.header.number.saturating_sub(1);
+        cursor_hash = oldest.header.parent_hash;
+    }
+}
+
+/// Top-level recovery entry point.
+///
+/// 1. Walks back via `discover_fork_blocks` to find the common ancestor.
+/// 2. Imports fork blocks oldest → newest via `engine.new_payload`, awaiting
+///    `Valid` on each before submitting the next.
+/// 3. Issues a final `fork_choice_updated` for `head_hash`, so engine-tree
+///    re-evaluates canonical selection.
+pub async fn recover_ancestors<P>(
+    peer: PeerId,
+    head_hash: B256,
+    head_num: u64,
+    provider: P,
+    engine: ConsensusEngineHandle<BscPayloadTypes>,
+    forkchoice_engine: BscForkChoiceEngine<P>,
+    fetcher: &dyn RangeFetcher,
+) -> Result<(), ForkRecoverError>
+where
+    P: BlockHashReader
+        + BlockNumReader
+        + HeaderProvider<Header = alloy_consensus::Header>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    tracing::info!(
+        target: "bsc::fork_recover",
+        %peer,
+        %head_hash,
+        head_num,
+        "Starting fork recovery"
+    );
+
+    // ---- Phase 1 ----
+    let discovery = discover_fork_blocks(peer, head_hash, head_num, &provider, fetcher).await?;
+    tracing::debug!(
+        target: "bsc::fork_recover",
+        %peer,
+        %head_hash,
+        head_num,
+        fork_blocks = discovery.fork_blocks.len(),
+        outcome = ?discovery.outcome,
+        "Phase 1 complete"
+    );
+
+    // ---- Phase 2: import oldest → newest via new_payload ----
+    let mut to_import = discovery.fork_blocks;
+    to_import.reverse();
+    for block in &to_import {
+        let block_hash = block.header.hash_slow();
+        let block_num = block.header.number;
+        let sealed = block.clone().seal_unchecked(block_hash);
+        let payload = BscPayloadTypes::block_to_payload(sealed);
+
+        match engine.new_payload(payload).await {
+            Ok(status) => match status.status {
+                PayloadStatusEnum::Valid => {
+                    tracing::debug!(
+                        target: "bsc::fork_recover",
+                        %block_hash,
+                        block_num,
+                        "Fork block imported Valid"
+                    );
+                }
+                PayloadStatusEnum::Invalid { validation_error } => {
+                    return Err(ForkRecoverError::ImportInvalid {
+                        num: block_num,
+                        reason: validation_error,
+                    });
+                }
+                PayloadStatusEnum::Syncing => {
+                    // Sequencing guarantees parents were already Valid, so
+                    // Syncing here means a parent failed silently.
+                    return Err(ForkRecoverError::ImportSyncingMidChain { num: block_num });
+                }
+                other => {
+                    return Err(ForkRecoverError::EngineCall(format!(
+                        "unexpected new_payload status {other:?}"
+                    )));
+                }
+            },
+            Err(err) => {
+                return Err(ForkRecoverError::EngineCall(err.to_string()));
+            }
+        }
+    }
+
+    // ---- Phase 3: single FCU to let engine-tree re-evaluate canonical head ----
+    //
+    // `provider.header(head_hash)` is not safe on the AncestorFound path:
+    // engine-tree keeps the blocks we just imported in memory (TreeState)
+    // until persistence, so the DB-backed `provider` can return `None` for a
+    // block that `engine.new_payload` has already accepted as `Valid`. That
+    // false-negative was the qanet two-validator fork livelock: Phase 2
+    // succeeded, but Phase 3 aborted with `HeadHeaderMissing`, the head was
+    // cooled down for 30s, and the FCU that would flip canonical never fired.
+    //
+    // The Phase-2 tail is the recovery head by construction (see
+    // `discover_fork_blocks`: fork_blocks is newest→oldest with the head at
+    // index 0, so `to_import.last()` after `reverse()` is the head). Use its
+    // in-memory header directly. Only fall back to the provider on the
+    // Shortcircuit path, where `to_import` is empty and the head was already
+    // locally known (canonical or side-chain) — that lookup must succeed.
+    let head_header = resolve_fcu_head_header(&provider, head_hash, to_import.last())?;
+    if let Err(err) = forkchoice_engine.update_forkchoice(&head_header).await {
+        // FCU failure is recoverable (engine-tree may retry on next import);
+        // surface at warn level to match `service.rs` convention.
+        tracing::warn!(
+            target: "bsc::fork_recover",
+            %head_hash,
+            error = %err,
+            "fork_choice_updated returned error after recovery"
+        );
+    } else {
+        tracing::info!(
+            target: "bsc::fork_recover",
+            %head_hash,
+            head_num,
+            "Fork recovery FCU succeeded"
+        );
+    }
+
+    Ok(())
+}
+
+/// Resolve the header used as the FCU target at the end of `recover_ancestors`.
+///
+/// The AncestorFound path uses the Phase-2 tail (the peer's announced head,
+/// just imported via `engine.new_payload`) without consulting the DB provider:
+/// engine-tree holds that block in memory and the provider would return `None`
+/// until persistence lands — which is the qanet livelock we're fixing.
+///
+/// The Shortcircuit path (`phase_2_tail == None`) falls back to the provider,
+/// which is guaranteed to hold the head (canonical or side-chain) because
+/// `discover_fork_blocks` only short-circuits when the pre-hop local check
+/// succeeds. If the provider somehow disagrees, surface `HeadHeaderMissing`
+/// rather than forging an FCU target.
+fn resolve_fcu_head_header<P>(
+    provider: &P,
+    head_hash: B256,
+    phase_2_tail: Option<&crate::BscBlock>,
+) -> Result<alloy_consensus::Header, ForkRecoverError>
+where
+    P: HeaderProvider<Header = alloy_consensus::Header>,
+{
+    if let Some(last) = phase_2_tail {
+        debug_assert_eq!(
+            last.header.hash_slow(),
+            head_hash,
+            "phase-2 tail must be the recovery head; invariant of discover_fork_blocks",
+        );
+        return Ok(last.header.clone());
+    }
+    provider
+        .header(head_hash)?
+        .ok_or(ForkRecoverError::HeadHeaderMissing { hash: head_hash })
+}
+
+/// Bounded LRU of recently-failed recovery heads with per-entry deadlines.
+///
+/// `is_cooling` returns true only for entries whose deadline has not yet
+/// expired. Expired entries are lazily removed on access. Capacity eviction
+/// is handled by the underlying `schnellru::LruMap` and matches the
+/// `BODY_CACHE` / `RecoveringHeads` pattern elsewhere in the codebase.
+#[derive(Clone)]
+pub struct FailedHeadsCooler {
+    inner: Arc<Mutex<schnellru::LruMap<B256, std::time::Instant, schnellru::ByLength>>>,
+    cooldown: Duration,
+}
+
+impl FailedHeadsCooler {
+    pub fn new(capacity: u32, cooldown: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(schnellru::LruMap::new(
+                schnellru::ByLength::new(capacity),
+            ))),
+            cooldown,
+        }
+    }
+
+    pub fn mark_failed(&self, head: B256) {
+        let mut g = self.inner.lock();
+        g.insert(head, std::time::Instant::now() + self.cooldown);
+    }
+
+    pub fn is_cooling(&self, head: &B256) -> bool {
+        let mut g = self.inner.lock();
+        match g.get(head).copied() {
+            None => false,
+            Some(deadline) if std::time::Instant::now() >= deadline => {
+                g.remove(head);
+                false
+            }
+            Some(_) => true,
+        }
+    }
+}
+
+/// Factory matching the shape of `new_recovering_heads`.
+pub fn new_failed_heads_cooler(capacity: u32) -> FailedHeadsCooler {
+    FailedHeadsCooler::new(capacity, FAILED_HEAD_COOLDOWN)
+}
+
+/// RAII guard that removes a head hash from the dedup cache on drop, even on
+/// task panic or early return.
+pub struct RecoveringHeadGuard {
+    hash: B256,
+    set: Arc<Mutex<LruCache<B256>>>,
+}
+
+impl RecoveringHeadGuard {
+    pub fn new(hash: B256, set: Arc<Mutex<LruCache<B256>>>) -> Self {
+        Self { hash, set }
+    }
+}
+
+impl Drop for RecoveringHeadGuard {
+    fn drop(&mut self) {
+        self.set.lock().remove(&self.hash);
+    }
+}
+
+/// Shared dedup set — one entry per in-flight recovery.
+pub type RecoveringHeads = Arc<Mutex<LruCache<B256>>>;
+
+/// Convenience constructor matching `LRU_PROCESSED_BLOCKS_SIZE` cap.
+pub fn new_recovering_heads(cap: u32) -> RecoveringHeads {
+    Arc::new(Mutex::new(LruCache::new(cap)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_primitives::B256;
+    use reth_primitives_traits::AlloyBlockHeader;
+    use reth_provider::{BlockHashReader, HeaderProvider, ProviderError};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use crate::{BscBlock, BscBlockBody};
+
+    // ---------- Fake provider ----------
+    #[derive(Clone, Default)]
+    struct FakeProvider {
+        canonical_by_num: HashMap<u64, B256>, // number -> canonical hash
+        headers_by_hash: HashMap<B256, Header>, // every known header (canonical + side)
+    }
+
+    impl FakeProvider {
+        fn insert_canonical(&mut self, header: Header) {
+            let hash = header.hash_slow();
+            self.canonical_by_num.insert(header.number, hash);
+            self.headers_by_hash.insert(hash, header);
+        }
+        fn insert_side(&mut self, header: Header) {
+            let hash = header.hash_slow();
+            self.headers_by_hash.insert(hash, header);
+        }
+    }
+
+    impl BlockHashReader for FakeProvider {
+        fn block_hash(&self, number: u64) -> Result<Option<B256>, ProviderError> {
+            Ok(self.canonical_by_num.get(&number).copied())
+        }
+        fn canonical_hashes_range(
+            &self,
+            _start: u64,
+            _end: u64,
+        ) -> Result<Vec<B256>, ProviderError> {
+            Ok(vec![])
+        }
+    }
+
+    impl HeaderProvider for FakeProvider {
+        type Header = Header;
+        fn header(&self, block_hash: B256) -> Result<Option<Self::Header>, ProviderError> {
+            Ok(self.headers_by_hash.get(&block_hash).cloned())
+        }
+        fn header_by_number(&self, num: u64) -> Result<Option<Self::Header>, ProviderError> {
+            Ok(self.canonical_by_num.get(&num).and_then(|h| self.headers_by_hash.get(h).cloned()))
+        }
+        fn header_td(&self, _: &B256) -> Result<Option<alloy_primitives::U256>, ProviderError> {
+            Ok(None)
+        }
+        fn header_td_by_number(
+            &self,
+            _: u64,
+        ) -> Result<Option<alloy_primitives::U256>, ProviderError> {
+            Ok(None)
+        }
+        fn headers_range(
+            &self,
+            _range: impl core::ops::RangeBounds<u64>,
+        ) -> Result<Vec<Self::Header>, ProviderError> {
+            Ok(vec![])
+        }
+        fn sealed_header(
+            &self,
+            _number: u64,
+        ) -> Result<Option<reth_primitives::SealedHeader<Self::Header>>, ProviderError> {
+            Ok(None)
+        }
+        fn sealed_headers_while(
+            &self,
+            _range: impl core::ops::RangeBounds<u64>,
+            _predicate: impl FnMut(&reth_primitives::SealedHeader<Self::Header>) -> bool,
+        ) -> Result<Vec<reth_primitives::SealedHeader<Self::Header>>, ProviderError> {
+            Ok(vec![])
+        }
+    }
+
+    // ---------- Fake fetcher ----------
+    /// Script-driven fetcher: returns one canned response per call, recording
+    /// the requested `(start_num, start_hash, count)` tuples for assertions.
+    struct ScriptedFetcher {
+        responses: Mutex<Vec<Result<Vec<BscBlock>, String>>>,
+        requests: Mutex<Vec<(u64, B256, u64)>>,
+    }
+
+    impl ScriptedFetcher {
+        fn new(responses: Vec<Result<Vec<BscBlock>, String>>) -> Arc<Self> {
+            Arc::new(Self { responses: Mutex::new(responses), requests: Mutex::new(vec![]) })
+        }
+
+        fn calls(&self) -> Vec<(u64, B256, u64)> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    impl RangeFetcher for ScriptedFetcher {
+        fn fetch<'a>(
+            &'a self,
+            _peer: PeerId,
+            start_num: u64,
+            start_hash: B256,
+            count: u64,
+        ) -> BoxFuture<'a, Result<Vec<BscBlock>, String>> {
+            self.requests.lock().unwrap().push((start_num, start_hash, count));
+            let resp = self.responses.lock().unwrap().remove(0);
+            Box::pin(async move { resp })
+        }
+    }
+
+    // ---------- Header & block builders ----------
+    fn make_header(number: u64, parent_hash: B256, tag: u8) -> Header {
+        // `tag` makes hash_slow deterministic-yet-distinguishable.
+        Header { number, parent_hash, extra_data: vec![tag].into(), ..Default::default() }
+    }
+
+    fn make_block(header: Header) -> BscBlock {
+        BscBlock { header, body: BscBlockBody::default() }
+    }
+
+    /// Build a linear chain starting from `genesis_parent` of length `len`.
+    /// Returns `(headers, hashes)` in ascending height order.
+    fn linear_chain(
+        start_num: u64,
+        len: u64,
+        genesis_parent: B256,
+        tag: u8,
+    ) -> (Vec<Header>, Vec<B256>) {
+        let mut headers = Vec::new();
+        let mut hashes = Vec::new();
+        let mut parent = genesis_parent;
+        for i in 0..len {
+            let h = make_header(start_num + i, parent, tag);
+            parent = h.hash_slow();
+            hashes.push(parent);
+            headers.push(h);
+        }
+        (headers, hashes)
+    }
+
+    fn fake_peer() -> PeerId {
+        PeerId::from([0u8; 64])
+    }
+
+    // ---- Spec test #1: head already on canonical (pre-hop short-circuit) ----
+    #[tokio::test]
+    async fn discover_head_on_canonical_no_fetch() {
+        let mut provider = FakeProvider::default();
+        let (chain, hashes) = linear_chain(0, 101, B256::ZERO, 0xC);
+        for h in chain {
+            provider.insert_canonical(h);
+        }
+
+        let fetcher = ScriptedFetcher::new(vec![]);
+        let out = discover_fork_blocks(fake_peer(), hashes[100], 100, &provider, fetcher.as_ref())
+            .await
+            .unwrap();
+
+        assert!(out.fork_blocks.is_empty(), "no blocks to import");
+        assert!(matches!(out.outcome, DiscoveryOutcome::Shortcircuit));
+        assert_eq!(fetcher.calls().len(), 0, "no network fetch should happen");
+    }
+
+    // ---- Spec test #2: simple linear-ahead, one hop, one extra pre-hop check ----
+    #[tokio::test]
+    async fn discover_linear_ahead_one_hop() {
+        let mut provider = FakeProvider::default();
+        let (local, local_hashes) = linear_chain(0, 101, B256::ZERO, 0xC); // canonical 0..=100
+        for h in &local {
+            provider.insert_canonical(h.clone());
+        }
+
+        // Peer extends with blocks 101..=104 parented on 100.
+        let (peer_ext, _peer_hashes) = linear_chain(101, 4, local_hashes[100], 0xC);
+        let hop1: Vec<BscBlock> = peer_ext.iter().cloned().rev().map(make_block).collect();
+        let fetcher = ScriptedFetcher::new(vec![Ok(hop1)]);
+
+        let head_hash = peer_ext.last().unwrap().hash_slow();
+        let out = discover_fork_blocks(fake_peer(), head_hash, 104, &provider, fetcher.as_ref())
+            .await
+            .unwrap();
+
+        assert!(matches!(out.outcome, DiscoveryOutcome::AncestorFound));
+        // Ascending-hash list after reverse; we assert on numbers for clarity.
+        let nums: Vec<u64> = out.fork_blocks.iter().map(|b| b.header.number).collect();
+        assert_eq!(nums, vec![104, 103, 102, 101], "newest→oldest");
+        assert_eq!(fetcher.calls().len(), 1);
+        assert_eq!(fetcher.calls()[0], (104, head_hash, FORK_RECOVER_HOP_COUNT));
+    }
+
+    // ---- Spec test #3: short fork within two hops (divergence at 95, depth 7) ----
+    #[tokio::test]
+    async fn discover_short_fork_two_hops() {
+        let mut provider = FakeProvider::default();
+
+        // Shared 0..=95
+        let (shared, shared_hashes) = linear_chain(0, 96, B256::ZERO, 0xC);
+        for h in &shared {
+            provider.insert_canonical(h.clone());
+        }
+        let ancestor_hash = shared_hashes[95];
+
+        // Local fork X: 96X..=100X
+        let (local_x, _) = linear_chain(96, 5, ancestor_hash, 0xA);
+        for h in &local_x {
+            provider.insert_canonical(h.clone());
+        }
+
+        // Peer fork Y: 96Y..=102Y
+        let (peer_y, peer_y_hashes) = linear_chain(96, 7, ancestor_hash, 0xB);
+
+        // Hop 1: server returns [102Y, 101Y, 100Y, 99Y] (newest→oldest).
+        let hop1: Vec<BscBlock> = peer_y[3..=6].iter().cloned().rev().map(make_block).collect();
+        // Hop 2: server returns [98Y, 97Y, 96Y, 95_shared].
+        let mut hop2: Vec<BscBlock> = peer_y[0..=2].iter().cloned().rev().map(make_block).collect();
+        hop2.push(make_block(shared[95].clone()));
+        let fetcher = ScriptedFetcher::new(vec![Ok(hop1), Ok(hop2)]);
+
+        let out =
+            discover_fork_blocks(fake_peer(), peer_y_hashes[6], 102, &provider, fetcher.as_ref())
+                .await
+                .unwrap();
+
+        assert!(matches!(out.outcome, DiscoveryOutcome::AncestorFound));
+        let nums: Vec<u64> = out.fork_blocks.iter().map(|b| b.header.number).collect();
+        assert_eq!(nums, vec![102, 101, 100, 99, 98, 97, 96]);
+        assert_eq!(fetcher.calls().len(), 2);
+        assert_eq!(fetcher.calls()[0].0, 102);
+        assert_eq!(fetcher.calls()[1].0, 98, "second hop starts at 99Y.parent_hash num = 98");
+    }
+
+    // ---- Spec test #6: fork too deep (depth MAX_FORK_DEPTH + 1 → ForkTooDeep) ----
+    #[tokio::test]
+    async fn discover_fork_too_deep() {
+        let mut provider = FakeProvider::default();
+        let (shared, shared_hashes) = linear_chain(0, 1, B256::ZERO, 0xC);
+        for h in &shared {
+            provider.insert_canonical(h.clone());
+        }
+
+        // Peer chain: genesis + (MAX_FORK_DEPTH + FORK_RECOVER_HOP_COUNT) fork
+        // blocks. None match canonical (which only has block 0).
+        let peer_len = MAX_FORK_DEPTH + FORK_RECOVER_HOP_COUNT;
+        let (peer, peer_hashes) = linear_chain(1, peer_len, shared_hashes[0], 0xB);
+
+        // Script: return FORK_RECOVER_HOP_COUNT fork blocks per hop; after
+        // `MAX_FORK_DEPTH / FORK_RECOVER_HOP_COUNT` hops, `walked ==
+        // MAX_FORK_DEPTH`, so the next iteration's pre-hop check trips
+        // ForkTooDeep.
+        //
+        // `peer` is indexed `0..=peer_len-1` with peer[idx] at height idx+1.
+        // For hop `i` (0-indexed), the top height served is
+        // `peer_len - FORK_RECOVER_HOP_COUNT * i` and the response covers
+        // heights `(top - FORK_RECOVER_HOP_COUNT + 1)..=top` newest→oldest.
+        let hops = (MAX_FORK_DEPTH / FORK_RECOVER_HOP_COUNT) as usize;
+        let hop = FORK_RECOVER_HOP_COUNT as usize;
+        let peer_len_usize = peer_len as usize;
+        let mut responses: Vec<Result<Vec<BscBlock>, String>> = Vec::new();
+        for i in 0..hops {
+            let top_height = peer_len_usize - hop * i;
+            let slice: Vec<BscBlock> = peer[(top_height - hop)..=(top_height - 1)]
+                .iter()
+                .cloned()
+                .rev()
+                .map(make_block)
+                .collect();
+            responses.push(Ok(slice));
+        }
+        let fetcher = ScriptedFetcher::new(responses);
+
+        let err = discover_fork_blocks(
+            fake_peer(),
+            peer_hashes[peer_len_usize - 1],
+            peer_len,
+            &provider,
+            fetcher.as_ref(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ForkRecoverError::ForkTooDeep));
+        assert_eq!(fetcher.calls().len(), hops);
+    }
+
+    // ---- Spec test #7: head already present as side-chain (short-circuit, empty fork_blocks) ----
+    #[tokio::test]
+    async fn discover_head_side_chain_shortcircuit() {
+        let mut provider = FakeProvider::default();
+        let (shared, shared_hashes) = linear_chain(0, 96, B256::ZERO, 0xC);
+        for h in &shared {
+            provider.insert_canonical(h.clone());
+        }
+        // Insert a side-chain block at 96 (not canonical).
+        let side_96 = make_header(96, shared_hashes[95], 0xB);
+        let side_hash = side_96.hash_slow();
+        provider.insert_side(side_96);
+
+        let fetcher = ScriptedFetcher::new(vec![]);
+        let out = discover_fork_blocks(fake_peer(), side_hash, 96, &provider, fetcher.as_ref())
+            .await
+            .unwrap();
+        assert!(matches!(out.outcome, DiscoveryOutcome::Shortcircuit));
+        assert!(out.fork_blocks.is_empty());
+        assert_eq!(fetcher.calls().len(), 0);
+    }
+
+    // ---- Spec test #8: mid-chain side block already present, skipped ----
+    #[tokio::test]
+    async fn discover_mid_chain_side_block_skipped() {
+        let mut provider = FakeProvider::default();
+        let (shared, shared_hashes) = linear_chain(0, 96, B256::ZERO, 0xC);
+        for h in &shared {
+            provider.insert_canonical(h.clone());
+        }
+        let ancestor_hash = shared_hashes[95];
+
+        // Peer fork Y: 96Y..=99Y (4 blocks).
+        let (peer_y, peer_y_hashes) = linear_chain(96, 4, ancestor_hash, 0xB);
+        // Register 97Y as an already-known side-chain block.
+        provider.insert_side(peer_y[1].clone());
+
+        // Hop 1: [99Y, 98Y, 97Y, 96Y].
+        let hop1: Vec<BscBlock> = peer_y.iter().cloned().rev().map(make_block).collect();
+        let fetcher = ScriptedFetcher::new(vec![Ok(hop1)]);
+
+        let out =
+            discover_fork_blocks(fake_peer(), peer_y_hashes[3], 99, &provider, fetcher.as_ref())
+                .await
+                .unwrap();
+
+        assert!(matches!(out.outcome, DiscoveryOutcome::AncestorFound));
+        let nums: Vec<u64> = out.fork_blocks.iter().map(|b| b.header.number).collect();
+        // Non-contiguous fork_blocks: 97Y is omitted because it's already a
+        // known side-block. Task 4's import loop must therefore tolerate gaps
+        // — it imports [96, 98, 99] oldest-first and relies on engine-tree
+        // already holding 97Y as Valid (which is why the side-block exists).
+        assert_eq!(nums, vec![99, 98, 96], "97Y skipped because already on side-chain");
+        assert_eq!(fetcher.calls().len(), 1);
+    }
+
+    // ---- Phase-3 head-header resolver tests ----
+    //
+    // These pin the qanet livelock fix: Phase 2 imports the peer's head via
+    // `engine.new_payload` (Valid), but the DB-backed provider does not see
+    // that block until engine-tree persists it. The resolver must use the
+    // Phase-2 tail, not the provider, on the AncestorFound path.
+
+    #[test]
+    fn resolve_fcu_head_header_uses_phase2_tail_when_provider_misses() {
+        // Provider has the shared ancestor but not the peer's head (simulates
+        // the just-imported-but-not-persisted engine-tree state that caused
+        // the two-validator fork livelock).
+        let mut provider = FakeProvider::default();
+        let (shared, shared_hashes) = linear_chain(0, 1, B256::ZERO, 0xC);
+        for h in &shared {
+            provider.insert_canonical(h.clone());
+        }
+
+        // Peer fork: one block on top of the ancestor.
+        let head = make_header(1, shared_hashes[0], 0xB);
+        let head_hash = head.hash_slow();
+        let tail_block = make_block(head.clone());
+
+        // Sanity: provider can't see the head (neither canonical nor side).
+        assert!(
+            BlockHashReader::block_hash(&provider, 1).unwrap() != Some(head_hash),
+            "precondition: head not canonical in provider",
+        );
+        assert!(
+            HeaderProvider::header(&provider, head_hash).unwrap().is_none(),
+            "precondition: head not as side-chain in provider",
+        );
+
+        let resolved =
+            super::resolve_fcu_head_header(&provider, head_hash, Some(&tail_block)).unwrap();
+        assert_eq!(
+            resolved.hash_slow(),
+            head_hash,
+            "must return the Phase-2 tail header verbatim, never consult provider",
+        );
+        assert_eq!(resolved.number, 1);
+    }
+
+    #[test]
+    fn resolve_fcu_head_header_shortcircuit_falls_back_to_provider() {
+        // Shortcircuit: fork_blocks empty, head already known locally
+        // (side-chain block the provider can serve).
+        let mut provider = FakeProvider::default();
+        let (shared, shared_hashes) = linear_chain(0, 1, B256::ZERO, 0xC);
+        for h in &shared {
+            provider.insert_canonical(h.clone());
+        }
+        let side = make_header(1, shared_hashes[0], 0xB);
+        let side_hash = side.hash_slow();
+        provider.insert_side(side);
+
+        let resolved = super::resolve_fcu_head_header(&provider, side_hash, None).unwrap();
+        assert_eq!(resolved.hash_slow(), side_hash);
+    }
+
+    #[test]
+    fn resolve_fcu_head_header_shortcircuit_missing_yields_error() {
+        // Defensive path: if Shortcircuit somehow fires but the provider no
+        // longer has the head (pruning race / DB corruption), surface
+        // `HeadHeaderMissing` rather than forging an FCU target.
+        let provider = FakeProvider::default();
+        let head_hash = B256::repeat_byte(0xAB);
+
+        let err = super::resolve_fcu_head_header(&provider, head_hash, None).unwrap_err();
+        match err {
+            ForkRecoverError::HeadHeaderMissing { hash } => assert_eq!(hash, head_hash),
+            other => panic!("expected HeadHeaderMissing, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod cooler_tests {
+    use super::{FailedHeadsCooler, FAILED_HEAD_COOLDOWN};
+    use alloy_primitives::B256;
+    use std::time::Duration;
+
+    #[test]
+    fn is_cooling_is_false_before_mark_failed() {
+        let cooler = FailedHeadsCooler::new(8, FAILED_HEAD_COOLDOWN);
+        assert!(!cooler.is_cooling(&B256::repeat_byte(0x11)));
+    }
+
+    #[test]
+    fn is_cooling_is_true_right_after_mark_failed() {
+        let cooler = FailedHeadsCooler::new(8, FAILED_HEAD_COOLDOWN);
+        let h = B256::repeat_byte(0x22);
+        cooler.mark_failed(h);
+        assert!(cooler.is_cooling(&h));
+    }
+
+    #[test]
+    fn cooldown_expires_after_duration() {
+        // Use a 0-length cooldown so expiry fires immediately.
+        let cooler = FailedHeadsCooler::new(8, Duration::from_millis(0));
+        let h = B256::repeat_byte(0x33);
+        cooler.mark_failed(h);
+        // With 0ms cooldown the next check must not consider it cooling.
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(!cooler.is_cooling(&h));
+    }
+
+    #[test]
+    fn capacity_evicts_oldest_entries() {
+        let cooler = FailedHeadsCooler::new(2, Duration::from_secs(60));
+        let a = B256::repeat_byte(0xaa);
+        let b = B256::repeat_byte(0xbb);
+        let c = B256::repeat_byte(0xcc);
+        cooler.mark_failed(a);
+        cooler.mark_failed(b);
+        cooler.mark_failed(c);
+        // `a` must be evicted; `b` and `c` must remain.
+        assert!(!cooler.is_cooling(&a));
+        assert!(cooler.is_cooling(&b));
+        assert!(cooler.is_cooling(&c));
+    }
+}

--- a/src/node/network/block_import/fork_recover.rs
+++ b/src/node/network/block_import/fork_recover.rs
@@ -1,7 +1,5 @@
 //! Fork recovery: ancestor-aware block pull that replaces the naive
 //! batch range-request call in the import service.
-//!
-//! See `docs/superpowers/specs/2026-04-17-p2p-fork-recovery-design.md`.
 
 use std::{sync::Arc, time::Duration};
 
@@ -26,8 +24,7 @@ use crate::{
 pub const MAX_FORK_DEPTH: u64 = 2048;
 
 /// Blocks fetched per `GetBlocksByRange` hop. Kept small because BSC blocks
-/// are large (full tx bodies + sidecars); a 64-block response is slow to
-/// transmit and wasteful when the ancestor is a handful of blocks away.
+/// are large (full tx bodies + sidecars).
 pub const FORK_RECOVER_HOP_COUNT: u64 = 4;
 
 /// Per-hop network timeout.

--- a/src/node/network/block_import/mod.rs
+++ b/src/node/network/block_import/mod.rs
@@ -15,6 +15,7 @@ use crate::node::network::BscNewBlock;
 
 pub mod handle;
 pub mod service;
+pub(crate) mod fork_recover;
 
 #[derive(Debug)]
 pub struct BscBlockImport {

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -36,7 +36,6 @@ use reth_payload_primitives::{BuiltPayload, EngineApiMessageVersion, PayloadType
 use reth_primitives::NodePrimitives;
 use reth_primitives_traits::{AlloyBlockHeader, Block};
 use reth_provider::{BlockHashReader, BlockNumReader, BlockReaderIdExt, HeaderProvider};
-use schnellru::{ByLength, LruMap};
 use std::{
     future::Future,
     pin::Pin,
@@ -69,8 +68,18 @@ pub(crate) type IncomingHashes = (NewBlockHashes, PeerId);
 /// Size of the LRU cache for processed blocks.
 const LRU_PROCESSED_BLOCKS_SIZE: u32 = 100;
 
-/// Cooldown duration for downloading block hashes to avoid re-downloading the same block.
-const DOWNLOAD_COOLDOWN_DURATION_MS: u128 = 200;
+/// Announcements whose height exceeds the local canonical tip by more than
+/// this many blocks are routed to the staged backfill pipeline (via a
+/// synthesized FCU) instead of `fork_recover`.
+///
+/// Matches `fork_recover::MAX_FORK_DEPTH`: at or below that cap, `fork_recover`
+/// can reach a common ancestor and resolve the reorg itself; beyond it, the
+/// ancestor walk must fail (`ForkTooDeep`), so we skip the doomed attempt and
+/// hand off to the pipeline via engine-tree's optimistic-sync branch.
+///
+/// See `docs/superpowers/specs/2026-04-21-far-behind-pipeline-trigger-design.md`.
+const PIPELINE_TRIGGER_DELTA: u64 =
+    crate::node::network::block_import::fork_recover::MAX_FORK_DEPTH;
 
 /// A service that handles bidirectional block import communication with the network.
 /// It receives new blocks from the network via `from_network` channel and sends back
@@ -97,13 +106,35 @@ where
     processed_blocks: LruCache<B256>,
     /// Cache of queued block hashes to avoid processing the same block.
     queued_blocks: LruCache<B256>,
-    /// Cache of downloading block hashes to avoid re-downloading the same block.
-    downloading_blocks: LruMap<B256, u128, ByLength>,
+    /// Heads currently being fork-recovered. Prevents duplicate spawned tasks
+    /// when the same head is announced repeatedly.
+    recovering_heads: crate::node::network::block_import::fork_recover::RecoveringHeads,
+    /// Heads whose most recent recovery attempt failed. Suppresses
+    /// re-spawning recovery until the cooldown elapses. Prevents storm
+    /// behaviour when the 3s head-announce tick re-announces the same
+    /// unreachable head.
+    failed_heads: crate::node::network::block_import::fork_recover::FailedHeadsCooler,
+    /// Periodic timer for head announcement.
+    announce_interval: tokio::time::Interval,
+}
+
+fn resolve_bsc_peer_static(announcer: PeerId) -> Option<PeerId> {
+    if crate::node::network::bsc_protocol::registry::has_registered_peer(announcer) {
+        Some(announcer)
+    } else {
+        crate::node::network::bsc_protocol::registry::list_registered_peers().into_iter().next()
+    }
 }
 
 impl<Provider> ImportService<Provider>
 where
-    Provider: BlockNumReader + HeaderProvider<Header = Header> + Clone + Send + Sync + 'static,
+    Provider: BlockNumReader
+        + BlockHashReader
+        + HeaderProvider<Header = Header>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     /// Create a new block import service
     pub fn new(
@@ -131,7 +162,20 @@ where
             pending_imports: FuturesUnordered::new(),
             processed_blocks: LruCache::new(LRU_PROCESSED_BLOCKS_SIZE),
             queued_blocks: LruCache::new(LRU_PROCESSED_BLOCKS_SIZE),
-            downloading_blocks: LruMap::new(ByLength::new(LRU_PROCESSED_BLOCKS_SIZE)),
+            recovering_heads:
+                crate::node::network::block_import::fork_recover::new_recovering_heads(
+                    LRU_PROCESSED_BLOCKS_SIZE,
+                ),
+            failed_heads: crate::node::network::block_import::fork_recover::new_failed_heads_cooler(
+                LRU_PROCESSED_BLOCKS_SIZE,
+            ),
+            announce_interval: {
+                // 3s ≈ 6-7 BSC slots (450ms each). Fast enough to break fork
+                // livelocks, slow enough to be negligible overhead.
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(3));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                interval
+            },
         }
     }
 
@@ -139,6 +183,8 @@ where
     fn new_payload(&self, block: BlockMsg, peer_id: PeerId) -> ImportFut {
         let engine = self.engine.clone();
         let forkchoice_engine = self.forkchoice_engine.clone();
+        let recovering_heads = self.recovering_heads.clone();
+        let failed_heads = self.failed_heads.clone();
 
         let announced_hash = block.hash;
         let block_hash = block.block.0.block.header.hash_slow();
@@ -162,7 +208,7 @@ where
                         .into(),
                     )),
                 }
-                .into()
+                .into();
             }
 
             let sealed_block = block.block.0.block.clone().seal_unchecked(block_hash);
@@ -208,51 +254,76 @@ where
                         None
                     }
                     PayloadStatusEnum::Syncing => {
-                        // When new_payload returns Syncing status, we need to manually trigger FCU
-                        // to avoid the engine-tree being stuck in syncing state without any driver.
-                        // By calling FCU, we inform the engine about the new head block hash,
-                        // which can help trigger additional sync/download activities in the engine-tree.
+                        // Parent block is missing. Launch fork-aware ancestor
+                        // recovery rather than a naive range fetch + premature
+                        // FCU. The recovery task also owns the final FCU.
                         let block_number = header.number;
-                        tracing::debug!(
+                        tracing::info!(
                             target: "bsc::block_import",
-                            block_hash = %block_hash,
-                            block_number = block_number,
-                            "New payload returned Syncing status - attempting fork choice update"
+                            %block_hash,
+                            block_number,
+                            parent_hash = %header.parent_hash,
+                            peer = %peer_id,
+                            "New payload returned Syncing - spawning fork recovery"
                         );
 
-                        // Direct FCU call to help sync progress
-                        let forkchoice_state = alloy_rpc_types::engine::ForkchoiceState {
-                            head_block_hash: block_hash,
-                            safe_block_hash: alloy_primitives::B256::ZERO,
-                            finalized_block_hash: alloy_primitives::B256::ZERO,
-                        };
-                        match engine
-                            .fork_choice_updated(
-                                forkchoice_state,
-                                None,
-                                reth_payload_primitives::EngineApiMessageVersion::V1,
-                            )
-                            .await
-                        {
-                            Ok(result) => {
-                                tracing::debug!(
-                                    target: "bsc::block_import",
-                                    block_hash = %block_hash,
-                                    block_number = block_number,
-                                    status = ?result.payload_status.status,
-                                    "FCU result for syncing block"
-                                );
-                            }
-                            Err(err) => {
-                                tracing::trace!(
-                                    target: "bsc::block_import",
-                                    block_hash = %block_hash,
-                                    block_number = block_number,
-                                    error = %err,
-                                    "Failed to update fork choice for syncing block"
-                                );
-                            }
+                        if failed_heads.is_cooling(&block_hash) {
+                            tracing::debug!(
+                                target: "bsc::block_import",
+                                %block_hash,
+                                block_number,
+                                "Skipping fork recovery: head is in cooldown after recent failure"
+                            );
+                            return None;
                         }
+
+                        // Fire-and-forget spawn; `recover_ancestors` runs its
+                        // own Phase-1 local checks so it's correct even if the
+                        // head is already on chain by the time the task starts.
+                        {
+                            let mut guard = recovering_heads.lock();
+                            if guard.contains(&block_hash) {
+                                return None;
+                            }
+                            guard.insert(block_hash);
+                        }
+                        let provider = forkchoice_engine.provider.clone();
+                        let engine_clone = engine.clone();
+                        let forkchoice_engine_clone = forkchoice_engine.clone();
+                        let recovering = recovering_heads.clone();
+                        let peer = resolve_bsc_peer_static(peer_id);
+                        let failed_heads = failed_heads.clone();
+                        tokio::spawn(async move {
+                            let _guard = crate::node::network::block_import::fork_recover::RecoveringHeadGuard::new(
+                                block_hash, recovering,
+                            );
+                            let fetcher =
+                                crate::node::network::block_import::fork_recover::BscRangeFetcher;
+                            let Some(target) = peer else {
+                                return;
+                            };
+                            if let Err(err) =
+                                crate::node::network::block_import::fork_recover::recover_ancestors(
+                                    target,
+                                    block_hash,
+                                    block_number,
+                                    provider,
+                                    engine_clone,
+                                    forkchoice_engine_clone,
+                                    &fetcher,
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    target: "bsc::block_import",
+                                    %block_hash,
+                                    block_number,
+                                    error = %err,
+                                    "Fork recovery failed (Syncing path)"
+                                );
+                                failed_heads.mark_failed(block_hash);
+                            }
+                        });
                         None
                     }
                     _ => None,
@@ -319,7 +390,9 @@ where
                         block_hash = %block_hash,
                         "Inserting mined block into engine tree"
                     );
-                    if let Err(e) = engine_tx.send(EngineApiRequest::InsertExecutedBlock(executed_block)) {
+                    if let Err(e) =
+                        engine_tx.send(EngineApiRequest::InsertExecutedBlock(executed_block))
+                    {
                         tracing::warn!(
                             target: "bsc::block_import",
                             block_number = %header_for_fcu.number,
@@ -434,102 +507,203 @@ where
         self.pending_imports.push(payload_fut);
     }
 
-    /// Handle incoming block hashes by using Reth engine-tree download mechanism
+    /// Handle incoming block hashes by spawning fork-aware ancestor recovery
+    /// for any head we do not already have. Announcements whose height exceeds
+    /// the local tip by more than `PIPELINE_TRIGGER_DELTA` are instead routed
+    /// to the staged backfill pipeline via a synthesized FCU — `fork_recover`
+    /// cannot close gaps that deep.
     fn on_new_block_hashes(&mut self, hashes: NewBlockHashes, peer_id: PeerId) {
-        let hash_numbers = hashes.0.clone();
+        let local_tip = match self.forkchoice_engine.provider.best_block_number() {
+            Ok(tip) => tip,
+            Err(err) => {
+                tracing::warn!(
+                    target: "bsc::block_import",
+                    error = %err,
+                    "Failed to read local best_block_number; skipping hash announcements"
+                );
+                return;
+            }
+        };
 
-        for hash_number in hash_numbers {
-            // Skip if the block is already processed.
+        for hash_number in hashes.0 {
             if self.processed_blocks.contains(&hash_number.hash) {
-                tracing::trace!(target: "bsc::block_import", "Block already processed when requesting block hashes: number = {:?}, hash = {:?}", hash_number.number, hash_number.hash);
                 continue;
             }
             if self.queued_blocks.contains(&hash_number.hash) {
-                tracing::trace!(target: "bsc::block_import", "Block already queued when requesting block hashes: number = {:?}, hash = {:?}", hash_number.number, hash_number.hash);
+                continue;
+            }
+            if self.failed_heads.is_cooling(&hash_number.hash) {
+                tracing::debug!(
+                    target: "bsc::block_import",
+                    block_hash = %hash_number.hash,
+                    block_number = hash_number.number,
+                    "Skipping fork recovery: head is in cooldown after recent failure"
+                );
                 continue;
             }
 
-            // Check if the block is already being downloaded, if it times out, download it again.
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis();
-            if let Some(last_requested) = self.downloading_blocks.get(&hash_number.hash) {
-                if *last_requested + DOWNLOAD_COOLDOWN_DURATION_MS > now {
+            let delta = hash_number.number.saturating_sub(local_tip);
+            if delta > PIPELINE_TRIGGER_DELTA {
+                // Far-behind: fork_recover's 2048-ancestor walk cannot close
+                // this gap. Mark processed so subsequent announcements of the
+                // same head are deduped, then synthesize an FCU. Engine-tree's
+                // optimistic-sync branch treats `head_block_hash` as a
+                // backfill target when `finalized_block_hash` is zero (BSC has
+                // no CL to supply one).
+                self.processed_blocks.insert(hash_number.hash);
+                self.spawn_pipeline_trigger_fcu(
+                    peer_id,
+                    hash_number.hash,
+                    hash_number.number,
+                    local_tip,
+                    delta,
+                );
+                continue;
+            }
+
+            // Concurrent-dedup: one recovery per head at a time.
+            {
+                let mut guard = self.recovering_heads.lock();
+                if guard.contains(&hash_number.hash) {
                     continue;
                 }
+                guard.insert(hash_number.hash);
             }
 
             tracing::debug!(
                 target: "bsc::block_import",
-                peer_id = %peer_id,
+                %peer_id,
                 block_hash = %hash_number.hash,
                 block_number = hash_number.number,
-                "Requesting block download for NewBlockHashes"
+                "Spawning fork recovery for announced head"
             );
 
-            // Try quick range fetch via BSC subprotocol (mimic geth asyncFetchRangeBlocks)
-            // Prefer the announcing peer; if it doesn't have bsc extension, fallback to any bsc peer.
-            let start_height = hash_number.number;
-            let start_hash = hash_number.hash;
-            let announcing_peer = peer_id;
-            // Resolve target bsc peer
-            let target_peer = if crate::node::network::bsc_protocol::registry::has_registered_peer(
-                announcing_peer,
-            ) {
-                Some(announcing_peer)
-            } else {
-                crate::node::network::bsc_protocol::registry::list_registered_peers()
-                    .into_iter()
-                    .next()
-            };
-            if let Some(bsc_peer) = target_peer {
-                tracing::debug!(
-                    target: "bsc::block_import",
-                    peer_id = %bsc_peer,
-                    block_hash = %start_hash,
-                    block_number = start_height,
-                    "Requesting block with block range for NewBlockHashes"
-                );
-                tokio::spawn(async move {
-                    use std::time::Duration;
-                    // Bump request timeout to 1000ms to accommodate slower peers
-                    let req_timeout = Duration::from_millis(DOWNLOAD_COOLDOWN_DURATION_MS as u64);
-                    let _ = crate::node::network::bsc_protocol::registry::batch_request_range_and_await_import(
-                        bsc_peer,
-                        start_height,
-                        start_hash,
-                        1,
-                        req_timeout,
-                    ).await;
-                });
-            }
-            self.downloading_blocks.insert(hash_number.hash, now);
+            let peer = self.resolve_bsc_peer(peer_id);
+            let provider = self.forkchoice_engine.provider.clone();
+            let engine = self.engine.clone();
+            let forkchoice_engine = self.forkchoice_engine.clone();
+            let recovering = self.recovering_heads.clone();
+            let failed_heads = self.failed_heads.clone();
+            let head_hash = hash_number.hash;
+            let head_num = hash_number.number;
+
+            tokio::spawn(async move {
+                let _guard =
+                    crate::node::network::block_import::fork_recover::RecoveringHeadGuard::new(
+                        head_hash, recovering,
+                    );
+                let fetcher = crate::node::network::block_import::fork_recover::BscRangeFetcher;
+                let Some(target) = peer else {
+                    tracing::debug!(
+                        target: "bsc::block_import",
+                        %head_hash,
+                        "No BSC protocol peer available for fork recovery"
+                    );
+                    return;
+                };
+                if let Err(err) =
+                    crate::node::network::block_import::fork_recover::recover_ancestors(
+                        target,
+                        head_hash,
+                        head_num,
+                        provider,
+                        engine,
+                        forkchoice_engine,
+                        &fetcher,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        target: "bsc::block_import",
+                        %head_hash,
+                        head_num,
+                        error = %err,
+                        "Fork recovery failed"
+                    );
+                    failed_heads.mark_failed(head_hash);
+                }
+            });
         }
+    }
+
+    /// Pick a peer to route `GetBlocksByRange` to. Prefer the announcing peer
+    /// if it speaks the BSC sub-protocol; otherwise any registered BSC peer.
+    fn resolve_bsc_peer(&self, announcer: PeerId) -> Option<PeerId> {
+        resolve_bsc_peer_static(announcer)
+    }
+
+    /// Synthesize a `forkchoiceUpdated` call targeting the announced peer head
+    /// so engine-tree's optimistic-sync branch can start the staged backfill
+    /// pipeline. Used for announcements whose gap exceeds
+    /// `PIPELINE_TRIGGER_DELTA`, where `fork_recover` cannot help.
+    fn spawn_pipeline_trigger_fcu(
+        &self,
+        peer_id: PeerId,
+        head_hash: B256,
+        head_num: u64,
+        local_tip: u64,
+        delta: u64,
+    ) {
+        let engine = self.engine.clone();
+        tracing::info!(
+            target: "bsc::block_import",
+            %peer_id,
+            %head_hash,
+            head_num,
+            local_tip,
+            delta,
+            "Far-behind gap detected; dispatching pipeline-trigger FCU"
+        );
+        tokio::spawn(async move {
+            let state = ForkchoiceState {
+                head_block_hash: head_hash,
+                safe_block_hash: B256::ZERO,
+                finalized_block_hash: B256::ZERO,
+            };
+            match engine.fork_choice_updated(state, None, EngineApiMessageVersion::V1).await {
+                Ok(ret) => tracing::info!(
+                    target: "bsc::block_import",
+                    %head_hash,
+                    head_num,
+                    status = ?ret.payload_status.status,
+                    "Pipeline-trigger FCU dispatched"
+                ),
+                Err(err) => tracing::warn!(
+                    target: "bsc::block_import",
+                    %head_hash,
+                    head_num,
+                    error = %err,
+                    "Pipeline-trigger FCU failed"
+                ),
+            }
+        });
     }
 
     /// Transfer the block to EVN peers if from proxied validators or validator address.
     fn transfer_to_evn_peers(&self, block: BlockMsg) -> Result<(), Box<dyn std::error::Error>> {
-        let mining_config = crate::node::miner::config::get_global_mining_config().ok_or("Mining config is not set")?;
-        let cfg = crate::node::network::evn::get_global_evn_config().ok_or("EVN config is not set")?;
+        let mining_config = crate::node::miner::config::get_global_mining_config()
+            .ok_or("Mining config is not set")?;
+        let cfg =
+            crate::node::network::evn::get_global_evn_config().ok_or("EVN config is not set")?;
         if !cfg.enabled {
             return Ok(());
         }
         let header_ref = &block.block.0.block.header;
         let coinbase = header_ref.beneficiary;
         // If from proxied validators or validator address, target EVN peers with ETH NewBlockHashes.
-        if cfg.proxyed_validators.contains(&coinbase) || (mining_config.enabled && mining_config.validator_address.unwrap_or_default() == coinbase) {
+        if cfg.proxyed_validators.contains(&coinbase)
+            || (mining_config.enabled
+                && mining_config.validator_address.unwrap_or_default() == coinbase)
+        {
             if let Some(net) = crate::shared::get_network_handle() {
                 let peers = crate::node::network::evn_peers::snapshot();
                 for (peer_id, info) in peers {
                     // Send to EVN peers or proxyed peers
-                    let is_proxyed = crate::node::network::bsc_protocol::registry::is_proxyed_peer(&peer_id);
+                    let is_proxyed =
+                        crate::node::network::bsc_protocol::registry::is_proxyed_peer(&peer_id);
                     if info.is_evn || is_proxyed {
                         // Send full NewBlock to EVN/proxyed peers to avoid re-fetching.
-                        net.send_eth_message(
-                            peer_id,
-                            PeerMessage::NewBlock(block.clone()),
-                        );
+                        net.send_eth_message(peer_id, PeerMessage::NewBlock(block.clone()));
                         tracing::debug!(target: "bsc::block_import", "Sent full NewBlock to EVN/proxyed peer: number = {:?}, hash = {:?}, peer = {:?}", block.block.0.block.header.number, block.hash, peer_id);
                     }
                 }
@@ -537,11 +711,119 @@ where
         }
         Ok(())
     }
+
+    /// Read local head and spawn a detached task that announces it to every
+    /// connected peer that is not more than 64 blocks ahead of us.
+    ///
+    /// Runs on every `announce_interval` tick. This is the livelock-breaking
+    /// mechanism for the case where two validators are forked and both are
+    /// blocked from producing new blocks: without this, neither learns of the
+    /// other's head after the initial handshake.
+    fn spawn_head_announcement(&self) {
+        let provider = self.forkchoice_engine.provider.clone();
+
+        tokio::spawn(async move {
+            // Resolve local head.
+            let num = match provider.best_block_number() {
+                Ok(n) if n > 0 => n,
+                Ok(_) => {
+                    tracing::debug!(target: "bsc::block_import", "Skip head announce: local best_block_number is 0");
+                    return;
+                }
+                Err(e) => {
+                    tracing::debug!(target: "bsc::block_import", error = %e, "Skip head announce: failed to read best_block_number");
+                    return;
+                }
+            };
+            let hash = match provider.block_hash(num) {
+                Ok(Some(h)) => h,
+                Ok(None) => {
+                    tracing::debug!(target: "bsc::block_import", num, "Skip head announce: no hash for best_block_number");
+                    return;
+                }
+                Err(e) => {
+                    tracing::debug!(target: "bsc::block_import", num, error = %e, "Skip head announce: block_hash lookup failed");
+                    return;
+                }
+            };
+
+            // Resolve network handle.
+            let net = match crate::shared::get_network_handle() {
+                Some(n) => n,
+                None => {
+                    tracing::debug!(target: "bsc::block_import", "Skip head announce: network handle not yet initialized");
+                    return;
+                }
+            };
+
+            // Query peers.
+            let peers = match net.get_all_peers().await {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::debug!(target: "bsc::block_import", error = %e, "Skip head announce: get_all_peers failed");
+                    return;
+                }
+            };
+            if peers.is_empty() {
+                return;
+            }
+
+            let peer_tuples: Vec<(PeerId, Option<u64>)> =
+                peers.iter().map(|p| (p.remote_id, p.best_number)).collect();
+            let targets = plan_head_announcements(num, &peer_tuples);
+
+            if targets.is_empty() {
+                return;
+            }
+
+            let hashes = NewBlockHashes(vec![BlockHashNumber { hash, number: num }]);
+            let target_count = targets.len();
+            for peer_id in targets {
+                tracing::debug!(
+                    target: "bsc::block_import",
+                    %peer_id,
+                    local_num = num,
+                    %hash,
+                    "Sending head announce to peer"
+                );
+                net.send_eth_message(peer_id, PeerMessage::NewBlockHashes(hashes.clone()));
+            }
+            tracing::debug!(
+                target: "bsc::block_import",
+                local_num = num,
+                sent_to = target_count,
+                total_peers = peers.len(),
+                "Announced head to peers"
+            );
+        });
+    }
+}
+
+/// Decide which peers to send `NewBlockHashes(local_head)` to.
+///
+/// A peer is skipped when its known `best_number` is more than
+/// `MAX_STALE_BLOCK_DISTANCE` (64) blocks ahead of the local head: announcing a
+/// stale hash to such a peer would be dropped and trigger a `BadAnnouncement`
+/// reputation penalty on us.
+///
+/// A peer with `best_number = None` (head not yet observed) is announced to:
+/// there's no evidence it is ahead, and the worst case is the peer ignores the
+/// hint.
+fn plan_head_announcements(local_head: u64, peers: &[(PeerId, Option<u64>)]) -> Vec<PeerId> {
+    const MAX_STALE_BLOCK_DISTANCE: u64 = 64;
+    peers
+        .iter()
+        .filter_map(|(peer_id, peer_best)| match peer_best {
+            Some(peer_best) if local_head + MAX_STALE_BLOCK_DISTANCE < *peer_best => None,
+            _ => Some(*peer_id),
+        })
+        .collect()
 }
 
 impl<Provider> Future for ImportService<Provider>
 where
     Provider: BlockNumReader
+        + BlockHashReader
         + HeaderProvider<Header = Header>
         + Clone
         + Send
@@ -596,6 +878,13 @@ where
             }
         }
 
+        // Drive periodic head announcement to break forked-validator livelocks.
+        // Each tick spawns a detached task so we never block the poll loop on
+        // the async `get_all_peers()` query.
+        while this.announce_interval.poll_tick(cx).is_ready() {
+            this.spawn_head_announcement();
+        }
+
         Poll::Pending
     }
 }
@@ -644,7 +933,10 @@ mod tests {
         let mut fixture = TestFixture::new(EngineResponses::invalid_new_payload()).await;
         fixture
             .assert_block_import(|outcome| {
-                matches!(outcome, BlockImportEvent::Announcement(BlockValidation::ValidHeader { .. }))
+                matches!(
+                    outcome,
+                    BlockImportEvent::Announcement(BlockValidation::ValidHeader { .. })
+                )
             })
             .await;
 
@@ -1040,5 +1332,205 @@ mod tests {
                 }
             }
         }));
+    }
+
+    /// Spawn an `ImportService` with `MockProvider::best_block_number = local_tip`
+    /// and an engine handler that forwards every observed `ForkchoiceState`
+    /// into the returned channel, and every `NewPayload` into the other.
+    /// Replies Valid to both kinds of message so the service doesn't block.
+    async fn spawn_service_with_tip(
+        local_tip: u64,
+    ) -> (ImportHandle, mpsc::UnboundedReceiver<ForkchoiceState>, mpsc::UnboundedReceiver<()>) {
+        let mut provider = MockProvider::new();
+        let header = Header { number: local_tip, ..Default::default() };
+        provider.insert(header, U256::from(1));
+        let chain_spec =
+            Arc::new(crate::chainspec::BscChainSpec::from(crate::chainspec::bsc::bsc_mainnet()));
+
+        let (to_engine, mut from_engine) = mpsc::unbounded_channel();
+        let engine_handle = ConsensusEngineHandle::new(to_engine);
+
+        let (fcu_tx, fcu_rx) = mpsc::unbounded_channel();
+        let (np_tx, np_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(message) = from_engine.recv().await {
+                match message {
+                    BeaconEngineMessage::NewPayload { payload: _, tx } => {
+                        let _ = np_tx.send(());
+                        let _ = tx.send(Ok(PayloadStatus::new(PayloadStatusEnum::Valid, None)));
+                    }
+                    BeaconEngineMessage::ForkchoiceUpdated {
+                        state,
+                        payload_attrs: _,
+                        version: _,
+                        tx,
+                    } => {
+                        let _ = fcu_tx.send(state);
+                        let _ = tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::new(
+                            PayloadStatusEnum::Valid,
+                            None,
+                        ))));
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let (to_import, from_network) = mpsc::unbounded_channel();
+        let (_to_import_mined, from_builder) = mpsc::unbounded_channel();
+        let (to_hashes, from_hashes) = mpsc::unbounded_channel();
+        let (to_network, import_outcome) = mpsc::unbounded_channel();
+        let handle = ImportHandle::new(to_import, to_hashes, import_outcome);
+
+        let service = ImportService::new(
+            provider,
+            chain_spec,
+            engine_handle,
+            from_network,
+            from_builder,
+            from_hashes,
+            to_network,
+        );
+        tokio::spawn(Box::pin(async move {
+            service.await.unwrap();
+        }));
+
+        (handle, fcu_rx, np_rx)
+    }
+
+    /// Try to receive a FCU from the observation channel within `timeout`.
+    async fn recv_fcu_within(
+        fcu_rx: &mut mpsc::UnboundedReceiver<ForkchoiceState>,
+        timeout: tokio::time::Duration,
+    ) -> Option<ForkchoiceState> {
+        tokio::time::timeout(timeout, fcu_rx.recv()).await.ok().flatten()
+    }
+
+    #[tokio::test]
+    async fn routes_far_behind_announcement_to_pipeline_fcu() {
+        // Local tip = 100. Announce a head whose gap exceeds the threshold by
+        // one. Expect the engine to see exactly one FCU with the announced
+        // hash as `head_block_hash` and zeroed safe/finalized.
+        let (handle, mut fcu_rx, _np_rx) = spawn_service_with_tip(100).await;
+
+        let head_hash = B256::from([0xAA; 32]);
+        let head_num = 100 + PIPELINE_TRIGGER_DELTA + 1;
+        let hashes = NewBlockHashes(vec![BlockHashNumber { hash: head_hash, number: head_num }]);
+        handle.send_hashes(hashes, PeerId::random()).unwrap();
+
+        let fcu = recv_fcu_within(&mut fcu_rx, tokio::time::Duration::from_millis(500))
+            .await
+            .expect("expected a pipeline-trigger FCU");
+        assert_eq!(fcu.head_block_hash, head_hash);
+        assert_eq!(fcu.safe_block_hash, B256::ZERO);
+        assert_eq!(fcu.finalized_block_hash, B256::ZERO);
+    }
+
+    #[tokio::test]
+    async fn routes_at_threshold_to_fork_recover_not_pipeline() {
+        // Equality case: gap == PIPELINE_TRIGGER_DELTA (2048). Threshold is a
+        // strict `>`, so this announcement must NOT dispatch an FCU — it goes
+        // to fork_recover (which will itself no-op here since the MockProvider
+        // has no BSC peer and no ancestry, but we only assert absence of FCU).
+        let (handle, mut fcu_rx, _np_rx) = spawn_service_with_tip(100).await;
+
+        let head_hash = B256::from([0xBB; 32]);
+        let head_num = 100 + PIPELINE_TRIGGER_DELTA;
+        let hashes = NewBlockHashes(vec![BlockHashNumber { hash: head_hash, number: head_num }]);
+        handle.send_hashes(hashes, PeerId::random()).unwrap();
+
+        assert!(
+            recv_fcu_within(&mut fcu_rx, tokio::time::Duration::from_millis(200)).await.is_none(),
+            "announcement at the exact threshold must not dispatch an FCU"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_fcu_deduped_by_processed_blocks_cache() {
+        // Same head announced twice from two peers should dispatch exactly
+        // one FCU — the Option-A concurrency policy relies on
+        // `processed_blocks.insert(..)` right before spawning the FCU.
+        let (handle, mut fcu_rx, _np_rx) = spawn_service_with_tip(100).await;
+
+        let head_hash = B256::from([0xCC; 32]);
+        let head_num = 100 + PIPELINE_TRIGGER_DELTA + 10;
+        let hashes = NewBlockHashes(vec![BlockHashNumber { hash: head_hash, number: head_num }]);
+
+        handle.send_hashes(hashes.clone(), PeerId::random()).unwrap();
+        // Let the first FCU be dispatched and recorded.
+        let first = recv_fcu_within(&mut fcu_rx, tokio::time::Duration::from_millis(500))
+            .await
+            .expect("expected one FCU");
+        assert_eq!(first.head_block_hash, head_hash);
+
+        // Re-announce the same head. Must be deduped.
+        handle.send_hashes(hashes, PeerId::random()).unwrap();
+        assert!(
+            recv_fcu_within(&mut fcu_rx, tokio::time::Duration::from_millis(200)).await.is_none(),
+            "duplicate head announcement must not dispatch a second FCU"
+        );
+    }
+
+    fn peer(tag: u8, best_number: Option<u64>) -> (PeerId, Option<u64>) {
+        // `PeerId` is `alloy_primitives::B512`. Build a deterministic 64-byte
+        // value from the tag via the `From<[u8; 64]>` impl.
+        let mut bytes = [0u8; 64];
+        bytes[0] = tag;
+        (PeerId::from(bytes), best_number)
+    }
+
+    #[test]
+    fn planner_announces_when_we_are_ahead() {
+        let peers = vec![peer(1, Some(100))];
+        let result = plan_head_announcements(200, &peers);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], peers[0].0);
+    }
+
+    #[test]
+    fn planner_announces_at_exact_64_gap_boundary() {
+        // Receiver drops only on strict `num + 64 < peer_best`, so gap == 64 is still fine.
+        let local = 100;
+        let peers = vec![peer(1, Some(local + 64))];
+        let result = plan_head_announcements(local, &peers);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn planner_skips_peer_more_than_64_ahead() {
+        let local = 100;
+        let peers = vec![peer(1, Some(local + 65))];
+        let result = plan_head_announcements(local, &peers);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn planner_announces_when_peer_best_number_unknown() {
+        // best_number is None before any head info has been observed; announce is the right default.
+        let peers = vec![peer(1, None)];
+        let result = plan_head_announcements(100, &peers);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn planner_mixes_skip_and_announce_across_peers() {
+        let local = 1000;
+        let p_ahead = peer(1, Some(local + 65)); // skipped
+        let p_at_boundary = peer(2, Some(local + 64)); // announced
+        let p_behind = peer(3, Some(local - 10)); // announced
+        let p_unknown = peer(4, None); // announced
+        let peers = vec![p_ahead, p_at_boundary, p_behind, p_unknown];
+        let result = plan_head_announcements(local, &peers);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&p_at_boundary.0));
+        assert!(result.contains(&p_behind.0));
+        assert!(result.contains(&p_unknown.0));
+        assert!(!result.contains(&p_ahead.0));
+    }
+
+    #[test]
+    fn planner_returns_empty_on_no_peers() {
+        let result = plan_head_announcements(100, &[]);
+        assert!(result.is_empty());
     }
 }

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -76,8 +76,6 @@ const LRU_PROCESSED_BLOCKS_SIZE: u32 = 100;
 /// can reach a common ancestor and resolve the reorg itself; beyond it, the
 /// ancestor walk must fail (`ForkTooDeep`), so we skip the doomed attempt and
 /// hand off to the pipeline via engine-tree's optimistic-sync branch.
-///
-/// See `docs/superpowers/specs/2026-04-21-far-behind-pipeline-trigger-design.md`.
 const PIPELINE_TRIGGER_DELTA: u64 =
     crate::node::network::block_import::fork_recover::MAX_FORK_DEPTH;
 

--- a/src/node/network/blocks_by_range.rs
+++ b/src/node/network/blocks_by_range.rs
@@ -70,36 +70,36 @@ impl Decodable for BlocksByRangePacket {
     }
 }
 
-/// Build a best-effort response for a GetBlocksByRange request using only headers if needed.
-///
-/// Note: This currently constructs blocks with empty bodies if full data is not available
-/// via global providers. It prioritizes `start_block_hash` if non-zero, otherwise uses
-/// `start_block_height`. The traversal follows parent hashes up to `count` blocks.
-pub fn build_blocks_by_range_response(req: &GetBlocksByRangePacket) -> BlocksByRangePacket {
-    use crate::shared::{get_cached_block_by_hash, get_cached_block_by_number};
-
+/// Pure variant of [`build_blocks_by_range_response`] parameterised by a block
+/// lookup. `lookup(hash, number_opt)` returns `Some(block)` when the block is
+/// available. The first call receives `number_opt = Some(start_block_height)`
+/// only when `start_block_hash == B256::ZERO`; subsequent hops always pass the
+/// parent hash with `number_opt = None`. Exposed `pub(crate)` for testing.
+pub(crate) fn build_blocks_by_range_response_with<F>(
+    req: &GetBlocksByRangePacket,
+    mut lookup: F,
+) -> BlocksByRangePacket
+where
+    F: FnMut(&B256, Option<u64>) -> Option<BscBlock>,
+{
     let mut blocks: Vec<BscBlock> = Vec::new();
 
-    // Resolve starting block: only include full blocks (cached or provider). If not found, return empty.
     let mut current_block: Option<BscBlock> = if req.start_block_hash != B256::ZERO {
-        get_cached_block_by_hash(&req.start_block_hash)
+        lookup(&req.start_block_hash, None)
     } else {
-        get_cached_block_by_number(req.start_block_height)
+        lookup(&B256::ZERO, Some(req.start_block_height))
     };
 
-    // Walk back by parents up to count
     let mut remaining = req.count.min(MAX_REQUEST_RANGE_BLOCKS_COUNT);
     while let (Some(block), r) = (current_block.clone(), remaining) {
         if r == 0 {
             break;
         }
-        // Push the current full block
         blocks.push(block.clone());
 
-        // Prepare next parent
         let parent_hash = block.header.parent_hash;
         current_block =
-            if parent_hash != B256::ZERO { get_cached_block_by_hash(&parent_hash) } else { None };
+            if parent_hash != B256::ZERO { lookup(&parent_hash, None) } else { None };
         remaining -= 1;
     }
 
@@ -115,6 +115,23 @@ pub fn build_blocks_by_range_response(req: &GetBlocksByRangePacket) -> BlocksByR
     }
 
     BlocksByRangePacket { request_id: req.request_id, blocks }
+}
+
+/// Build a response for a `GetBlocksByRange` request using the BODY_CACHE
+/// first, then the installed [`crate::shared::FullBlockProvider`]
+/// (DB / canonical state).
+pub fn build_blocks_by_range_response(req: &GetBlocksByRangePacket) -> BlocksByRangePacket {
+    use crate::shared::{
+        get_cached_block_by_hash, get_cached_block_by_number, get_full_block_provider,
+    };
+
+    let provider = get_full_block_provider();
+    build_blocks_by_range_response_with(req, |hash, number_opt| match number_opt {
+        Some(num) => get_cached_block_by_number(num)
+            .or_else(|| provider.as_ref().and_then(|p| p.block_by_number(num))),
+        None => get_cached_block_by_hash(hash)
+            .or_else(|| provider.as_ref().and_then(|p| p.block_by_hash(hash))),
+    })
 }
 
 // === RLP inner helpers (without message-id prefix) ===
@@ -190,6 +207,7 @@ mod tests {
     use alloy_rlp::RlpDecodable;
     use reth_primitives::TransactionSigned;
     use bytes::BytesMut;
+    use std::collections::HashMap;
 
     #[test]
     fn test_get_blocks_by_range_codec_roundtrip() {
@@ -374,5 +392,96 @@ mod tests {
         // Parent missing => only child should be included
         assert_eq!(resp.blocks.len(), 1);
         assert_eq!(resp.blocks[0].header.hash_slow(), child_hash);
+    }
+
+    fn mk_block_t3(number: u64, parent: B256) -> BscBlock {
+        BscBlock {
+            header: Header { number, parent_hash: parent, ..Default::default() },
+            body: BscBlockBody {
+                inner: reth_ethereum_primitives::BlockBody::default(),
+                sidecars: None,
+            },
+        }
+    }
+
+    #[test]
+    fn build_response_falls_back_to_provider_lookup_on_cache_miss() {
+        // Simulate a 4-block parent chain only available via the "provider" map.
+        let b3 = mk_block_t3(3, B256::ZERO);
+        let b2 = mk_block_t3(2, b3.header.hash_slow());
+        let b1 = mk_block_t3(1, b2.header.hash_slow());
+        let b0 = mk_block_t3(0, b1.header.hash_slow());
+
+        let mut by_hash: HashMap<B256, BscBlock> = HashMap::new();
+        by_hash.insert(b0.header.hash_slow(), b0.clone());
+        by_hash.insert(b1.header.hash_slow(), b1.clone());
+        by_hash.insert(b2.header.hash_slow(), b2.clone());
+        by_hash.insert(b3.header.hash_slow(), b3.clone());
+
+        let req = GetBlocksByRangePacket {
+            request_id: 42,
+            start_block_height: 0,
+            start_block_hash: b0.header.hash_slow(),
+            count: 4,
+        };
+        let resp =
+            build_blocks_by_range_response_with(&req, |h, _| by_hash.get(h).cloned());
+
+        assert_eq!(resp.request_id, 42);
+        assert_eq!(resp.blocks.len(), 4, "should walk the full chain via provider fallback");
+        assert_eq!(resp.blocks[0].header.number, 0);
+        assert_eq!(resp.blocks[3].header.number, 3);
+    }
+
+    #[test]
+    fn build_response_returns_empty_when_start_block_unknown() {
+        let req = GetBlocksByRangePacket {
+            request_id: 7,
+            start_block_height: 0,
+            start_block_hash: B256::repeat_byte(0xaa),
+            count: 4,
+        };
+        let resp = build_blocks_by_range_response_with(&req, |_, _| None);
+        assert!(resp.blocks.is_empty());
+    }
+
+    #[test]
+    fn build_response_looks_up_by_number_when_hash_is_zero() {
+        let b0 = mk_block_t3(10, B256::ZERO);
+        let req = GetBlocksByRangePacket {
+            request_id: 9,
+            start_block_height: 10,
+            start_block_hash: B256::ZERO,
+            count: 1,
+        };
+        let b0_clone = b0.clone();
+        let resp = build_blocks_by_range_response_with(&req, move |_, n| {
+            if n == Some(10) { Some(b0_clone.clone()) } else { None }
+        });
+        assert_eq!(resp.blocks.len(), 1);
+        assert_eq!(resp.blocks[0].header.number, 10);
+    }
+
+    #[test]
+    fn build_response_returns_empty_when_cache_miss_and_no_provider_installed() {
+        // Pin the public wrapper's fallback wiring: with the broadcast cache cleared
+        // and no FullBlockProvider installed in this test process, a request for an
+        // unknown start block must return an empty response instead of walking a
+        // stale entry. Protects against future refactors dropping the
+        // get_full_block_provider() plumbing in build_blocks_by_range_response.
+        crate::shared::clear_body_cache();
+
+        let req = GetBlocksByRangePacket {
+            request_id: 99,
+            start_block_height: 0,
+            start_block_hash: B256::repeat_byte(0x55),
+            count: 4,
+        };
+        let resp = build_blocks_by_range_response(&req);
+        assert_eq!(resp.request_id, 99);
+        assert!(
+            resp.blocks.is_empty(),
+            "no cache entry + no FullBlockProvider installed must yield empty response"
+        );
     }
 }

--- a/src/node/network/bsc_protocol/registry.rs
+++ b/src/node/network/bsc_protocol/registry.rs
@@ -2,10 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::RwLock;
 
-use alloy_primitives::{U128, U256};
 use once_cell::sync::Lazy;
-use reth_eth_wire::NewBlock;
-use reth_network::message::NewBlockMessage;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
@@ -17,7 +14,6 @@ use super::stream::BscCommand;
 use crate::node::network::blocks_by_range::{
     BlocksByRangePacket, GetBlocksByRangePacket, MAX_REQUEST_RANGE_BLOCKS_COUNT,
 };
-use crate::node::network::BscNewBlock;
 use alloy_primitives::B256;
 use reth_network::Peers;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -162,44 +158,6 @@ pub async fn request_blocks_by_range(
         Ok(Err(_canceled)) => Err("request canceled".to_string()),
         Err(_elapsed) => Err("request timed out".to_string()),
     }
-}
-
-/// Batch request a range and wait for import of the returned blocks.
-/// Returns the list of imported block hashes in ascending order (oldest -> newest).
-pub async fn batch_request_range_and_await_import(
-    peer: PeerId,
-    start_height: u64,
-    start_hash: B256,
-    count: u64,
-    request_timeout: Duration,
-) -> Result<(), String> {
-    let resp =
-        request_blocks_by_range(peer, start_height, start_hash, count, request_timeout).await?;
-    tracing::debug!(
-        target: "bsc::registry",
-        peer = %peer,
-        start_height = start_height,
-        start_hash = %start_hash,
-        count = count,
-        blocks = resp.blocks.len(),
-        "Batch request range and await importing blocks"
-    );
-
-    // Forward blocks to import path (iterate oldest -> newest)
-    if let Some(sender) = crate::shared::get_block_import_sender() {
-        for block in resp.blocks.iter().rev() {
-            let nb = BscNewBlock(NewBlock { block: block.clone(), td: U128::from(0u64) });
-            let hash = block.header.hash_slow();
-            let msg = NewBlockMessage { hash, block: Arc::new(nb), td: Some(U256::ZERO) };
-            if let Err(e) = sender.send((msg, peer)) {
-                tracing::error!(target: "bsc::registry", error=%e, "Failed to send block to import path");
-            }
-        }
-    } else {
-        tracing::debug!(target: "bsc_protocol", "Block import sender not available; dropping range import forward");
-    }
-
-    Ok(())
 }
 
 /// Broadcast votes to all connected peers.
@@ -396,6 +354,116 @@ pub fn spawn_evn_refresh_listener() {
             }
         });
         *guard = Some(handle);
+    }
+}
+
+/// Compute a failover peer ordering: `preferred` first, then up to
+/// `max_attempts - 1` other peers from `registered`, preserving order and
+/// deduplicating. Returns at most `max_attempts` entries.
+pub(crate) fn plan_failover_peers(
+    preferred: PeerId,
+    registered: Vec<PeerId>,
+    max_attempts: usize,
+) -> Vec<PeerId> {
+    if max_attempts == 0 {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(max_attempts);
+    out.push(preferred);
+    for p in registered {
+        if out.len() >= max_attempts {
+            break;
+        }
+        if !out.contains(&p) {
+            out.push(p);
+        }
+    }
+    out
+}
+
+/// Like [`request_blocks_by_range`], but rotates through other registered BSC
+/// peers on `Err` or empty response. Returns the first non-empty success,
+/// otherwise the last seen result (preserving the original error for
+/// diagnostics).
+pub async fn request_blocks_by_range_with_failover(
+    preferred: PeerId,
+    start_height: u64,
+    start_hash: B256,
+    count: u64,
+    timeout_dur: Duration,
+    max_attempts: usize,
+) -> Result<BlocksByRangePacket, String> {
+    let peers = plan_failover_peers(preferred, list_registered_peers(), max_attempts);
+    if peers.is_empty() {
+        return Err("no BSC peers available for range request".to_string());
+    }
+
+    let mut last: Result<BlocksByRangePacket, String> =
+        Err("uninitialised failover".to_string());
+    for (idx, peer) in peers.iter().enumerate() {
+        match request_blocks_by_range(*peer, start_height, start_hash, count, timeout_dur).await {
+            Ok(resp) if !resp.blocks.is_empty() => return Ok(resp),
+            Ok(empty_resp) => {
+                tracing::debug!(
+                    target: "bsc_protocol",
+                    %peer,
+                    attempt = idx + 1,
+                    total = peers.len(),
+                    start_height,
+                    %start_hash,
+                    "Empty BlocksByRange response, trying next peer"
+                );
+                last = Ok(empty_resp);
+            }
+            Err(err) => {
+                tracing::debug!(
+                    target: "bsc_protocol",
+                    %peer,
+                    attempt = idx + 1,
+                    total = peers.len(),
+                    start_height,
+                    %start_hash,
+                    %err,
+                    "BlocksByRange request failed, trying next peer"
+                );
+                last = Err(err);
+            }
+        }
+    }
+    last
+}
+
+#[cfg(test)]
+mod failover_tests {
+    use super::*;
+    use alloy_primitives::B512;
+
+    fn pid(byte: u8) -> PeerId {
+        B512::repeat_byte(byte)
+    }
+
+    #[test]
+    fn plan_puts_preferred_first_and_dedups() {
+        let plan = plan_failover_peers(pid(1), vec![pid(2), pid(1), pid(3)], 3);
+        assert_eq!(plan, vec![pid(1), pid(2), pid(3)]);
+    }
+
+    #[test]
+    fn plan_respects_max_attempts() {
+        let plan = plan_failover_peers(pid(1), vec![pid(2), pid(3), pid(4)], 2);
+        assert_eq!(plan, vec![pid(1), pid(2)]);
+    }
+
+    #[test]
+    fn plan_handles_zero_attempts() {
+        let plan = plan_failover_peers(pid(1), vec![pid(2)], 0);
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn plan_handles_empty_registered() {
+        let plan = plan_failover_peers(pid(1), vec![], 5);
+        assert_eq!(plan, vec![pid(1)]);
     }
 }
 

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -250,18 +250,17 @@ impl BscNetworkBuilder {
         let provider = ctx.provider().clone();
         let chain_spec = ctx.chain_spec().clone();
 
-        // Install a cached full block provider so that BSC BlocksByRange replies
-        // can include full bodies if they were recently imported. External callers
-        // can override by setting a richer provider before network starts.
+        // Install a cached full block provider so BSC BlocksByRange replies can include
+        // full bodies when blocks are in the provider (DB + canonical in-memory state),
+        // not just the broadcast-populated BODY_CACHE.
         {
-            use reth_provider::{BlockNumReader, HeaderProvider};
+            use reth_provider::BlockReader;
             struct CachedFullBlockProvider<P> {
                 inner: P,
             }
             impl<P> crate::shared::FullBlockProvider for CachedFullBlockProvider<P>
             where
-                P: HeaderProvider<Header = alloy_consensus::Header>
-                    + BlockNumReader
+                P: BlockReader<Block = crate::node::primitives::BscBlock>
                     + Clone
                     + Send
                     + Sync
@@ -271,33 +270,15 @@ impl BscNetworkBuilder {
                     &self,
                     hash: &alloy_primitives::B256,
                 ) -> Option<crate::node::primitives::BscBlock> {
-                    crate::shared::get_cached_block_by_hash(hash).or_else(|| {
-                        self.inner.header(*hash).ok().flatten().map(|h| {
-                            crate::node::primitives::BscBlock {
-                                header: h,
-                                body: crate::node::primitives::BscBlockBody {
-                                    inner: reth_ethereum_primitives::BlockBody::default(),
-                                    sidecars: None,
-                                },
-                            }
-                        })
-                    })
+                    crate::shared::get_cached_block_by_hash(hash)
+                        .or_else(|| self.inner.block_by_hash(*hash).ok().flatten())
                 }
                 fn block_by_number(
                     &self,
                     number: u64,
                 ) -> Option<crate::node::primitives::BscBlock> {
-                    crate::shared::get_cached_block_by_number(number).or_else(|| {
-                        self.inner.header_by_number(number).ok().flatten().map(|h| {
-                            crate::node::primitives::BscBlock {
-                                header: h,
-                                body: crate::node::primitives::BscBlockBody {
-                                    inner: reth_ethereum_primitives::BlockBody::default(),
-                                    sidecars: None,
-                                },
-                            }
-                        })
-                    })
+                    crate::shared::get_cached_block_by_number(number)
+                        .or_else(|| self.inner.block_by_number(number).ok().flatten())
                 }
             }
 

--- a/src/node/pool/mod.rs
+++ b/src/node/pool/mod.rs
@@ -216,6 +216,10 @@ where
 
         let blob_store = create_blob_store_with_cache(ctx, blob_cache_size)?;
 
+        // Register blob store globally so the block-body serving path can
+        // look up blob sidecars by tx hash (for GetBlockBodies responses).
+        crate::shared::set_global_blob_store(std::sync::Arc::new(blob_store.clone()));
+
         // Build default Ethereum validator executor
         // BSC rejected EIP-7594 (PeerDAS), so we disable EIP-7594 sidecar support to always
         // use v0 (legacy) blob sidecars and reject v1 (EIP-7594) sidecars.

--- a/src/node/primitives.rs
+++ b/src/node/primitives.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::owned_cow)]
 use alloy_consensus::{BlobTransactionSidecar, Header};
 use alloy_primitives::B256;
-use alloy_rlp::{Encodable, RlpDecodable, RlpEncodable};
+use alloy_rlp::{Decodable, Encodable};
 use reth_ethereum_primitives::{BlockBody, Receipt};
 use reth_primitives::{NodePrimitives, TransactionSigned};
 use reth_primitives_traits::{Block, BlockBody as BlockBodyTrait, InMemorySize};
@@ -22,13 +22,85 @@ impl NodePrimitives for BscPrimitives {
 }
 
 /// BSC representation of a EIP-4844 sidecar.
-#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
+///
+/// RLP encoding matches go-bsc's `BlobSidecar` nested layout:
+///   `[[blobs, commitments, proofs], block_number, block_hash, tx_index, tx_hash]`
+/// The inner `BlobTxSidecar` is encoded as a sub-list, matching the Go struct
+/// `BlobSidecar { BlobTxSidecar, BlockNumber, BlockHash, TxIndex, TxHash }`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BscBlobTransactionSidecar {
     pub inner: BlobTransactionSidecar,
     pub block_number: u64,
     pub block_hash: B256,
     pub tx_index: u64,
     pub tx_hash: B256,
+}
+
+impl Encodable for BscBlobTransactionSidecar {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        // Inner BlobTxSidecar encoded as a nested sub-list: [blobs, commitments, proofs]
+        let inner_fields_len = self.inner.rlp_encoded_fields_length();
+        let inner_header =
+            alloy_rlp::Header { list: true, payload_length: inner_fields_len };
+
+        let payload_len = inner_header.length() + inner_fields_len
+            + self.block_number.length()
+            + self.block_hash.length()
+            + self.tx_index.length()
+            + self.tx_hash.length();
+        alloy_rlp::Header { list: true, payload_length: payload_len }.encode(out);
+        inner_header.encode(out);
+        self.inner.rlp_encode_fields(out);
+        self.block_number.encode(out);
+        self.block_hash.encode(out);
+        self.tx_index.encode(out);
+        self.tx_hash.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let inner_fields_len = self.inner.rlp_encoded_fields_length();
+        let inner_header =
+            alloy_rlp::Header { list: true, payload_length: inner_fields_len };
+
+        let payload_len = inner_header.length() + inner_fields_len
+            + self.block_number.length()
+            + self.block_hash.length()
+            + self.tx_index.length()
+            + self.tx_hash.length();
+        alloy_rlp::Header { list: true, payload_length: payload_len }.length() + payload_len
+    }
+}
+
+impl Decodable for BscBlobTransactionSidecar {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining_before = buf.len();
+
+        // Decode inner BlobTxSidecar from a nested sub-list
+        let inner_header = alloy_rlp::Header::decode(buf)?;
+        if !inner_header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let inner_remaining = buf.len();
+        let inner = BlobTransactionSidecar::rlp_decode_fields(buf)?;
+        let inner_consumed = inner_remaining - buf.len();
+        if inner_consumed != inner_header.payload_length {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        let block_number = u64::decode(buf)?;
+        let block_hash = B256::decode(buf)?;
+        let tx_index = u64::decode(buf)?;
+        let tx_hash = B256::decode(buf)?;
+        let consumed = remaining_before - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(Self { inner, block_number, block_hash, tx_index, tx_hash })
+    }
 }
 
 /// Block body for BSC. It is equivalent to Ethereum [`BlockBody`] but additionally stores sidecars
@@ -144,7 +216,7 @@ impl Block for BscBlock {
 mod rlp {
     use super::*;
     use alloy_eips::eip4895::Withdrawals;
-    use alloy_rlp::Decodable;
+    use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
 
     #[derive(RlpEncodable, RlpDecodable)]
     #[rlp(trailing)]
@@ -170,10 +242,20 @@ mod rlp {
             let BscBlockBody { inner: BlockBody { transactions, ommers, withdrawals }, sidecars } =
                 value;
 
+            // Geth decodes withdrawals as a list type. When sidecars are present but
+            // withdrawals are absent, encode empty withdrawals as `[]` (0xC0) instead of
+            // relying on the `#[rlp(trailing)]` placeholder `0x80` which Go rejects as
+            // "wrong kind of empty value (got String, want List)".
+            let withdrawals = match (withdrawals.as_ref(), sidecars.as_ref()) {
+                (None, Some(_)) => Some(Cow::Owned(Withdrawals::default())),
+                (Some(w), _) => Some(Cow::Borrowed(w)),
+                (None, None) => None,
+            };
+
             Self {
                 transactions: Cow::Borrowed(transactions),
                 ommers: Cow::Borrowed(ommers),
-                withdrawals: withdrawals.as_ref().map(Cow::Borrowed),
+                withdrawals,
                 sidecars: sidecars.as_ref().map(Cow::Borrowed),
             }
         }
@@ -187,11 +269,18 @@ mod rlp {
                     BscBlockBody { inner: BlockBody { transactions, ommers, withdrawals }, sidecars },
             } = value;
 
+            // Same withdrawals backfill as BlockBodyHelper — see comment there.
+            let withdrawals = match (withdrawals.as_ref(), sidecars.as_ref()) {
+                (None, Some(_)) => Some(Cow::Owned(Withdrawals::default())),
+                (Some(w), _) => Some(Cow::Borrowed(w)),
+                (None, None) => None,
+            };
+
             Self {
                 header: Cow::Borrowed(header),
                 transactions: Cow::Borrowed(transactions),
                 ommers: Cow::Borrowed(ommers),
-                withdrawals: withdrawals.as_ref().map(Cow::Borrowed),
+                withdrawals,
                 sidecars: sidecars.as_ref().map(Cow::Borrowed),
             }
         }
@@ -440,6 +529,111 @@ mod tests {
     }
 
     #[test]
+    fn test_body_encodes_empty_withdrawals_as_list_when_sidecars_present() {
+        // Regression test: when sidecars are present but withdrawals is None,
+        // the encoder must produce an empty list (0xC0) for withdrawals, NOT the
+        // RLP empty string (0x80). Go's decoder rejects 0x80 for slice/struct
+        // pointer types because nilKind = List.
+        use alloy_rlp::{Decodable, Encodable};
+
+        let body = BscBlockBody {
+            inner: BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: None,  // <-- None, but sidecars present
+            },
+            sidecars: Some(Vec::new()),
+        };
+
+        let mut buf = Vec::new();
+        body.encode(&mut buf);
+
+        // Decode the body back
+        let decoded = BscBlockBody::decode(&mut buf.as_slice())
+            .expect("Failed to decode body with backfilled withdrawals");
+
+        // The decoded body should have withdrawals = Some(empty), not None
+        assert!(
+            decoded.inner.withdrawals.is_some(),
+            "withdrawals should be Some after backfill"
+        );
+        assert!(
+            decoded.inner.withdrawals.as_ref().unwrap().is_empty(),
+            "withdrawals should be empty"
+        );
+        assert!(decoded.sidecars.is_some(), "sidecars should be preserved");
+
+        // Verify the raw RLP bytes do NOT contain 0x80 as a withdrawals placeholder.
+        // After [txs_list, ommers_list], the next byte should be 0xC0 (empty list),
+        // not 0x80 (empty string).
+        // The outer list header is the first few bytes, then txs=0xC0, ommers=0xC0,
+        // so the 4th byte (index 3) should be 0xC0 (empty withdrawals list).
+        // Outer header for small body: 0xC0 + len => 1 byte header
+        // Then: txs=0xC0, ommers=0xC0, withdrawals=?, sidecars=0xC0
+        assert!(
+            !buf.windows(2).any(|w| w == [0x80, 0xC0]),
+            "Should not have 0x80 (empty string) followed by 0xC0 — withdrawals must be 0xC0 (empty list)"
+        );
+    }
+
+    #[test]
+    fn test_block_encodes_empty_withdrawals_as_list_when_sidecars_present() {
+        // Same test but for BscBlock encoding (BlockHelper path)
+        use alloy_rlp::{Decodable, Encodable};
+
+        let block = BscBlock {
+            header: Header::default(),
+            body: BscBlockBody {
+                inner: BlockBody {
+                    transactions: vec![],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+                sidecars: Some(Vec::new()),
+            },
+        };
+
+        let mut buf = Vec::new();
+        block.encode(&mut buf);
+
+        let decoded = BscBlock::decode(&mut buf.as_slice())
+            .expect("Failed to decode block with backfilled withdrawals");
+
+        assert!(
+            decoded.body.inner.withdrawals.is_some(),
+            "withdrawals should be Some after backfill"
+        );
+        assert!(decoded.body.sidecars.is_some(), "sidecars should be preserved");
+    }
+
+    #[test]
+    fn test_body_no_backfill_when_no_sidecars() {
+        // When sidecars are None, withdrawals=None should remain None (no backfill)
+        use alloy_rlp::{Decodable, Encodable};
+
+        let body = BscBlockBody {
+            inner: BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: None,
+            },
+            sidecars: None,
+        };
+
+        let mut buf = Vec::new();
+        body.encode(&mut buf);
+
+        let decoded = BscBlockBody::decode(&mut buf.as_slice())
+            .expect("Failed to decode body without sidecars");
+
+        assert!(
+            decoded.inner.withdrawals.is_none(),
+            "withdrawals should remain None when no sidecars"
+        );
+        assert!(decoded.sidecars.is_none(), "sidecars should remain None");
+    }
+
+    #[test]
     fn test_rlp_length_empty_withdrawals_less_than_encoded() {
         use alloy_rlp::Encodable;
 
@@ -460,6 +654,68 @@ mod tests {
             computed_length + 1,
             actual_length,
             "Computed RLP length for empty withdrawals should be 1 byte less than actual encoded length"
+        );
+    }
+
+    #[test]
+    fn test_blob_sidecar_nested_rlp_layout() {
+        // Regression test: BscBlobTransactionSidecar must encode BlobTxSidecar as a
+        // nested sub-list to match go-bsc's struct layout:
+        //   BlobSidecar { BlobTxSidecar, BlockNumber, BlockHash, TxIndex, TxHash }
+        //
+        // Expected RLP: [[blobs, commitments, proofs], block_number, block_hash, tx_index, tx_hash]
+        // NOT the flat:  [blobs, commitments, proofs, block_number, block_hash, tx_index, tx_hash]
+        //
+        // go-bsc decodes field-by-field: it reads the first element as BlobTxSidecar
+        // (expecting a list), then block_number, etc. A flat encoding causes:
+        //   "rlp: expected input list for []kzg4844.Blob"
+        use alloy_rlp::{Decodable, Encodable};
+
+        let sidecar = BscBlobTransactionSidecar {
+            inner: BlobTransactionSidecar {
+                blobs: vec![alloy_eips::eip4844::Blob::default()],
+                commitments: vec![alloy_eips::eip4844::Bytes48::default()],
+                proofs: vec![alloy_eips::eip4844::Bytes48::default()],
+            },
+            block_number: 42,
+            block_hash: B256::repeat_byte(0xab),
+            tx_index: 7,
+            tx_hash: B256::repeat_byte(0xcd),
+        };
+
+        // Encode
+        let mut buf = Vec::new();
+        sidecar.encode(&mut buf);
+
+        // Verify nested structure: outer list → first element must be a list (BlobTxSidecar)
+        let mut cursor = buf.as_slice();
+        let outer = alloy_rlp::Header::decode(&mut cursor).unwrap();
+        assert!(outer.list, "outer should be a list");
+
+        let first_elem = alloy_rlp::Header::decode(&mut cursor).unwrap();
+        assert!(
+            first_elem.list,
+            "first element (BlobTxSidecar) must be a nested list, not a raw field — \
+             go-bsc expects struct BlobSidecar {{ BlobTxSidecar, ... }}"
+        );
+
+        // Inside the nested BlobTxSidecar list, first sub-element should also be a list (blobs)
+        let blobs_hdr = alloy_rlp::Header::decode(&mut cursor).unwrap();
+        assert!(
+            blobs_hdr.list,
+            "blobs field inside BlobTxSidecar must be a list of Blob items"
+        );
+
+        // Roundtrip
+        let decoded = BscBlobTransactionSidecar::decode(&mut buf.as_slice())
+            .expect("Failed to decode sidecar");
+        assert_eq!(sidecar, decoded, "sidecar should roundtrip through RLP");
+
+        // Verify length() matches actual encoded size
+        assert_eq!(
+            sidecar.length(),
+            buf.len(),
+            "length() must match actual encoded size"
         );
     }
 }

--- a/src/node/storage.rs
+++ b/src/node/storage.rs
@@ -1,4 +1,9 @@
 use crate::{BscBlock, BscBlockBody, BscPrimitives};
+use crate::node::primitives::BscBlobTransactionSidecar;
+use alloy_consensus::BlockHeader;
+use alloy_eips::eip2718::{EIP4844_TX_TYPE_ID, Typed2718};
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
+use alloy_primitives::B256;
 use reth_chainspec::EthereumHardforks;
 use reth_db::transaction::{DbTx, DbTxMut};
 use reth_provider::{
@@ -6,6 +11,9 @@ use reth_provider::{
     BlockBodyReader, BlockBodyWriter, ChainSpecProvider, ChainStorageReader, ChainStorageWriter,
     DBProvider, DatabaseProvider, EthStorage, ProviderResult, ReadBodyInput,
 };
+use reth_transaction_pool::blobstore::BlobStore;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
@@ -20,17 +28,49 @@ where
         provider: &Provider,
         bodies: Vec<(u64, Option<&BscBlockBody>)>,
     ) -> ProviderResult<()> {
-        let (eth_bodies, _sidecars) = bodies
+        let (eth_bodies, sidecar_entries): (Vec<_>, Vec<_>) = bodies
             .into_iter()
             .map(|(block_number, body)| {
                 let inner = body.map(|b| &b.inner);
                 let sidecars = body.and_then(|b| b.sidecars.as_ref());
                 ((block_number, inner), (block_number, sidecars))
             })
-            .unzip::<_, _, Vec<_>, Vec<_>>();
+            .unzip();
         self.0.write_block_bodies(provider, eth_bodies)?;
 
-        // TODO: Write sidecars
+        // Write blob sidecars to the blob store keyed by tx hash.
+        if let Some(blob_store) = crate::shared::get_global_blob_store() {
+            let mut to_insert: Vec<(B256, BlobTransactionSidecarVariant)> = Vec::new();
+            for (_, sidecars) in &sidecar_entries {
+                if let Some(sidecars) = sidecars {
+                    for sidecar in sidecars.iter() {
+                        to_insert.push((
+                            sidecar.tx_hash,
+                            BlobTransactionSidecarVariant::Eip4844(sidecar.inner.clone()),
+                        ));
+                    }
+                }
+            }
+            if !to_insert.is_empty() {
+                let tx_hashes: Vec<_> = to_insert.iter().map(|(h, _)| *h).collect();
+                match blob_store.insert_all(to_insert) {
+                    Ok(()) => {
+                        tracing::debug!(
+                            target: "bsc::storage",
+                            ?tx_hashes,
+                            "blob_store_write: inserted sidecars"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "bsc::storage",
+                            ?tx_hashes,
+                            "blob_store_write: failed to insert sidecars: {e}"
+                        );
+                    }
+                }
+            }
+        }
 
         Ok(())
     }
@@ -41,9 +81,7 @@ where
         block: u64,
     ) -> ProviderResult<()> {
         self.0.remove_block_bodies_above(provider, block)?;
-
-        // TODO: Remove sidecars
-
+        // Blob store cleanup is handled by the pool maintenance task (finality-based eviction).
         Ok(())
     }
 }
@@ -59,12 +97,130 @@ where
         provider: &Provider,
         inputs: Vec<ReadBodyInput<'_, Self::Block>>,
     ) -> ProviderResult<Vec<BscBlockBody>> {
+        // Pre-extract block metadata and per-tx (hash, type) before `inputs` is consumed.
+        #[allow(clippy::type_complexity)]
+        let block_info: Vec<(u64, B256, Vec<(B256, u8)>)> = inputs
+            .iter()
+            .map(|(header, txs)| {
+                (
+                    header.number(),
+                    header.hash_slow(),
+                    txs.iter().map(|tx| (*tx.hash(), tx.ty())).collect(),
+                )
+            })
+            .collect();
+
         let eth_bodies = self.0.read_block_bodies(provider, inputs)?;
 
-        // TODO: Read sidecars
-
-        Ok(eth_bodies.into_iter().map(|inner| BscBlockBody { inner, sidecars: None }).collect())
+        let blob_store = crate::shared::get_global_blob_store().cloned();
+        let bodies = eth_bodies
+            .into_iter()
+            .zip(block_info)
+            .map(|(inner, (block_number, block_hash, tx_info))| {
+                // Collect blob tx hashes and their position in the full block tx list.
+                let blob_txs: Vec<(B256, u64)> = tx_info.iter()
+                    .enumerate()
+                    .filter(|(_, (_, ty))| *ty == EIP4844_TX_TYPE_ID)
+                    .map(|(idx, (hash, _))| (*hash, idx as u64))
+                    .collect();
+                let blob_tx_hashes: Vec<B256> = blob_txs.iter().map(|(h, _)| *h).collect();
+                let sidecars = if blob_txs.is_empty() {
+                    None
+                } else {
+                    blob_store.as_ref().and_then(|store| {
+                        read_sidecars_from_blob_store(store, block_number, block_hash, &blob_txs)
+                    })
+                };
+                if !blob_tx_hashes.is_empty() {
+                    let found = sidecars.as_ref().map_or(0, |s| s.len());
+                    tracing::debug!(
+                        target: "bsc::storage",
+                        block_number,
+                        ?block_hash,
+                        ?blob_tx_hashes,
+                        found,
+                        blob_store_available = blob_store.is_some(),
+                        "blob_store_read: queried sidecars for blob txs"
+                    );
+                    if found == 0 {
+                        tracing::warn!(
+                            target: "bsc::storage",
+                            block_number,
+                            ?block_hash,
+                            ?blob_tx_hashes,
+                            "blob_store_read: block has blob txs but no sidecars found!"
+                        );
+                    }
+                }
+                BscBlockBody { inner, sidecars }
+            })
+            .collect();
+        Ok(bodies)
     }
+}
+
+/// Look up blob sidecars from the blob store.
+/// `blob_txs` contains `(tx_hash, tx_index_in_block)` pairs — only type-3 txs.
+fn read_sidecars_from_blob_store(
+    blob_store: &Arc<dyn BlobStore>,
+    block_number: u64,
+    block_hash: B256,
+    blob_txs: &[(B256, u64)],
+) -> Option<Vec<BscBlobTransactionSidecar>> {
+    let tx_hashes: Vec<B256> = blob_txs.iter().map(|(h, _)| *h).collect();
+    let blobs = blob_store.get_all(tx_hashes).ok()?;
+    if blobs.is_empty() {
+        return None;
+    }
+    let hash_to_idx: HashMap<B256, u64> = blob_txs.iter().copied().collect();
+
+    let mut sidecars: Vec<_> = blobs
+        .into_iter()
+        .filter_map(|(tx_hash, variant)| {
+            let inner = match variant.as_ref() {
+                BlobTransactionSidecarVariant::Eip4844(s) => s.clone(),
+                _ => {
+                    tracing::warn!(
+                        target: "bsc::storage",
+                        block_number,
+                        ?tx_hash,
+                        "blob_store_read: sidecar is NOT Eip4844 variant, skipping"
+                    );
+                    return None;
+                }
+            };
+            let tx_index = *hash_to_idx.get(&tx_hash)?;
+            tracing::debug!(
+                target: "bsc::storage",
+                block_number,
+                ?tx_hash,
+                tx_index,
+                blobs = inner.blobs.len(),
+                commitments = inner.commitments.len(),
+                proofs = inner.proofs.len(),
+                "blob_store_read: sidecar detail"
+            );
+            if inner.blobs.is_empty() || inner.commitments.is_empty() || inner.proofs.is_empty() {
+                tracing::error!(
+                    target: "bsc::storage",
+                    block_number,
+                    ?tx_hash,
+                    blobs = inner.blobs.len(),
+                    commitments = inner.commitments.len(),
+                    proofs = inner.proofs.len(),
+                    "blob_store_read: sidecar has EMPTY fields!"
+                );
+            }
+            Some(BscBlobTransactionSidecar { inner, block_number, block_hash, tx_index, tx_hash })
+        })
+        .collect();
+
+    // get_all() does not guarantee input order (cache-hits precede disk-reads).
+    // go-bsc validates sidecars[i].TxHash == blobTxs[i].Hash(), so order must
+    // match the tx position in the block.
+    sidecars.sort_unstable_by_key(|s| s.tx_index);
+
+    if sidecars.is_empty() { None } else { Some(sidecars) }
 }
 
 impl ChainStorage<BscPrimitives> for BscStorage {

--- a/src/rpc/blob.rs
+++ b/src/rpc/blob.rs
@@ -3,6 +3,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObject;
 use alloy_primitives::B256;
 use alloy_consensus::transaction::TxHashRef;
+use alloy_eips::eip2718::{EIP4844_TX_TYPE_ID, Typed2718};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use reth_transaction_pool::{BlobStoreError, TransactionPool};
@@ -346,11 +347,19 @@ where
         // Get block hash
         let block_hash = self.provider.block_hash(block_num).ok().flatten();
 
-        // Collect transaction hashes
-        let tx_hashes: Vec<B256> = txs.iter().map(|tx| *tx.tx_hash()).collect();
+        // Collect only blob (type-3) tx hashes with their block-level index.
+        let blob_txs: Vec<(B256, u64)> = txs.iter()
+            .enumerate()
+            .filter(|(_, tx)| tx.ty() == EIP4844_TX_TYPE_ID)
+            .map(|(idx, tx)| (*tx.tx_hash(), idx as u64))
+            .collect();
+        let blob_tx_hashes: Vec<B256> = blob_txs.iter().map(|(h, _)| *h).collect();
 
-        // Get all blobs for these transactions
-        let blob_results = self.pool.get_all_blobs(tx_hashes).map_err(|e| {
+        // Build hash → block-level tx_index map.
+        let hash_to_idx: std::collections::HashMap<B256, u64> = blob_txs.into_iter().collect();
+
+        // Get blobs only for blob transactions.
+        let blob_results = self.pool.get_all_blobs(blob_tx_hashes).map_err(|e| {
             ErrorObject::owned(
                 -32603,
                 format!("Failed to get blobs for block {}: {}", block_num, e),
@@ -358,16 +367,17 @@ where
             )
         })?;
 
-        // Convert to responses
+        // Convert to responses with correct block-level tx_index.
         let mut responses = Vec::new();
-        for (index, (tx_hash, sidecar)) in blob_results.into_iter().enumerate() {
+        for (tx_hash, sidecar) in blob_results.into_iter() {
+            let tx_index = hash_to_idx.get(&tx_hash).copied();
             let response = Self::sidecar_to_response(
                 tx_hash,
                 sidecar,
                 full_blob,
                 Some(block_num),
                 block_hash,
-                Some(index as u64),
+                tx_index,
             );
             responses.push(response);
         }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -205,6 +205,23 @@ pub trait FullBlockProvider: Send + Sync {
 /// Global full block provider instance
 static FULL_BLOCK_PROVIDER: OnceLock<Arc<dyn FullBlockProvider + Send + Sync>> = OnceLock::new();
 
+/// Global blob store shared between the tx pool and the block body serving path.
+static GLOBAL_BLOB_STORE: OnceLock<Arc<dyn reth_transaction_pool::blobstore::BlobStore>> =
+    OnceLock::new();
+
+/// Register the node-wide blob store so that block-body serving can read blob sidecars.
+pub fn set_global_blob_store(
+    store: Arc<dyn reth_transaction_pool::blobstore::BlobStore>,
+) {
+    let _ = GLOBAL_BLOB_STORE.set(store);
+}
+
+/// Return a reference to the global blob store, if one has been registered.
+pub fn get_global_blob_store(
+) -> Option<&'static Arc<dyn reth_transaction_pool::blobstore::BlobStore>> {
+    GLOBAL_BLOB_STORE.get()
+}
+
 /// In-memory cache for recently seen full blocks (hash -> block), and number -> hash mapping.
 /// This allows answering range requests with full bodies if they were recently imported.
 static BODY_CACHE: OnceLock<RwLock<BodyCache>> = OnceLock::new();
@@ -440,6 +457,11 @@ pub fn set_full_block_provider(
     provider: Arc<dyn FullBlockProvider + Send + Sync>,
 ) -> Result<(), Arc<dyn FullBlockProvider + Send + Sync>> {
     FULL_BLOCK_PROVIDER.set(provider)
+}
+
+/// Get a clone of the installed [`FullBlockProvider`], if any.
+pub fn get_full_block_provider() -> Option<Arc<dyn FullBlockProvider + Send + Sync>> {
+    FULL_BLOCK_PROVIDER.get().cloned()
 }
 
 /// Try to get a full block by hash from the global provider

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -13,24 +13,24 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 # BSC crate
 reth_bsc = { path = "../.." }
 
-# reth dependencies aligned with root crate tag to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = ["mdbx", "test-utils", "disable-lock"] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = ["test-utils"] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9", features = ["std"] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.9" }
+# reth dependencies aligned with root crate rev to avoid duplicate crate versions
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = ["mdbx", "test-utils", "disable-lock"] }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = ["test-utils"] }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = ["std"] }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
 
 # revm
 revm = { version = "34.0.0", features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,23 +14,23 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate rev to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = ["mdbx", "test-utils", "disable-lock"] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = ["test-utils"] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = ["std"] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = ["mdbx", "test-utils", "disable-lock"] }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = ["test-utils"] }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928", features = ["std"] }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "ed59a0985b62f4964b389b1666b73b03b39b6928" }
 
 # revm
 revm = { version = "34.0.0", features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,23 +14,23 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate rev to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = ["mdbx", "test-utils", "disable-lock"] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = ["test-utils"] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a", features = ["std"] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "dc3ef30890d06057867da6ea93102478ac63737a" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = ["mdbx", "test-utils", "disable-lock"] }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = ["test-utils"] }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c", features = ["std"] }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "232a9a41efd5c228647a4b4dced54d5528090f1c" }
 
 # revm
 revm = { version = "34.0.0", features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }


### PR DESCRIPTION
### Description

Fixes for cross-region multi-validator test failures, makes reth-bsc more stable. Paired with bnb-chain/reth#175.

### Rationale

Two groups of failure modes addressed:

**1. Forks and bad blocks**

- Miner waits for peer-ready before producing — avoids small private forks when a validator restarts in isolation during the peer-handshake window.
- Head blockhash broadcast + common-ancestor recovery — resolves divergent forks via 4-block ancestor walks; FCU-routed backfill for far-behind tips.
- Fix timestamp drift causing peers to reject blocks as "Block time is too early" — `prepare_timestamp` returns the planned ms, cached on `MiningContext` and reused verbatim by `finalize_new_header` so the seconds/ms halves don't desync at sealing time.
- Fix MDBX/TrieDB tip mismatch producing mismatched-state-root bad blocks — paired reth fix aligns MDBX to TrieDB at startup (bnb-chain/reth#175).

**2. Other**

- Fix blob sidecar RLP encoding (nested layout + empty-withdrawals kind) and the write/read persistence paths, so go-bsc peers can fetch blob-bearing blocks from reth-bsc.
- Tune cross-region network timeouts to tolerate geographic skew without dropping otherwise-healthy peers.
- Print reth-bsc version/git SHA in startup logs and the P2P client string.

### Example

N/A.

### Changes

- **Periodic head announcement** — 3 s tick in the import-service poll loop, skipping peers >64 blocks ahead.
- **Ancestor-aware fork recovery** — new `fork_recover` module: 4-block hops, oldest-first imports, FCU last, 30 s retry-suppression, up-to-3 BSC-peer failover.
- **Far-behind → pipeline FCU** — gap > `MAX_FORK_DEPTH` synthesizes a forkchoice to route through staged backfill.
- **Peer-gated mining** — `is_network_ready_to_mine` refuses to mine with zero peers (deliberately not gated on `is_syncing()`).
- **Mining ms-timestamp cache** — `prepare_timestamp` returns planned ms, cached on `MiningContext`, reused in `finalize_new_header`.
- **Blob sidecar fixes** — filter to EIP-4844, real block-level `tx_index`, global blob store so `GetBlockBodies` can attach sidecars.
- **GetBlocksByRange DB fallback** — `FULL_BLOCK_PROVIDER` returns full bodies; cache miss no longer aborts recovery.
- **reth bump to `232a9a41…`** — pulls in the reth-side half of the cross-region fixes (bnb-chain/reth#175).
- **P2P client identity** — startup logs and P2P client string read `reth-bsc/vX-<sha>/<os>`.

### Potential Impacts

- 3 s periodic announce adds one `PeerMessage::NewBlockHashes` per eligible peer; negligible bandwidth.
- Peer-gated mining does **not** support fresh-genesis single-validator bootstrap (documented at call site).
- Depends on bnb-chain/reth#175 merging (or the reth rev being bumped again) before this merges into `develop`.
