### PR TITLE
fix: resolve in-memory parent header for multi-block eth_simulateV1

### DIFF
--- a/src/node/evm/builder.rs
+++ b/src/node/evm/builder.rs
@@ -88,6 +88,15 @@ where
     type Executor = BscBlockExecutor<'a, EVM, Spec, R>;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
+        // Parlia pre-execution and the snapshot rebuild resolve the parent by hash via
+        // the global header reader, which only holds canonical headers. During a
+        // multi-block eth_simulateV1 the parent is the previous in-memory simulated
+        // block, so seed it here — by hash only, to leave the canonical block-number
+        // index intact. Re-seeding an already-canonical parent is a no-op.
+        crate::node::evm::util::insert_header_to_cache_hash_only(
+            self.parent.header().clone(),
+            self.parent.hash(),
+        );
         self.executor.apply_pre_execution_changes()
     }
 

--- a/src/node/evm/pre_execution_tests.rs
+++ b/src/node/evm/pre_execution_tests.rs
@@ -6,6 +6,34 @@ mod tests {
     use crate::node::evm::pre_execution::{TURN_LENGTH_CACHE, VALIDATOR_CACHE};
     use alloy_primitives::{Address, B256};
 
+    /// Multi-block `eth_simulateV1` parent resolution (regression for bnb-chain/reth#194).
+    /// A simulated block must be resolvable by hash for the next block's parent lookup,
+    /// and hash-only seeding must not touch the canonical block-number index.
+    #[test]
+    fn test_simulated_block_parent_resolvable_by_hash_only() {
+        use crate::node::evm::util::{insert_header_to_cache_hash_only, HEADER_CACHE_READER};
+        use alloy_consensus::Header;
+
+        // High block number so it can't collide with a real cached/provider header.
+        let simulated_block_1 =
+            Header { number: 99_000_000, gas_limit: 140_000_000, ..Default::default() };
+        let block_1_hash = simulated_block_1.hash_slow();
+
+        // Unseeded: invisible to the reader (the None that aborts block 2 today).
+        assert!(HEADER_CACHE_READER.lock().unwrap().get_header_by_hash(&block_1_hash).is_none());
+
+        // Seed by hash, as BscBlockBuilder does before block 2 pre-executes.
+        insert_header_to_cache_hash_only(simulated_block_1.clone(), block_1_hash);
+
+        let resolved = HEADER_CACHE_READER.lock().unwrap().get_header_by_hash(&block_1_hash);
+        assert_eq!(resolved.map(|h| h.number), Some(simulated_block_1.number));
+
+        // Hash-only seeding must leave the canonical block-number index untouched.
+        let by_number =
+            HEADER_CACHE_READER.lock().unwrap().get_header_by_number(simulated_block_1.number);
+        assert!(by_number.is_none());
+    }
+
     /// Test validator cache basic operations
     #[test]
     fn test_validator_cache_insert_and_get() {

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -80,6 +80,13 @@ impl HeaderCacheReader {
         self.blockhash_to_header.insert(block_hash, header);
         tracing::trace!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header_clone_for_log);
     }
+
+    /// Insert a header keyed by hash only, leaving the block-number index untouched.
+    /// Lets non-canonical in-memory blocks (e.g. intermediate `eth_simulateV1` blocks)
+    /// satisfy by-hash parent lookups without shadowing the real chain by number.
+    pub fn insert_header_hash_only(&mut self, header: Header, block_hash: BlockHash) {
+        self.blockhash_to_header.insert(block_hash, header);
+    }
 }
 
 pub static HEADER_CACHE_READER: LazyLock<Mutex<HeaderCacheReader>> = LazyLock::new(|| {
@@ -109,4 +116,10 @@ pub fn insert_header_to_cache(header: Header) {
 /// Insert header with a known hash to avoid re-hashing.
 pub fn insert_header_to_cache_with_hash(header: Header, block_hash: Option<BlockHash>) {
     HEADER_CACHE_READER.lock().unwrap().insert_header_to_cache_with_hash(header, block_hash);
+}
+
+/// Insert a header keyed only by its hash (leaves the block-number index alone).
+/// See [`HeaderCacheReader::insert_header_hash_only`].
+pub fn insert_header_to_cache_hash_only(header: Header, block_hash: BlockHash) {
+    HEADER_CACHE_READER.lock().unwrap().insert_header_hash_only(header, block_hash);
 }


### PR DESCRIPTION
### Description

`eth_simulateV1` returned `-32603 "Failed to get parent header from global header reader"` whenever a request contained more than one `blockStateCalls` entry (one block works, two or more fail). This makes each block produced during a multi-block simulation visible to the global header reader by hash, so the next block's parlia pre-execution can resolve its parent. Fixes bnb-chain/reth#194.

### Rationale

The simulate loop chains blocks: block N+1's parent is the in-memory block N produced one iteration earlier. BSC pre-execution (`check_new_block`) and the parlia snapshot rebuild resolve the parent **by hash** via `HEADER_CACHE_READER`, which only contains real canonical headers. Block 1's parent is the canonical chain tip and resolves; block 2's parent is the synthetic block 1, which is never persisted, so the lookup returns `None` and execution aborts. geth serves multi-block simulate fine, so this is a reth-bsc-specific gap.

### Example

Reproduced against a BSC archive node. (The reported node version `1.10.2-dev` is the `bnb-chain/reth` baseline — reth-node-core `1.10.2` with the `-dev` suffix for an untagged build — not a distinct reth-bsc release.)

```bash
# 1 block — succeeds
cast rpc eth_simulateV1 --raw '[{"blockStateCalls":[{"calls":[]}]},"latest"]' --rpc-url $URL

# 2 blocks — fails before this change
cast rpc eth_simulateV1 --raw '[{"blockStateCalls":[{"calls":[]},{"calls":[]}]},"latest"]' --rpc-url $URL
# => error -32603 "Failed to get parent header from global header reader"
```

With this change the two-block request is expected to return two simulated blocks instead of erroring.

> Note: the failing case above is reproduced; the success case has not yet been validated on a node built from this branch (the publicly reachable endpoint runs the pre-fix binary). On-node verification of the two-block call — including a simulated block landing on an epoch boundary — is still pending.

### Changes

Notable changes:
* `BscBlockBuilder::apply_pre_execution_changes` seeds its parent header into `HEADER_CACHE_READER` by hash before pre-execution runs.
* Add `HeaderCacheReader::insert_header_hash_only` / `insert_header_to_cache_hash_only` — a hash-keyed insert that deliberately leaves the canonical block-number index untouched.
* Add regression test `test_simulated_block_parent_resolvable_by_hash_only`.

### Potential Impacts

* Real block building/import: the parent is already canonical, so the seed is a no-op re-insert (same header, same hash) — no behavior change.
* The snapshot lookup (`snapshot_by_hash`) is fixed implicitly: the provider falls back to `get_header_by_hash` + `try_rebuild`, which now walks the seeded header back to the tip's snapshot.
* Hash-only seeding intentionally does **not** write the block-number index, so a speculative simulated block can never shadow the real chain in by-number lookups.
* Memory: each simulated block adds one entry to the 100k-capacity LRU hash map — negligible.
