### PR TITLE
chore: upgrade bnb-chain/reth to develop-v2.2 and reth-core to v0.3.1-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.33.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f092eb6af80456e4ab41c9722e777d791335bc9c00b11bc3db7bf29a432dfd0"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -3224,8 +3224,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7999df38d0bd8f688212e1a4fae31fd2fea6d218649b9cd7c40bf3ec1318fc"
+source = "git+https://github.com/sigp/discv5?rev=7663c00#7663c00ee0837ea98547caaedede95d9d6736f4d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4964,16 +4963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5125,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7508,8 +7497,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7549,8 +7538,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -7560,7 +7549,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-execution-cache",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7576,8 +7565,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -7594,7 +7583,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
@@ -7609,8 +7598,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7629,8 +7618,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7642,8 +7631,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7732,8 +7721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7742,8 +7731,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -7761,8 +7750,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.0-v2#3de2f240b60c2819740da690370bb499bd6c04bf"
+version = "0.3.1"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.1-v2#2b45bde5fcf8a0f5acec927d568ffb934b179dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -7781,8 +7770,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.0-v2#3de2f240b60c2819740da690370bb499bd6c04bf"
+version = "0.3.1"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.1-v2#2b45bde5fcf8a0f5acec927d568ffb934b179dc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7791,8 +7780,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7807,8 +7796,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7820,8 +7809,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -7833,8 +7822,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -7859,12 +7848,13 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
  "eyre",
+ "libc",
  "metrics",
  "page_size",
  "parking_lot",
@@ -7872,7 +7862,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7887,8 +7877,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7913,8 +7903,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7947,8 +7937,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -7962,8 +7952,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7987,8 +7977,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8001,7 +7991,7 @@ dependencies = [
  "rand 0.9.4",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -8011,8 +8001,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.1.0",
@@ -8035,8 +8025,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8052,7 +8042,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -8070,8 +8060,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8098,8 +8088,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8121,8 +8111,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8146,8 +8136,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8174,7 +8164,7 @@ dependencies = [
  "reth-evm",
  "reth-execution-cache",
  "reth-execution-types",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8207,8 +8197,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8235,8 +8225,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8244,14 +8234,15 @@ dependencies = [
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "sha2 0.10.9",
  "snap",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8266,8 +8257,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8288,8 +8279,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8299,8 +8290,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8314,7 +8305,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8328,8 +8319,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8353,8 +8344,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "clap",
  "eyre",
@@ -8376,8 +8367,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8392,8 +8383,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8408,8 +8399,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8422,8 +8413,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8452,8 +8443,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8466,8 +8457,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8476,8 +8467,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8490,7 +8481,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8501,8 +8492,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8521,15 +8512,15 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
  "metrics",
  "parking_lot",
  "reth-errors",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -8539,8 +8530,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8552,8 +8543,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8571,8 +8562,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8589,7 +8580,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8609,8 +8600,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8623,8 +8614,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "serde",
  "serde_json",
@@ -8633,8 +8624,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8661,8 +8652,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8681,8 +8672,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8698,8 +8689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "bindgen",
  "cc",
@@ -8719,20 +8710,21 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
+ "reth-primitives-traits",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8740,8 +8732,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8754,8 +8746,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8786,7 +8778,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
  "reth-fs-util",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8802,6 +8794,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -8811,8 +8804,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8836,8 +8829,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8859,8 +8852,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8874,8 +8867,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8888,8 +8881,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8905,8 +8898,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8929,8 +8922,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8999,8 +8992,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9054,8 +9047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9092,8 +9085,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9116,8 +9109,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9140,8 +9133,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9154,7 +9147,7 @@ dependencies = [
  "metrics-util",
  "procfs",
  "reqwest 0.13.3",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9164,8 +9157,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9176,8 +9169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9188,7 +9181,7 @@ dependencies = [
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
  "reth-execution-cache",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9200,8 +9193,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9212,8 +9205,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9236,8 +9229,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9246,8 +9239,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.0-v2#3de2f240b60c2819740da690370bb499bd6c04bf"
+version = "0.3.1"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.1-v2#2b45bde5fcf8a0f5acec927d568ffb934b179dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9278,8 +9271,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9302,7 +9295,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9326,8 +9319,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9339,7 +9332,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9355,8 +9348,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9371,8 +9364,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9386,8 +9379,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9430,7 +9423,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9464,8 +9457,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -9494,8 +9487,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9510,7 +9503,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-api",
  "reth-node-core",
  "reth-payload-primitives",
@@ -9537,8 +9530,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9558,8 +9551,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9571,7 +9564,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9589,8 +9582,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9637,8 +9630,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9663,7 +9656,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9685,8 +9678,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -9699,8 +9692,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9715,8 +9708,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.0-v2#3de2f240b60c2819740da690370bb499bd6c04bf"
+version = "0.3.1"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.1-v2#2b45bde5fcf8a0f5acec927d568ffb934b179dc4"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -9729,8 +9722,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9784,8 +9777,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9796,7 +9789,7 @@ dependencies = [
  "reth-codecs",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9812,8 +9805,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9826,8 +9819,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9846,8 +9839,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9861,8 +9854,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9885,8 +9878,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9903,8 +9896,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.1.0",
@@ -9914,7 +9907,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rayon",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "thiserror 2.0.18",
  "thread-priority",
  "tokio",
@@ -9924,8 +9917,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9940,8 +9933,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9950,8 +9943,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "clap",
  "eyre",
@@ -9965,8 +9958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "clap",
  "eyre",
@@ -9983,8 +9976,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10008,7 +10001,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -10028,8 +10021,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10041,7 +10034,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10054,8 +10047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10083,15 +10076,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
@@ -10104,8 +10097,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10118,7 +10111,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
@@ -10132,17 +10125,16 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.1.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.1#43475795ea6b2fbfbd2cda3e6a335d5225fee8f1"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop-v2.2#048b728160bc84ab9e58f18a8d0f45fd03c29ac9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "auto_impl",
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
@@ -10154,8 +10146,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.0-v2#3de2f240b60c2819740da690370bb499bd6c04bf"
+version = "0.3.1"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.3.1-v2#2b45bde5fcf8a0f5acec927d568ffb934b179dc4"
 dependencies = [
  "zstd",
 ]
@@ -10240,7 +10232,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 2.1.0",
+ "reth-metrics 2.2.0",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",
@@ -10467,6 +10459,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",
@@ -12321,9 +12314,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12347,9 +12340,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes 1.11.1",
  "prost 0.14.3",
@@ -12378,9 +12371,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -12393,7 +12386,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -12404,6 +12396,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
  "uuid 1.23.1",
 ]
 
@@ -12924,9 +12917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12937,9 +12930,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12947,9 +12940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12957,9 +12950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12970,9 +12963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -13040,9 +13033,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.0-v2", default-features = false }
-reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.0-v2" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = [
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
+reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2" }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
 
 # triedb dependencies
 rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.2" }
@@ -86,17 +86,17 @@ revm-interpreter = "35.0.0"
 revm-database-interface = "11.0.0"
 
 # alloy dependencies
-alloy-evm = { version = "0.33.0", features = ["rpc"] }
+alloy-evm = { version = "0.34.0", features = ["rpc"] }
 
-alloy-genesis = "2.0.0"
-alloy-consensus = "2.0.0"
-alloy-eips = "2.0.0"
-alloy-network = "2.0.0"
-alloy-rpc-types = { version = "2.0.0", features = ["eth"] }
-alloy-rpc-types-eth = "2.0.0"
-alloy-rpc-types-engine = "2.0.0"
-alloy-rpc-types-mev = "2.0.0"
-alloy-signer = "2.0.0"
+alloy-genesis = "2.0.4"
+alloy-consensus = "2.0.4"
+alloy-eips = "2.0.4"
+alloy-network = "2.0.4"
+alloy-rpc-types = { version = "2.0.4", features = ["eth"] }
+alloy-rpc-types-eth = "2.0.4"
+alloy-rpc-types-engine = "2.0.4"
+alloy-rpc-types-mev = "2.0.4"
+alloy-signer = "2.0.4"
 
 alloy-chains = "0.2.33"
 alloy-rlp = { version = "0.3.13", default-features = false, features = [

--- a/src/consensus/parlia/validation.rs
+++ b/src/consensus/parlia/validation.rs
@@ -11,7 +11,7 @@ use reth_primitives_traits::GotExpected;
 use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK_DENCUN};
 use crate::BscBlock;
 use reth_primitives_traits::Block;
-use std::time::SystemTime;
+use std::{sync::Arc, time::SystemTime};
 
 const MAX_RLP_BLOCK_SIZE_OSAKA: usize = 8 * 1024 * 1024;
 
@@ -51,11 +51,11 @@ pub fn validate_4844_header_of_bsc<ChainSpec: BscHardforks>(
 
     // BEP-657: After Mendel, non-eligible blocks must have blob_gas_used == 0
     if !is_blob_eligible_block(chain_spec, header.number, header.timestamp) && blob_gas_used != 0 {
-        return Err(ConsensusError::Other(format!(
+        return Err(ConsensusError::Other(Arc::new(std::io::Error::other(format!(
             "blob transactions not allowed in block {} (N % {} != 0)",
             header.number,
             crate::consensus::eip4844::BLOB_ELIGIBLE_BLOCK_INTERVAL
-        )));
+        )))));
     }
 
     if blob_gas_used > MAX_DATA_GAS_PER_BLOCK_DENCUN {
@@ -114,16 +114,16 @@ fn validate_mix_digest_for_parlia(
 ) -> Result<(), ConsensusError> {
     if !lorentz_active {
         if header.mix_hash != B256::ZERO {
-            return Err(ConsensusError::Other("non-zero mix digest".to_string()));
+            return Err(ConsensusError::Other(Arc::new(std::io::Error::other("non-zero mix digest"))));
         }
         return Ok(());
     }
 
     // In Lorentz+, mix digest carries the millisecond remainder. It must not overflow seconds.
     if calculate_millisecond_timestamp(header) / 1000 != header.timestamp {
-        return Err(ConsensusError::Other(
-            "invalid mix digest milliseconds component".to_string(),
-        ));
+        return Err(ConsensusError::Other(Arc::new(std::io::Error::other(
+            "invalid mix digest milliseconds component",
+        ))));
     }
     Ok(())
 }
@@ -172,7 +172,7 @@ impl<ChainSpec: EthChainSpec + BscHardforks + std::fmt::Debug + Send + Sync + 's
         validate_header_not_from_future(header, present_unix_seconds())?;
 
         // Check extra data
-        self.check_header_extra(header).map_err(|e| ConsensusError::Other(format!("Invalid header extra: {e}")))?;
+        self.check_header_extra(header).map_err(|e| ConsensusError::Other(Arc::new(std::io::Error::other(format!("Invalid header extra: {e}")))))?;
 
         // Ensure that the block with no uncles
         if header.ommers_hash != EMPTY_OMMER_ROOT_HASH {
@@ -268,9 +268,9 @@ impl<ChainSpec: EthChainSpec + BscHardforks + std::fmt::Debug + Send + Sync + 's
             if !is_blob_eligible_block(&*self.spec, block.number, block.timestamp)
                 && block.body().transactions().any(|tx| tx.is_eip4844())
             {
-                return Err(ConsensusError::Other(
-                    "blob transactions not allowed in this block".to_string(),
-                ));
+                return Err(ConsensusError::Other(Arc::new(std::io::Error::other(
+                    "blob transactions not allowed in this block",
+                ))));
             }
             // Check that the blob gas used in the header matches the sum of the blob gas used by
             // each blob tx

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -86,10 +86,10 @@ fn validate_bsc_gas_limit_against_parent<ChainSpec: BscHardforks>(
 ) -> Result<(), ConsensusError> {
     // Keep parity with go-bsc's Parlia checks.
     if header.gas_limit > GAS_LIMIT_CAPACITY {
-        return Err(ConsensusError::Other(format!(
+        return Err(ConsensusError::Other(Arc::new(std::io::Error::other(format!(
             "invalid gasLimit: have {}, max {}",
             header.gas_limit, GAS_LIMIT_CAPACITY
-        )));
+        )))));
     }
 
     if header.gas_used > header.gas_limit {
@@ -109,12 +109,12 @@ fn validate_bsc_gas_limit_against_parent<ChainSpec: BscHardforks>(
     let limit = parent.gas_limit / bound_divisor;
 
     if diff >= limit || header.gas_limit < MINIMUM_GAS_LIMIT {
-        return Err(ConsensusError::Other(format!(
+        return Err(ConsensusError::Other(Arc::new(std::io::Error::other(format!(
             "invalid gas limit: have {}, want {} += {}",
             header.gas_limit,
             parent.gas_limit,
             limit.saturating_sub(1)
-        )));
+        )))));
     }
 
     Ok(())

--- a/src/node/evm/builder.rs
+++ b/src/node/evm/builder.rs
@@ -10,7 +10,7 @@ use crate::{
     BscPrimitives,
 };
 use alloy_consensus::BlockHeader as _;
-use alloy_evm::block::BlockExecutor;
+use alloy_evm::block::{BlockExecutor, GasOutput};
 use alloy_evm::eth::receipt_builder::ReceiptBuilder;
 use alloy_primitives::BlockHash;
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
@@ -95,13 +95,13 @@ where
         &mut self,
         tx: impl ExecutorTx<Self::Executor>,
         f: impl FnOnce(&<Self::Executor as alloy_evm::block::BlockExecutor>::Result) -> alloy_evm::block::CommitChanges,
-    ) -> Result<Option<u64>, BlockExecutionError> {
+    ) -> Result<Option<GasOutput>, BlockExecutionError> {
         let (tx_env, recovered) = tx.into_parts();
         if let Some(gas_output) =
             self.executor.execute_transaction_with_commit_condition((tx_env, &recovered), f)?
         {
             self.transactions.push(recovered);
-            Ok(Some(gas_output.tx_gas_used()))
+            Ok(Some(gas_output))
         } else {
             Ok(None)
         }

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -1,5 +1,6 @@
 use super::{
-    assembler::BscBlockAssembler, builder::BscBlockBuilder, executor::BscBlockExecutor,
+    assembler::BscBlockAssembler, builder::BscBlockBuilder,
+    executor::{BscBlockExecutor, BscTxResult},
     factory::BscEvmFactory,
 };
 use crate::{
@@ -230,23 +231,25 @@ where
     BscTxEnv: IntoTxEnv<<EvmF as EvmFactory>::Tx>,
 {
     type EvmFactory = EvmF;
+    type TxExecutionResult = BscTxResult<<EvmF as EvmFactory>::HaltReason>;
     type ExecutionCtx<'a> = BscBlockExecutionCtx<'a>;
     type Transaction = TransactionSigned;
     type Receipt = R::Receipt;
+    type Executor<'a, DB: alloy_evm::block::StateDB, I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>> =
+        BscBlockExecutor<'a, <EvmF as EvmFactory>::Evm<DB, I>, Spec, R>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory
     }
 
-    #[allow(refining_impl_trait)]
     fn create_executor<'a, DB, I>(
         &'a self,
         evm: <Self::EvmFactory as EvmFactory>::Evm<DB, I>,
         ctx: Self::ExecutionCtx<'a>,
-    ) -> BscBlockExecutor<'a, <Self::EvmFactory as EvmFactory>::Evm<DB, I>, Spec, R>
+    ) -> Self::Executor<'a, DB, I>
     where
-        DB: alloy_evm::block::StateDB + 'a,
-        I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>> + 'a,
+        DB: alloy_evm::block::StateDB,
+        I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>,
     {
         BscBlockExecutor::new(
             evm,
@@ -474,7 +477,7 @@ where
         ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
     ) -> impl BlockBuilder<
         Primitives = Self::Primitives,
-        Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>, I>,
+        Executor = BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>, I>,
     >
     where
         DB: Database,

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -56,7 +56,7 @@ pub struct BscTxResult<H> {
     pub is_system: bool,
 }
 
-impl<H> TxResult for BscTxResult<H> {
+impl<H: Send + 'static> TxResult for BscTxResult<H> {
     type HaltReason = H;
 
     fn result(&self) -> &ResultAndState<H> {
@@ -124,12 +124,14 @@ where
     pub(super) executor_metrics: BscExecutorMetrics,
     /// Rewards metrics for tracking reward distributions.
     pub(super) rewards_metrics: BscRewardsMetrics,
+    /// Deferred error from commit_transaction (e.g. hertz patch), returned from finish().
+    pub(super) deferred_error: Option<BlockExecutionError>,
 }
 
 impl<'a, EVM, Spec, R: ReceiptBuilder> BscBlockExecutor<'a, EVM, Spec, R>
 where
     EVM: Evm<
-        DB: alloy_evm::block::StateDB + 'a,
+        DB: alloy_evm::block::StateDB,
         Tx: FromRecoveredTx<R::Transaction>
                 + FromRecoveredTx<TransactionSigned>
                 + FromTxWithEncoded<TransactionSigned>,
@@ -199,6 +201,7 @@ where
             vote_metrics: BscVoteMetrics::default(),
             executor_metrics: BscExecutorMetrics::default(),
             rewards_metrics: BscRewardsMetrics::default(),
+            deferred_error: None,
         }
     }
 
@@ -385,7 +388,7 @@ where
 impl<'a, E, Spec, R> BlockExecutor for BscBlockExecutor<'a, E, Spec, R>
 where
     E: Evm<
-        DB: alloy_evm::block::StateDB + 'a,
+        DB: alloy_evm::block::StateDB,
         Tx: FromRecoveredTx<R::Transaction>
                 + FromRecoveredTx<TransactionSigned>
                 + FromTxWithEncoded<TransactionSigned>,
@@ -549,9 +552,9 @@ where
     fn commit_transaction(
         &mut self,
         output: BscTxResult<E::HaltReason>,
-    ) -> Result<GasOutput, BlockExecutionError> {
+    ) -> GasOutput {
         if output.is_system {
-            return Ok(GasOutput::new(0));
+            return GasOutput::new(0);
         }
 
         let ResultAndState { result, state } = output.inner;
@@ -576,16 +579,22 @@ where
         self.evm.db_mut().commit(state);
 
         // Apply hertz patch after tx (validation only, not mining).
+        // commit_transaction cannot return errors in the new API, so defer any error to finish().
         if !self.ctx.is_miner {
-            self.hertz_patch_manager.patch_after_tx(&output.tx, self.evm.db_mut())?;
+            if let Err(e) = self.hertz_patch_manager.patch_after_tx(&output.tx, self.evm.db_mut()) {
+                self.deferred_error = Some(e);
+            }
         }
 
-        Ok(GasOutput::new(gas_used))
+        GasOutput::new(gas_used)
     }
 
     fn finish(
         mut self,
     ) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
+        if let Some(err) = self.deferred_error.take() {
+            return Err(err);
+        }
         let block_env = self.evm.block().clone();
         debug!(
             target: "bsc::executor",

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -41,7 +41,7 @@ fn turn_length_matches(turn_length_from_header: Option<u8>, expected_turn_length
 impl<'a, EVM, Spec, R: ReceiptBuilder> BscBlockExecutor<'a, EVM, Spec, R>
 where
     EVM: Evm<
-        DB: alloy_evm::block::StateDB + 'a,
+        DB: alloy_evm::block::StateDB,
         Tx: FromRecoveredTx<R::Transaction>
                 + FromRecoveredTx<TransactionSigned>
                 + FromTxWithEncoded<TransactionSigned>,

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -43,7 +43,7 @@ pub static TURN_LENGTH_CACHE: LazyLock<Mutex<TurnLengthCache>> = LazyLock::new(|
 impl<'a, EVM, Spec, R: ReceiptBuilder> BscBlockExecutor<'a, EVM, Spec, R>
 where
     EVM: Evm<
-        DB: alloy_evm::block::StateDB + 'a,
+        DB: alloy_evm::block::StateDB,
         Tx: FromRecoveredTx<R::Transaction>
                 + FromRecoveredTx<TransactionSigned>
                 + FromTxWithEncoded<TransactionSigned>,

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -932,13 +932,13 @@ where
                 }
             }
 
-            self.gas_used += tx_gas_used;
+            self.gas_used += tx_gas_used.tx_gas_used();
             let tx_effective_gas_price = recovered_tx
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
             self.gas_fee += (U256::from(tx_effective_gas_price) + U256::from(base_fee))
-                * U256::from(tx_gas_used);
-            self.system_balance += U256::from(tx_effective_gas_price) * U256::from(tx_gas_used);
+                * U256::from(tx_gas_used.tx_gas_used());
+            self.system_balance += U256::from(tx_effective_gas_price) * U256::from(tx_gas_used.tx_gas_used());
         }
 
         Ok(())

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -741,8 +741,8 @@ where
             let miner_fee = tx
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
-            total_fees += U256::from(miner_fee) * U256::from(gas_used);
-            cumulative_gas_used += gas_used;
+            total_fees += U256::from(miner_fee) * U256::from(gas_used.tx_gas_used());
+            cumulative_gas_used += gas_used.tx_gas_used();
 
             let tx_duration = tx_start.elapsed();
             if tx_duration.as_micros() > 3000 {

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,22 +14,22 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate branch to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = ["mdbx", "test-utils", "disable-lock"] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.0-v2", default-features = false }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = ["test-utils"] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1", features = ["std"] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.1" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = ["mdbx", "test-utils", "disable-lock"] }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = ["test-utils"] }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2", features = ["std"] }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop-v2.2" }
 
 # revm
 revm = { version = "38.0.0", features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }


### PR DESCRIPTION
## Summary

- Bump `bnb-chain/reth` branch `develop-v2.1` → `develop-v2.2` (commit `048b7281`)
- Bump `bnb-chain/reth-core` branch `v0.3.0-v2` → `v0.3.1-v2`
- Bump `alloy-evm` `0.33.0` → `0.34.0`; `alloy-*` `2.0.0` → `2.0.4`

## API compatibility fixes (alloy-evm 0.34.0)

- **`BlockExecutorFactory`**: added `TxExecutionResult` and `Executor` GAT associated types; fixed `create_executor` lifetime/return-type signature
- **`BlockExecutor::commit_transaction`**: now infallible (`→ GasOutput`); hertz patch errors deferred to `finish()` via new `deferred_error` field
- **`DB: 'a` bounds**: removed from executor, pre_execution, and post_execution impl blocks (no longer required by trait)
- **`GasOutput`**: extract gas via `.tx_gas_used()` in `payload.rs` and `bid_simulator.rs`
- **`ConsensusError::Other`**: now takes `Arc<dyn Error + Send + Sync>`; wrapped string messages accordingly

## Test plan

- [ ] `cargo check` — passes
- [ ] `cargo build` — passes
- [ ] Run node smoke test against BSC testnet

🤖 Generated with [Claude Code](https://claude.ai/claude-code)