### PR TITLE
fix(network): seed fork filter from DB head and update on each canonical block

### DIFF
--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -35,6 +35,7 @@ use reth_payload_builder_primitives::Events;
 use reth_payload_primitives::{BuiltPayload, EngineApiMessageVersion, PayloadTypes};
 use reth_primitives::NodePrimitives;
 use reth_primitives_traits::{AlloyBlockHeader, Block};
+use reth_chainspec::Head;
 use reth_provider::{BlockHashReader, BlockNumReader, BlockReaderIdExt, HeaderProvider};
 use std::{
     future::Future,
@@ -221,6 +222,20 @@ where
                             tracing::warn!(target: "bsc::block_import", "Failed to update fork choice: {}", e);
                         } else {
                             tracing::debug!(target: "bsc::block_import", "Succeed to update fork choice for new payload: number = {:?}, hash = {:?}", header.number, block_hash);
+                            if let Some(net) = crate::shared::get_network_handle() {
+                                let td = forkchoice_engine.provider
+                                    .header_td_by_number(header.number)
+                                    .ok()
+                                    .flatten()
+                                    .unwrap_or_default();
+                                net.update_status(Head {
+                                    number: header.number,
+                                    hash: block_hash,
+                                    timestamp: header.timestamp,
+                                    difficulty: header.difficulty,
+                                    total_difficulty: td,
+                                });
+                            }
                         }
                         Outcome { peer: peer_id, result: Ok(BlockValidation::ValidBlock { block }) }
                             .into()
@@ -435,6 +450,20 @@ where
                         block_hash = %block_hash,
                         "Succeeded to update fork choice for mined block"
                     );
+                    if let Some(net) = crate::shared::get_network_handle() {
+                        let td = forkchoice_engine.provider
+                            .header_td_by_number(header_for_fcu.number)
+                            .ok()
+                            .flatten()
+                            .unwrap_or_default();
+                        net.update_status(Head {
+                            number: header_for_fcu.number,
+                            hash: block_hash,
+                            timestamp: header_for_fcu.timestamp,
+                            difficulty: header_for_fcu.difficulty,
+                            total_difficulty: td,
+                        });
+                    }
                 }
             });
         }

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -310,10 +310,9 @@ impl BscNetworkBuilder {
             .unwrap();
         });
 
-        // TODO: update network with the latest canonical head, but has a fork id issue, can fix it later.
         let mut network_builder = network_builder
             .boot_nodes(ctx.chain_spec().bootnodes().unwrap_or_default())
-            .set_head(ctx.chain_spec().head())
+            .set_head(ctx.head())
             .with_pow()
             .block_import(Box::new(BscBlockImport::new(handle)))
             .eth_rlpx_handshake(Arc::new(BscHandshake::default()))
@@ -332,8 +331,6 @@ impl BscNetworkBuilder {
             &mut network_config.discovery_v4_config,
             ctx.chain_spec().bootnodes(),
         );
-        network_config.status.forkid = network_config.fork_filter.current();
-
         // Initialize BSC protocol registry with proxied peers from config
         // This mirrors the same functionality in the main peer manager
         let proxied_node_ids = network_config.peers_config.proxied_node_ids.clone();


### PR DESCRIPTION
Fixes #335

## Root cause

`BscNetworkBuilder` was initialising the network's fork filter from a hardcoded block number baked into `BscChainSpec::head()` (block 40,000,000 on mainnet) rather than the actual canonical head read from the database.

The fork ID is a hash of which hardforks are active at a given block height. When the node advertises a fork ID computed from block 40M to peers who know it is actually at block ~95M, every peer handshake fails with `fork id mismatch` and the peer is disconnected. Once all peers are gone, block sync stalls entirely. A restart temporarily re-establishes connections until the same thing recurs.

A second related issue: `ImportService` never called `network_handle.update_status()` after importing blocks, so even if startup worked, the fork filter would go stale the moment a hardfork timestamp was crossed at runtime.

## Fix

**`src/node/network/mod.rs`**

Replace `ctx.chain_spec().head()` (hardcoded) with `ctx.head()` (DB-sourced) when building the `NetworkConfig`. This is exactly what upstream reth does — `ctx.head()` is populated from the database by `lookup_head()` before `BuilderContext` is constructed, so the fork filter is seeded correctly from the first handshake.

**`src/node/network/block_import/service.rs`**

Call `network_handle.update_status(head)` after every successful `update_forkchoice()` in `ImportService` — both for incoming network blocks and locally mined blocks. This keeps the fork filter current as the chain advances and hardforks activate, mirroring the `ChainEvent`-driven `update_status` loop in upstream reth's engine launcher.

## Testing

- `cargo check` passes cleanly
- Behaviour matches upstream reth's fork filter lifecycle: DB head at startup, live updates on every canonical block