### PR TITLE
fix: classify system txs at EVM replay entry points

### DIFF
--- a/src/evm/api/exec.rs
+++ b/src/evm/api/exec.rs
@@ -32,6 +32,9 @@ where
     }
 
     fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+        let mut tx = tx;
+        self.prepare_tx_for_execution(&mut tx);
+        self.maybe_bump_beneficiary_balance_for_trace(tx.is_system_transaction, tx.base.value);
         self.inner.ctx.set_tx(tx);
         BscHandler::new().run(self)
     }
@@ -41,6 +44,10 @@ where
     }
 
     fn replay(&mut self) -> Result<ResultAndState, Self::Error> {
+        self.prepare_current_tx_for_execution();
+        let is_sys = self.inner.ctx.tx.is_system_transaction;
+        let value = self.inner.ctx.tx.base.value;
+        self.maybe_bump_beneficiary_balance_for_trace(is_sys, value);
         BscHandler::new().run(self).map(|result| {
             let state = self.finalize();
             ResultAndState::new(result, state)
@@ -69,6 +76,9 @@ where
     }
 
     fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+        let mut tx = tx;
+        self.prepare_tx_for_execution(&mut tx);
+        self.maybe_bump_beneficiary_balance_for_trace(tx.is_system_transaction, tx.base.value);
         self.inner.ctx.set_tx(tx);
         BscHandler::new().inspect_run(self)
     }

--- a/src/evm/api/exec.rs
+++ b/src/evm/api/exec.rs
@@ -31,10 +31,11 @@ where
         self.inner.set_block(block);
     }
 
-    fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
-        let mut tx = tx;
+    fn transact_one(&mut self, mut tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.prepare_tx_for_execution(&mut tx);
-        self.maybe_bump_beneficiary_balance_for_trace(tx.is_system_transaction, tx.base.value);
+        if tx.is_system_transaction {
+            self.fund_beneficiary_for_system_tx_replay(tx.base.value);
+        }
         self.inner.ctx.set_tx(tx);
         BscHandler::new().run(self)
     }
@@ -45,9 +46,10 @@ where
 
     fn replay(&mut self) -> Result<ResultAndState, Self::Error> {
         self.prepare_current_tx_for_execution();
-        let is_sys = self.inner.ctx.tx.is_system_transaction;
-        let value = self.inner.ctx.tx.base.value;
-        self.maybe_bump_beneficiary_balance_for_trace(is_sys, value);
+        if self.inner.ctx.tx.is_system_transaction {
+            let value = self.inner.ctx.tx.base.value;
+            self.fund_beneficiary_for_system_tx_replay(value);
+        }
         BscHandler::new().run(self).map(|result| {
             let state = self.finalize();
             ResultAndState::new(result, state)
@@ -75,10 +77,11 @@ where
         self.inner.set_inspector(inspector);
     }
 
-    fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
-        let mut tx = tx;
+    fn inspect_one_tx(&mut self, mut tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.prepare_tx_for_execution(&mut tx);
-        self.maybe_bump_beneficiary_balance_for_trace(tx.is_system_transaction, tx.base.value);
+        if tx.is_system_transaction {
+            self.fund_beneficiary_for_system_tx_replay(tx.base.value);
+        }
         self.inner.ctx.set_tx(tx);
         BscHandler::new().inspect_run(self)
     }

--- a/src/evm/api/mod.rs
+++ b/src/evm/api/mod.rs
@@ -5,7 +5,7 @@ use crate::{evm::transaction::BscTxEnv, hardforks::bsc::BscHardfork};
 use super::precompiles::BscPrecompiles;
 use reth_evm::{precompiles::PrecompilesMap, Database, EvmEnv};
 use revm::{
-    context::{BlockEnv, CfgEnv, Evm as EvmCtx, FrameStack, JournalTr},
+    context::{BlockEnv, CfgEnv, ContextTr, Evm as EvmCtx, FrameStack, JournalTr},
     handler::{
         evm::{ContextDbError, FrameInitResult},
         instructions::EthInstructions,
@@ -16,6 +16,7 @@ use revm::{
     primitives::hardfork::SpecId,
     Context, Inspector, Journal,
 };
+use revm_context_interface::journaled_state::account::JournaledAccountTr;
 
 mod exec;
 
@@ -79,6 +80,51 @@ impl<DB: Database, I> BscEvm<DB, I> {
     /// Provides a mutable reference to the EVM context.
     pub fn ctx_mut(&mut self) -> &mut BscContext<DB> {
         &mut self.inner.ctx
+    }
+
+    /// `BscTxEnv` counterpart of `system_contracts::is_system_transaction`.
+    fn detect_system_transaction(&self, tx: &BscTxEnv) -> bool {
+        use crate::system_contracts::is_invoke_system_contract;
+        use revm::primitives::TxKind;
+
+        matches!(tx.base.kind, TxKind::Call(to)
+            if tx.base.caller == self.block.beneficiary
+                && is_invoke_system_contract(&to)
+                && tx.base.gas_price == 0)
+    }
+
+    /// Mark `tx` if it looks like a system tx. Idempotent: never downgrades an
+    /// already-true flag, because `pre/post_execution` hand-set it with
+    /// `caller = 0x00..00` which the predicate does not match.
+    pub(crate) fn prepare_tx_for_execution(&self, tx: &mut BscTxEnv) {
+        if !tx.is_system_transaction {
+            tx.is_system_transaction = self.detect_system_transaction(tx);
+        }
+    }
+
+    /// `prepare_tx_for_execution` for the `replay()` path (tx already on ctx).
+    pub(crate) fn prepare_current_tx_for_execution(&mut self) {
+        if !self.inner.ctx.tx.is_system_transaction {
+            let detected = self.detect_system_transaction(&self.inner.ctx.tx);
+            self.inner.ctx.tx.is_system_transaction = detected;
+        }
+    }
+
+    /// Trace-only: top up beneficiary so a value-transferring system tx (e.g. the
+    /// block-reward deposit) does not fail balance checks during replay — archive
+    /// state at block start has not yet received that reward.
+    pub(crate) fn maybe_bump_beneficiary_balance_for_trace(
+        &mut self,
+        is_system_tx: bool,
+        value: revm::primitives::U256,
+    ) {
+        if !self.trace || !is_system_tx {
+            return;
+        }
+        let beneficiary = self.block.beneficiary;
+        if let Ok(mut account) = self.journal_mut().load_account_mut(beneficiary) {
+            account.set_balance(value);
+        }
     }
 }
 
@@ -235,9 +281,9 @@ mod tests {
     use reth_evm::EvmEnv;
     use revm::{
         context::{BlockEnv, CfgEnv, TxEnv},
-        context_interface::result::{ExecutionResult, HaltReason},
+        context_interface::result::{EVMError, ExecutionResult, HaltReason, InvalidTransaction},
         handler::instructions::EthInstructions,
-        inspector::NoOpInspector,
+        inspector::{InspectEvm, NoOpInspector},
         primitives::{hardfork::SpecId, Address, Bytes, TxKind, U256},
         state::{AccountInfo, Bytecode},
         ExecuteEvm,
@@ -343,6 +389,176 @@ mod tests {
         assert!(
             mismatched_result.is_success(),
             "latest-spec instruction table should succeed with this gas limit"
+        );
+    }
+
+    /// `BscEvm` with Osaka + EIP-7825 cap enabled and a funded beneficiary,
+    /// shaped for trace-replay regression tests.
+    fn make_trace_replay_evm(
+        beneficiary: Address,
+        system_contract: Address,
+    ) -> BscEvm<InMemoryDB, NoOpInspector> {
+        let spec = BscHardfork::Osaka;
+        let mut cfg_env = CfgEnv::new_with_spec(spec).with_chain_id(56);
+        cfg_env.tx_gas_limit_cap = Some(2u64.pow(24));
+
+        let block_env = BlockEnv {
+            beneficiary,
+            prevrandao: Some(U256::from(1).into()),
+            ..Default::default()
+        };
+        let env = EvmEnv::new(cfg_env, block_env);
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            beneficiary,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000u64),
+                ..AccountInfo::default()
+            },
+        );
+        db.insert_account_info(system_contract, AccountInfo::default());
+
+        // trace = true enables `maybe_bump_beneficiary_balance_for_trace`.
+        BscEvm::new(env, db, NoOpInspector, false, true)
+    }
+
+    /// Mined-system-tx shape: signer = miner, to = system contract, fee = 0,
+    /// gas = `i64::MAX` (the value that trips the EIP-7825 cap).
+    fn system_tx_shape(beneficiary: Address, system_contract: Address) -> BscTxEnv {
+        BscTxEnv::new(
+            TxEnv::builder()
+                .caller(beneficiary)
+                .chain_id(Some(56))
+                .gas_limit(i64::MAX as u64)
+                .gas_price(0)
+                .kind(TxKind::Call(system_contract))
+                .build()
+                .expect("tx env should build"),
+        )
+    }
+
+    /// BSC `VALIDATOR_CONTRACT` (target of `deposit` / `distributeFinalityReward`).
+    const VALIDATOR_SYSTEM_CONTRACT: Address = Address::new([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x10, 0x00,
+    ]);
+
+    #[test]
+    fn prepare_marks_system_shape_tx() {
+        let beneficiary = Address::from([0x10; 20]);
+        let evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+        let mut tx = system_tx_shape(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+        assert!(!tx.is_system_transaction, "precondition: unmarked");
+
+        evm.prepare_tx_for_execution(&mut tx);
+
+        assert!(
+            tx.is_system_transaction,
+            "tx matching (caller == beneficiary, to ∈ system contracts, gas_price == 0) should be marked"
+        );
+    }
+
+    #[test]
+    fn prepare_is_idempotent_and_does_not_overwrite_pre_marked() {
+        // Regression guard for `pre/post_execution` helpers that hand-set
+        // is_system_transaction = true with caller = 0x00..00 (which the
+        // predicate would reject).
+        let beneficiary = Address::from([0x10; 20]);
+        let evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+        let mut tx = BscTxEnv {
+            base: TxEnv::builder()
+                .caller(Address::ZERO) // != beneficiary
+                .chain_id(Some(56))
+                .gas_limit(30_000_000)
+                .gas_price(0)
+                .kind(TxKind::Call(VALIDATOR_SYSTEM_CONTRACT))
+                .build()
+                .expect("tx env should build"),
+            is_system_transaction: true,
+        };
+
+        evm.prepare_tx_for_execution(&mut tx);
+
+        assert!(
+            tx.is_system_transaction,
+            "prepare must not overwrite an explicitly set is_system_transaction = true"
+        );
+    }
+
+    #[test]
+    fn prepare_leaves_normal_user_tx_unmarked() {
+        let beneficiary = Address::from([0x10; 20]);
+        let evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+        let mut tx = BscTxEnv::new(
+            TxEnv::builder()
+                .caller(Address::from([0x11; 20])) // not beneficiary
+                .chain_id(Some(56))
+                .gas_limit(21_000)
+                .gas_price(1) // not zero
+                .kind(TxKind::Call(Address::from([0x22; 20])))
+                .build()
+                .expect("tx env should build"),
+        );
+
+        evm.prepare_tx_for_execution(&mut tx);
+
+        assert!(
+            !tx.is_system_transaction,
+            "ordinary user tx must not be misclassified as a system tx"
+        );
+    }
+
+    #[test]
+    fn replay_marks_system_tx_before_validation() {
+        let beneficiary = Address::from([0x10; 20]);
+        let mut evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+        evm.inner.ctx.tx = system_tx_shape(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+
+        let result = evm.replay();
+        if let Err(EVMError::Transaction(InvalidTransaction::TxGasLimitGreaterThanCap { .. })) =
+            result
+        {
+            panic!("system transaction was not classified before replay validation");
+        }
+        assert!(
+            evm.inner.ctx.tx.is_system_transaction,
+            "system transaction should be marked after replay()"
+        );
+    }
+
+    #[test]
+    fn transact_one_marks_system_tx_before_validation() {
+        let beneficiary = Address::from([0x10; 20]);
+        let mut evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+        let tx = system_tx_shape(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+
+        let result = evm.transact_one(tx);
+        if let Err(EVMError::Transaction(InvalidTransaction::TxGasLimitGreaterThanCap { .. })) =
+            result
+        {
+            panic!("system transaction was not classified before transact_one validation");
+        }
+        assert!(
+            evm.inner.ctx.tx.is_system_transaction,
+            "system transaction should be marked after transact_one()"
+        );
+    }
+
+    #[test]
+    fn inspect_one_tx_marks_system_tx_before_validation() {
+        let beneficiary = Address::from([0x10; 20]);
+        let mut evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+        let tx = system_tx_shape(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+
+        let result = evm.inspect_one_tx(tx);
+        if let Err(EVMError::Transaction(InvalidTransaction::TxGasLimitGreaterThanCap { .. })) =
+            result
+        {
+            panic!("system transaction was not classified before inspect_one_tx validation");
+        }
+        assert!(
+            evm.inner.ctx.tx.is_system_transaction,
+            "system transaction should be marked after inspect_one_tx()"
         );
     }
 }

--- a/src/evm/api/mod.rs
+++ b/src/evm/api/mod.rs
@@ -110,17 +110,18 @@ impl<DB: Database, I> BscEvm<DB, I> {
         }
     }
 
-    /// Fund the beneficiary with `value` so a value-transferring BSC system tx
-    /// (e.g. the block-reward deposit) does not fail balance checks during trace
-    /// replay — archive state at block start has not yet received that reward.
-    /// Trace-mode only; callers must gate on `tx.is_system_transaction`.
+    /// Stand in for `post_execution::distribute_incoming`'s SYSTEM_ADDRESS →
+    /// validator credit, which trace replay skips. Use `incr_balance`, not
+    /// `set_balance`, so the archive-state balance survives the deposit's
+    /// `B + V → B` round-trip. Runs before the handler's tx checkpoint, so a
+    /// (very unlikely) system-tx revert would leave the top-up in place.
     pub(crate) fn fund_beneficiary_for_system_tx_replay(&mut self, value: revm::primitives::U256) {
-        if !self.trace {
+        if !self.trace || value.is_zero() {
             return;
         }
         let beneficiary = self.block.beneficiary;
         if let Ok(mut account) = self.journal_mut().load_account_mut(beneficiary) {
-            account.set_balance(value);
+            let _ = account.incr_balance(value);
         }
     }
 }
@@ -557,5 +558,68 @@ mod tests {
             evm.inner.ctx.tx.is_system_transaction,
             "system transaction should be marked after inspect_one_tx()"
         );
+    }
+
+    fn read_beneficiary_balance(
+        evm: &mut BscEvm<InMemoryDB, NoOpInspector>,
+        beneficiary: Address,
+    ) -> U256 {
+        use revm::context::{ContextTr, JournalTr};
+        use revm_context_interface::journaled_state::account::JournaledAccountTr;
+        *evm.journal_mut()
+            .load_account_mut(beneficiary)
+            .expect("beneficiary account should load")
+            .balance()
+    }
+
+    const TRACE_BENEFICIARY_INITIAL_BALANCE: u64 = 1_000_000_000_000u64;
+
+    #[test]
+    fn fund_uses_incr_semantics_not_set() {
+        let beneficiary = Address::from([0x10; 20]);
+        let mut evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+
+        let initial = U256::from(TRACE_BENEFICIARY_INITIAL_BALANCE);
+        let top_up = U256::from(42_000u64);
+        evm.fund_beneficiary_for_system_tx_replay(top_up);
+
+        assert_eq!(read_beneficiary_balance(&mut evm, beneficiary), initial + top_up);
+    }
+
+    #[test]
+    fn fund_is_noop_for_zero_value() {
+        let beneficiary = Address::from([0x10; 20]);
+        let mut evm = make_trace_replay_evm(beneficiary, VALIDATOR_SYSTEM_CONTRACT);
+
+        let initial = U256::from(TRACE_BENEFICIARY_INITIAL_BALANCE);
+        evm.fund_beneficiary_for_system_tx_replay(U256::ZERO);
+
+        assert_eq!(read_beneficiary_balance(&mut evm, beneficiary), initial);
+    }
+
+    #[test]
+    fn fund_is_noop_when_trace_disabled() {
+        let beneficiary = Address::from([0x10; 20]);
+        let mut cfg_env = CfgEnv::new_with_spec(BscHardfork::Osaka).with_chain_id(56);
+        cfg_env.tx_gas_limit_cap = Some(2u64.pow(24));
+        let block_env = BlockEnv {
+            beneficiary,
+            prevrandao: Some(U256::from(1).into()),
+            ..Default::default()
+        };
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            beneficiary,
+            AccountInfo {
+                balance: U256::from(TRACE_BENEFICIARY_INITIAL_BALANCE),
+                ..AccountInfo::default()
+            },
+        );
+        let mut evm = BscEvm::new(EvmEnv::new(cfg_env, block_env), db, NoOpInspector, false, false);
+
+        let initial = U256::from(TRACE_BENEFICIARY_INITIAL_BALANCE);
+        evm.fund_beneficiary_for_system_tx_replay(U256::from(123u64));
+
+        assert_eq!(read_beneficiary_balance(&mut evm, beneficiary), initial);
     }
 }

--- a/src/evm/api/mod.rs
+++ b/src/evm/api/mod.rs
@@ -110,15 +110,12 @@ impl<DB: Database, I> BscEvm<DB, I> {
         }
     }
 
-    /// Trace-only: top up beneficiary so a value-transferring system tx (e.g. the
-    /// block-reward deposit) does not fail balance checks during replay — archive
-    /// state at block start has not yet received that reward.
-    pub(crate) fn maybe_bump_beneficiary_balance_for_trace(
-        &mut self,
-        is_system_tx: bool,
-        value: revm::primitives::U256,
-    ) {
-        if !self.trace || !is_system_tx {
+    /// Fund the beneficiary with `value` so a value-transferring BSC system tx
+    /// (e.g. the block-reward deposit) does not fail balance checks during trace
+    /// replay — archive state at block start has not yet received that reward.
+    /// Trace-mode only; callers must gate on `tx.is_system_transaction`.
+    pub(crate) fn fund_beneficiary_for_system_tx_replay(&mut self, value: revm::primitives::U256) {
+        if !self.trace {
             return;
         }
         let beneficiary = self.block.beneficiary;
@@ -419,7 +416,7 @@ mod tests {
         );
         db.insert_account_info(system_contract, AccountInfo::default());
 
-        // trace = true enables `maybe_bump_beneficiary_balance_for_trace`.
+        // trace = true enables `fund_beneficiary_for_system_tx_replay`.
         BscEvm::new(env, db, NoOpInspector, false, true)
     }
 

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -20,12 +20,10 @@ use reth_evm::{precompiles::PrecompilesMap, Database, Evm, EvmEnv};
 use revm::{
     context::{
         result::{EVMError, HaltReason, ResultAndState},
-        BlockEnv, ContextTr,
+        BlockEnv,
     },
-    context_interface::JournalTr,
     Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
 };
-use revm_context_interface::journaled_state::account::JournaledAccountTr;
 
 mod assembler;
 mod builder;
@@ -68,30 +66,11 @@ where
         &mut self,
         mut tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        // Detect system transactions in inspect mode (for trace APIs)
-        // Normal execution: BlockExecutor filters system txs before calling transact
-        // debug_traceTransaction/debug_traceCall: detect and handle system txs here
+        // BlockExecutor filters mined system txs out before reaching here; trace
+        // RPCs do not — let `prepare` mark them idempotently for `BscHandler`.
+        self.prepare_tx_for_execution(&mut tx);
+        self.maybe_bump_beneficiary_balance_for_trace(tx.is_system_transaction, tx.base.value);
 
-        if self.trace {
-            use crate::system_contracts::is_invoke_system_contract;
-            use revm::primitives::TxKind;
-
-            tx.is_system_transaction = matches!(tx.base.kind, TxKind::Call(to)
-                if tx.base.caller == self.block.beneficiary
-                    && is_invoke_system_contract(&to)
-                    && tx.base.gas_price == 0);
-
-            // Increase beneficiary balance for system transactions in trace context
-            // Only runs when trace=true (CacheDB detected or explicit inspector used)
-            if tx.is_system_transaction {
-                let beneficiary = self.block.beneficiary;
-                if let Ok(mut account) = self.journal_mut().load_account_mut(beneficiary) {
-                    account.set_balance(tx.base.value);
-                }
-            }
-        }
-
-        // Save original environment for system transactions
         let saved_env = if tx.is_system_transaction {
             Some((
                 core::mem::replace(&mut self.block.gas_limit, tx.base.gas_limit),

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -69,9 +69,9 @@ where
         // BlockExecutor filters mined system txs out before reaching here; trace
         // RPCs do not — let `prepare` mark them idempotently for `BscHandler`.
         self.prepare_tx_for_execution(&mut tx);
-        self.maybe_bump_beneficiary_balance_for_trace(tx.is_system_transaction, tx.base.value);
 
         let saved_env = if tx.is_system_transaction {
+            self.fund_beneficiary_for_system_tx_replay(tx.base.value);
             Some((
                 core::mem::replace(&mut self.block.gas_limit, tx.base.gas_limit),
                 core::mem::replace(&mut self.block.basefee, 0),
@@ -81,10 +81,8 @@ where
             None
         };
 
-        // Execute transaction
         let res = if self.inspect { self.inspect_tx(tx) } else { ExecuteEvm::transact(self, tx) };
 
-        // Restore environment for system transactions
         if let Some((gas_limit, basefee, disable_nonce_check)) = saved_env {
             self.block.gas_limit = gas_limit;
             self.block.basefee = basefee;


### PR DESCRIPTION
### Description

Fix `intrinsic gas too high` from `debug_traceTransaction` / `debug_traceCall` on BSC system txs.

### Rationale

Trace replay calls `ExecuteCommitEvm::transact_commit` → `transact_one` directly. That path doesn't mark `is_system_transaction`, so `BscHandler` falls back to mainnet validation and the EIP-7825 cap rejects the `i64::MAX` gas limit.

Only the first system tx in a block traces successfully — any later one fails because replaying the deposit before it already trips the cap.

### Example

`debug_traceTransaction("0xccdda18752a8fbe976f0c08317a1582235e1cec90f0a97d4fee9f1eeb28091f0")` (distributeFinalityReward, idx 106 of block `0x5de3a50`):

- Before: `{"error":{"code":-32000,"message":"intrinsic gas too high"}}`
- After: works.

### Changes

- Mark system txs at the EVM entry layer (`transact_one`, `replay`, `inspect_one_tx`, `transact_raw`). Idempotent so manually marked txs from `pre/post_execution` aren't downgraded.
- Top up beneficiary balance on trace replay so value-transferring system txs (deposit) pass the balance check.
- Tests for marking, idempotence, no false positives on user txs, and all three entry points.

### Potential Impacts

N/A.