### PR TITLE
fix: make the received block metrics correct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config libclang-dev
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-05-11
           components: rustfmt
           override: true
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-udeps
       - name: Run cargo udeps
-        run: cargo +nightly udeps --workspace --lib --examples --tests --benches --all-features --locked
+        run: cargo +nightly-2026-05-11 udeps --workspace --lib --examples --tests --benches --all-features --locked
 
   clippy:
     name: clippy

--- a/src/consensus/parlia/block_stats.rs
+++ b/src/consensus/parlia/block_stats.rs
@@ -3,11 +3,13 @@
 //! Mirrors geth's `BlockStats` / `reportRecentBlocksLoop` functionality by tracking
 //! block timestamps and event timestamps to compute chain delay metrics.
 
+use alloy_consensus::Header;
 use alloy_primitives::B256;
 use lru::LruCache;
 use once_cell::sync::Lazy;
 use std::{num::NonZero, sync::RwLock};
 
+use crate::consensus::parlia::util::calculate_millisecond_timestamp;
 use crate::metrics::BscChainDelayMetrics;
 
 /// Size of the block stats LRU cache.
@@ -18,7 +20,9 @@ const DEFAULT_MAJORITY_THRESHOLD: usize = 14;
 
 /// Per-block tracking data for chain delay metrics.
 struct BlockStat {
-    /// Block timestamp in milliseconds (header.timestamp * 1000).
+    /// Block timestamp in milliseconds, from `calculate_millisecond_timestamp(header)`
+    /// (combines `header.timestamp` seconds with the Lorentz-era ms portion stored in
+    /// `header.mix_hash`).
     block_timestamp_ms: i64,
     /// Whether the first vote delay has been reported.
     first_vote_reported: bool,
@@ -38,23 +42,49 @@ fn now_ms() -> i64 {
         .as_millis() as i64
 }
 
-/// Register a block's timestamp when it is first received from the network.
-/// Also records the `chain.delay.block_recv` metric (delay from block creation to reception).
-pub fn on_block_received(block_hash: B256, block_timestamp_secs: u64) {
-    let block_ts_ms = block_timestamp_secs as i64 * 1000;
-    let recv_time = now_ms();
-
-    let delay_ms = recv_time - block_ts_ms;
-    if delay_ms >= 0 {
-        CHAIN_DELAY_METRICS.block_recv.record(delay_ms as f64);
-    }
-
+/// Cache a block's millisecond-precision timestamp so subsequent `on_vote_received` calls can
+/// compute vote-delay metrics. Does **not** touch the `chain.delay.block_recv` histogram.
+///
+/// On Lorentz and later forks, the block timestamp has millisecond precision (split between
+/// `header.timestamp` (seconds) and `header.mix_hash` (ms part)); we use
+/// `calculate_millisecond_timestamp` so delays are not biased by the 0-999 ms portion.
+fn cache_block_timestamp(block_hash: B256, header: &Header) -> i64 {
+    let block_ts_ms = calculate_millisecond_timestamp(header) as i64;
     let mut cache = BLOCK_STATS.write().expect("block stats poisoned");
     cache.get_or_insert(block_hash, || BlockStat {
         block_timestamp_ms: block_ts_ms,
         first_vote_reported: false,
         majority_vote_reported: false,
     });
+    block_ts_ms
+}
+
+/// Register a block's timestamp when it is first received from the network, and record the
+/// `chain.delay.block_recv` metric (delay from block creation to first network reception).
+///
+/// This is the network-receive path. For locally mined blocks call [`register_self_mined_block`]
+/// instead — they would otherwise pollute `block_recv` with samples that actually measure local
+/// mining/finalize latency rather than true network propagation delay (mirrors geth-bsc, where
+/// `RecvNewBlockTime` is only set in `handleBlockBroadcast`).
+pub fn on_block_received(block_hash: B256, header: &Header) {
+    let block_ts_ms = cache_block_timestamp(block_hash, header);
+    let recv_time = now_ms();
+
+    let delay_ms = recv_time - block_ts_ms;
+    if delay_ms >= 0 {
+        CHAIN_DELAY_METRICS.block_recv.record(delay_ms as f64);
+    }
+}
+
+/// Register a self-mined block's timestamp so subsequent `on_vote_received` calls work, **without**
+/// recording `chain.delay.block_recv`.
+///
+/// Mirrors geth-bsc's split between `SendBlockTime` (miner path) and `RecvNewBlockTime`
+/// (network path): we want votes for our own block to still count toward `vote_first` /
+/// `vote_majority`, but the block-recv histogram must stay clean of self-mined samples so it
+/// can be used to diagnose cross-region network propagation delays.
+pub fn register_self_mined_block(block_hash: B256, header: &Header) {
+    cache_block_timestamp(block_hash, header);
 }
 
 /// Called when a vote is added for a block. Records first-vote and majority-vote delay

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -369,10 +369,15 @@ where
         // Clone header for FCU update
         let header_for_fcu = block.header.clone();
 
-        // Register block stats for chain delay vote metrics (mined blocks also receive votes)
-        crate::consensus::parlia::block_stats::on_block_received(
+        // Register block stats so vote-delay metrics can still be computed when votes arrive for
+        // this self-mined block. We deliberately do NOT call `on_block_received` here — that
+        // records `chain.delay.block_recv`, which is meant to measure pure network propagation
+        // delay; for a block we just produced locally the sample would actually reflect local
+        // mining/finalize latency and would pollute cross-region diagnosis. Mirrors geth-bsc,
+        // which only sets `RecvNewBlockTime` inside `handleBlockBroadcast` (the network path).
+        crate::consensus::parlia::block_stats::register_self_mined_block(
             block_hash,
-            block.header.timestamp,
+            &block.header,
         );
 
         // send to EVN peers first
@@ -548,7 +553,7 @@ where
         // Record chain delay metrics: time from block creation to first network reception
         crate::consensus::parlia::block_stats::on_block_received(
             block.hash,
-            block.block.0.block.header.timestamp,
+            &block.block.0.block.header,
         );
 
         // send to EVN peers first


### PR DESCRIPTION
### Description

Make the received block metrics correct to ensure the `reth_chain_delay_block_recv` metrics are accurate for more effective network latency troubleshooting.

### Rationale

1. Make the ms-timestamp correct.
2. Do not update the received block metrics of the self-mined block.

### Example

N/A.

### Changes

Notable changes: 
* Metrics*

### Potential Impacts
N/A.
