### PR TITLE
chore: remove triedb (rust-eth-triedb/pathdb) state backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Workspace members: the root crate (binary `reth-bsc`, library `reth_bsc`) and `testing/bsc-ef-tests` (execution-spec tests harness).
 - All `reth-*` deps are pinned to one commit in `Cargo.toml` (currently `bnb-chain/reth` rev `ef46a48…`). If you change the Reth rev, update **every** `reth-*` line — a mismatched rev produces duplicate-crate build failures. The `testing/bsc-ef-tests/Cargo.toml` uses `branch = "develop"` of the same fork; that's intentional but keep it aligned when bumping.
-- Triedb backend (`--statedb.triedb`) pulls `rust-eth-triedb*` from `bnb-chain/reth-bsc-triedb` on the `develop` branch.
 - `build.rs` scans `src/system_contracts/<hardfork>/{mainnet,chapel,rialto}/*` at build time and emits `src/system_contracts/embedded_contracts.rs` (a `phf_map` keyed as `"<hardfork>_<network>_<contract>"`). It also records the git SHA into `RETH_BSC_GIT_SHA` / `RETH_BSC_GIT_SHA_LONG` used at startup and in the P2P client string. If you add a new hardfork directory with system contracts, add it to the `hardforks` list in `build.rs` so cargo rebuilds when those files change.
 
 ## Common commands
@@ -46,11 +45,10 @@ make ef-tests-nextest   # same, via cargo-nextest
 make clean-eest
 ```
 
-Run (binary is `reth-bsc`, chain ids `bsc`, `bsc-testnet`; optional `--statedb.triedb`):
+Run (binary is `reth-bsc`, chain ids `bsc`, `bsc-testnet`):
 ```bash
 ./target/release/reth-bsc node --chain bsc --datadir ./data_dir
 ./target/release/reth-bsc node --full --chain bsc --datadir ./data_dir            # full node
-./target/release/reth-bsc node --chain bsc --datadir ./data_dir --statedb.triedb  # triedb backend
 ```
 
 ## Where the wiring lives

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap 6.2.1",
+ "dashmap",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -1852,7 +1852,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cow-utils",
- "dashmap 6.2.1",
+ "dashmap",
  "dynify",
  "fast-float2",
  "float16",
@@ -2089,12 +2089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,15 +2166,6 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
@@ -2191,25 +2176,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform 0.1.9",
- "semver 1.0.28",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform 0.3.3",
+ "cargo-platform",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -2994,19 +2966,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -3554,15 +3513,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -5837,21 +5787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mini-moka"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-utils",
- "dashmap 5.5.3",
- "skeptic",
- "smallvec",
- "tagptr",
- "triomphe",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6974,17 +6909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.11.1",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7534,7 +7458,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7575,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7585,7 +7509,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-execution-cache",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7602,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7619,13 +7543,12 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
  "revm-database",
  "revm-state",
- "rust-eth-triedb-common",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7635,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7655,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7668,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7742,7 +7665,6 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
- "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -7758,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7768,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7817,7 +7739,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7833,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7846,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7859,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7885,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7898,7 +7820,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7914,7 +7836,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7940,12 +7862,11 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-trie",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -7962,9 +7883,6 @@ dependencies = [
  "reth-static-file-types",
  "reth-trie",
  "reth-trie-db",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-state-trie",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7974,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7989,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8014,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8027,7 +7945,7 @@ dependencies = [
  "rand 0.9.4",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -8038,10 +7956,10 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
- "dashmap 6.2.1",
+ "dashmap",
  "data-encoding",
  "enr",
  "hickory-resolver",
@@ -8062,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8078,7 +7996,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -8097,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8125,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8148,7 +8066,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8173,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8200,7 +8118,7 @@ dependencies = [
  "reth-evm",
  "reth-execution-cache",
  "reth-execution-types",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8221,10 +8139,6 @@ dependencies = [
  "reth-trie-sparse",
  "revm",
  "revm-primitives",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
- "rust-eth-triedb-state-trie",
  "schnellru",
  "thiserror 2.0.18",
  "tokio",
@@ -8234,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8262,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8278,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8294,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8316,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8327,7 +8241,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8341,7 +8255,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8356,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8381,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "clap",
  "eyre",
@@ -8404,7 +8318,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8420,7 +8334,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8436,7 +8350,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8450,7 +8364,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8480,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8494,7 +8408,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8504,7 +8418,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8517,19 +8431,18 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
- "rust-eth-triedb-common",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8549,14 +8462,14 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
  "metrics",
  "parking_lot",
  "reth-errors",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -8567,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8580,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8599,7 +8512,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8616,7 +8529,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8637,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8651,7 +8564,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "serde",
  "serde_json",
@@ -8661,7 +8574,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8689,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8709,12 +8622,12 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
  "crossbeam-queue",
- "dashmap 6.2.1",
+ "dashmap",
  "derive_more 2.1.1",
  "parking_lot",
  "reth-mdbx-sys",
@@ -8726,7 +8639,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "bindgen",
  "cc",
@@ -8734,20 +8647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.2"
-source = "git+https://github.com/bnb-chain/reth.git#95d649fe0b75ba06e23c317fd75e07b422fdebd0"
-dependencies = [
- "futures",
- "metrics",
- "metrics-derive",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "futures",
  "metrics",
@@ -8760,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8769,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8783,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8814,7 +8715,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
  "reth-fs-util",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8841,7 +8742,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8866,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8889,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8904,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8918,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8935,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8959,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8972,7 +8873,6 @@ dependencies = [
  "fdlimit",
  "futures",
  "jsonrpsee",
- "metrics",
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
@@ -9018,7 +8918,6 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
- "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9029,7 +8928,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9084,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -9122,7 +9021,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9146,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9170,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9183,7 +9082,7 @@ dependencies = [
  "metrics-util",
  "procfs",
  "reqwest 0.13.4",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9194,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9206,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9217,7 +9116,7 @@ dependencies = [
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
  "reth-execution-cache",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9230,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9242,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9266,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9288,7 +9187,7 @@ dependencies = [
  "arbitrary",
  "byteorder",
  "bytes 1.11.1",
- "dashmap 6.2.1",
+ "dashmap",
  "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
@@ -9308,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9331,7 +9230,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9346,8 +9245,6 @@ dependencies = [
  "revm-database",
  "revm-state",
  "rocksdb",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
  "strum",
  "tokio",
  "tracing",
@@ -9356,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9368,7 +9265,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9385,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9401,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9416,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9459,7 +9356,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9480,7 +9377,6 @@ dependencies = [
  "revm",
  "revm-inspectors",
  "revm-primitives",
- "rust-eth-triedb",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -9494,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -9524,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9539,7 +9435,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-api",
  "reth-node-core",
  "reth-payload-primitives",
@@ -9567,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9588,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9600,7 +9496,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9619,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9658,7 +9554,6 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
- "rust-eth-triedb",
  "serde_json",
  "tokio",
  "tracing",
@@ -9667,7 +9562,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9692,7 +9587,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9715,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.1",
@@ -9729,7 +9624,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9759,13 +9654,12 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-trie",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
@@ -9804,7 +9698,6 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
- "rust-eth-triedb",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -9814,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9825,7 +9718,7 @@ dependencies = [
  "reth-codecs",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9842,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9856,7 +9749,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9876,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9891,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9915,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9933,17 +9826,17 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "crossbeam-utils",
- "dashmap 6.2.1",
+ "dashmap",
  "futures-util",
  "libc",
  "metrics",
  "parking_lot",
  "pin-project",
  "rayon",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "thiserror 2.0.18",
  "thread-priority",
  "tokio",
@@ -9954,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9970,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9980,7 +9873,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "clap",
  "eyre",
@@ -9995,7 +9888,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "clap",
  "eyre",
@@ -10013,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10037,7 +9930,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -10058,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10070,7 +9963,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10084,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10104,8 +9997,6 @@ dependencies = [
  "reth-codecs",
  "reth-primitives-traits",
  "revm-database",
- "rust-eth-triedb",
- "rust-eth-triedb-state-trie",
  "serde",
  "serde_with",
 ]
@@ -10113,28 +10004,27 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "rust-eth-triedb",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10147,7 +10037,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
@@ -10162,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
+source = "git+https://github.com/bnb-chain/reth.git?rev=6dcb09c0090e046eea6440fbeb58cce5db0476b2#6dcb09c0090e046eea6440fbeb58cce5db0476b2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10170,7 +10060,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
@@ -10268,7 +10158,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 2.2.0",
+ "reth-metrics",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",
@@ -10296,10 +10186,6 @@ dependencies = [
  "revm-interpreter",
  "revm-primitives",
  "revm-state",
- "rust-eth-triedb",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
- "rust-eth-triedb-state-trie",
  "schnellru",
  "scrypt 0.11.0",
  "secp256k1 0.30.0",
@@ -10701,77 +10587,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rust-eth-triedb"
-version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
-dependencies = [
- "alloy-primitives",
- "alloy-trie",
- "metrics",
- "once_cell",
- "rayon",
- "reth-metrics 1.10.2",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
- "rust-eth-triedb-state-trie",
- "schnellru",
- "serde",
- "thiserror 1.0.69",
- "tikv-jemallocator",
- "tracing",
-]
-
-[[package]]
-name = "rust-eth-triedb-common"
-version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
-dependencies = [
- "alloy-primitives",
- "auto_impl",
- "thiserror 1.0.69",
- "tikv-jemallocator",
-]
-
-[[package]]
-name = "rust-eth-triedb-pathdb"
-version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
-dependencies = [
- "alloy-primitives",
- "alloy-trie",
- "metrics",
- "mini-moka",
- "reth-metrics 1.10.2",
- "rocksdb",
- "rust-eth-triedb-common",
- "schnellru",
- "tempfile",
- "thiserror 1.0.69",
- "tikv-jemallocator",
- "tracing",
-]
-
-[[package]]
-name = "rust-eth-triedb-state-trie"
-version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "arbitrary",
- "auto_impl",
- "hex 0.4.3",
- "rand 0.8.6",
- "rayon",
- "rust-eth-triedb-common",
- "rust-eth-triedb-pathdb",
- "thiserror 1.0.69",
- "tikv-jemallocator",
- "tracing",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -11607,21 +11422,6 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata 0.14.2",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
 
 [[package]]
 name = "sketches-ddsketch"
@@ -12629,12 +12429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triomphe"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12853,7 +12647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.23.1",
+ "cargo_metadata",
  "derive_builder",
  "regex",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7534,7 +7534,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7655,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7758,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7846,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7974,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -8062,7 +8062,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8125,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8148,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8173,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8278,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8294,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8316,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8327,7 +8327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "clap",
  "eyre",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8420,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8436,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8450,7 +8450,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8480,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8494,7 +8494,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8529,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8549,7 +8549,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8567,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8580,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8599,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8637,7 +8637,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "serde",
  "serde_json",
@@ -8661,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8689,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8709,7 +8709,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8726,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "bindgen",
  "cc",
@@ -8747,7 +8747,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "futures",
  "metrics",
@@ -8760,7 +8760,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8769,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8841,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8935,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9084,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -9122,7 +9122,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9194,7 +9194,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9206,7 +9206,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9416,7 +9416,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9494,7 +9494,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -9524,7 +9524,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9567,7 +9567,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9619,7 +9619,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9667,7 +9667,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9715,7 +9715,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.1",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9814,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9876,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9891,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9915,7 +9915,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9970,7 +9970,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9980,7 +9980,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "clap",
  "eyre",
@@ -9995,7 +9995,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "clap",
  "eyre",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10113,7 +10113,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10134,7 +10134,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10162,7 +10162,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#ccccfd7a24c93b16953837917b4deffbfbf8f1e1"
+source = "git+https://github.com/bnb-chain/reth.git?tag=v0.0.10#cb902b4d0ef5602348a3f6c0ceaefbdba423d565"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
 reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
 
 # triedb dependencies
 rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,66 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
 reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-
-# triedb dependencies
-rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop" }
-rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-common" }
-rust-eth-triedb-pathdb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-pathdb" }
-rust-eth-triedb-state-trie = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-state-trie" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
 
 revm = "38.0.0"
 revm-database = "13.0.0"
@@ -247,9 +241,9 @@ debug = "line-tables-only"
 strip = false
 split-debuginfo = "off"
 
-# Apply the same to every transitive dependency so triedb/revm/rayon frames
-# also resolve. Without this, only reth-bsc's own symbols show up and the
-# whole state-root path still looks opaque.
+# Apply the same to every transitive dependency so revm/rayon frames also
+# resolve. Without this, only reth-bsc's own symbols show up and the whole
+# state-root path still looks opaque.
 [profile.maxperf.package."*"]
 debug = "line-tables-only"
 strip = false

--- a/README.md
+++ b/README.md
@@ -80,15 +80,6 @@ An archive node stores the complete blockchain history and state:
 ./target/${profile}/reth-bsc node --chain bsc --datadir ./data_dir
 ```
 
-### TrieDB Node
-
-An triedb node uses RocksDB store state data:
-
-```bash
-./target/${profile}/reth-bsc node --chain bsc --datadir ./data_dir --statedb.triedb
-```
-
-
 ### BSC Testnet
 
 To run on BSC Testnet instead of Mainnet, simply replace `--chain bsc` with `--chain bsc-testnet` in any of the above commands:

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,7 @@ pub struct BscCliArgs {
     pub mining_min_gas_tip: Option<u128>,
 
     /// Use reth 2.0 sparse-trie background task for state-root computation in
-    /// MDBX-mode payload build (opt-in; no effect when `--statedb.triedb` is
-    /// active).
+    /// payload build (opt-in).
     ///
     /// Env alternative: `BSC_MINING_USE_SPARSE_TRIE_STATE_ROOT=true`.
     #[arg(long = "mining.use-sparse-trie-state-root")]

--- a/src/node/engine.rs
+++ b/src/node/engine.rs
@@ -55,7 +55,7 @@ pub struct BscBuiltPayload {
     pub exec_duration: Duration,
     /// Time spent computing the trie root (time spent in `finish()` after execution).
     pub trie_root_duration: Duration,
-    /// The executed block (includes difflayer if triedb produced one)
+    /// The executed block.
     pub(crate) executed_block: ExecutedBlock<BscPrimitives>,
     /// Validators from execution context, to be written to VALIDATOR_CACHE after finalization.
     /// `None` for bid payloads and non-epoch blocks.
@@ -123,9 +123,7 @@ where
         // `TreeConfig` built from the `--engine.*` CLI flags via
         // `ctx.config().engine.tree_config()`, so miner-side proof-worker counts /
         // cache sizes are CLI-tunable and match the import (engine) path.
-        if mining_config.use_sparse_trie_state_root
-            && !rust_eth_triedb::triedb_manager::is_triedb_active()
-        {
+        if mining_config.use_sparse_trie_state_root {
             use alloy_consensus::BlockHeader;
             use reth_chain_state::LazyOverlay;
             use reth_engine_tree::tree::{
@@ -246,7 +244,7 @@ where
             } else {
                 info!(
                     "Sparse-trie state-root spawner registered \
-                     (use_sparse_trie_state_root=true, triedb=inactive)"
+                     (use_sparse_trie_state_root=true)"
                 );
             }
         }

--- a/src/node/evm/builder.rs
+++ b/src/node/evm/builder.rs
@@ -6,28 +6,19 @@ use crate::{
         executor::BscBlockExecutor,
         factory::BscEvmFactory,
     },
-    shared::BscEngineApiTx,
     BscPrimitives,
 };
-use alloy_consensus::BlockHeader as _;
 use alloy_evm::block::{BlockExecutor, GasOutput};
 use alloy_evm::eth::receipt_builder::ReceiptBuilder;
-use alloy_primitives::BlockHash;
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
-use reth_engine_primitives::BSCEngineMessageError;
-use reth_engine_tree::engine::EngineApiRequest;
-use reth_engine_tree::tree::CustomRequestMessage;
-use reth_evm::execute::{BlockBuilder, BlockBuilderOutcome, BlockBuilderOutcomeWithDiffLayer, BlockExecutionError, ExecutorTx};
+use reth_evm::execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionError, ExecutorTx};
 use reth_primitives_traits::{
     HeaderTy, NodePrimitives, Recovered, RecoveredBlock, SealedHeader, SignerRecoverable, TxTy,
 };
 use reth_provider::StateProvider;
 use reth_trie_common::updates::TrieUpdates;
-use rust_eth_triedb::get_global_triedb;
-use rust_eth_triedb_common::DiffLayers;
 use revm::context::BlockEnv;
 use revm::database::{states::bundle_state::BundleRetention, State};
-use tokio::sync::oneshot;
 
 /// rewrite BasicBlockBuilder, mainly about the finish() trait.
 /// add system txs to sealed block.
@@ -51,14 +42,10 @@ where
     /// Optional precomputed `(state_root, trie_updates)` from a sparse-trie background
     /// task.
     ///
-    /// When `Some`, `finish_with_difflayer`'s MDBX branch uses these values directly
-    /// and skips the blocking `state_root_with_updates` call. Set via either:
+    /// When `Some`, `finish` uses these values directly and skips the blocking
+    /// `state_root_with_updates` call. Set via either:
     ///   * [`BscBlockBuilder::with_precomputed_state_root`] (fluent), or
-    ///   * the `state_root_precomputed` parameter on the [`BlockBuilder::finish`]
-    ///     trait method (which forwards into this field before delegating to
-    ///     `finish_with_difflayer`).
-    ///
-    /// `None` in the TrieDB branch and when no sparse-trie task is in flight.
+    ///   * the `state_root_precomputed` parameter on [`BlockBuilder::finish`].
     pub precomputed_state_root: Option<(alloy_primitives::B256, TrieUpdates)>,
 }
 
@@ -86,15 +73,9 @@ where
     }
 
     /// Install a precomputed `(state_root, trie_updates)` to be consumed by
-    /// `finish_with_difflayer` (MDBX branch only). Returns `self` for fluent usage.
+    /// `finish`. Returns `self` for fluent usage.
     ///
     /// Pass `None` to clear an existing value.
-    ///
-    /// Currently has no callers — `BscPayloadJob` obtains its builder via
-    /// `evm_config.builder_for_next_block(...)` which returns `impl BlockBuilder`, so
-    /// this concrete setter is unreachable through the trait. Kept as the documented
-    /// integration point for the follow-up sparse-trie wiring; see TODOs in
-    /// `payload.rs` for the two ways to bridge the gap.
     #[allow(dead_code)]
     pub fn with_precomputed_state_root(
         mut self,
@@ -146,34 +127,21 @@ where
         }
     }
 
-    // fetch assembled_system_txs and add into sealed block.
+    /// Finalize the block and compute the state root.
+    ///
+    /// Honors `self.precomputed_state_root` (set via
+    /// [`BscBlockBuilder::with_precomputed_state_root`] or the
+    /// `state_root_precomputed` parameter) to skip the blocking
+    /// `state_root_with_updates` call when a sparse-trie task has already computed
+    /// the root concurrently with execution.
     fn finish(
         mut self,
         state: impl StateProvider,
         state_root_precomputed: Option<(alloy_primitives::B256, TrieUpdates)>,
     ) -> Result<BlockBuilderOutcome<BscPrimitives>, BlockExecutionError> {
-        // Forward into the field so `finish_with_difflayer` (whose trait signature
-        // takes only `state`) can pick it up.
         if state_root_precomputed.is_some() {
             self.precomputed_state_root = state_root_precomputed;
         }
-        Ok(self.finish_with_difflayer(state)?.inner)
-    }
-
-    /// Finalize the block and compute the state root, supporting both MDBX-only and
-    /// TrieDB modes. When TrieDB is active the returned `difflayer` is `Some`, carrying
-    /// the precomputed diff layer that can be committed directly to the TrieDB backend;
-    /// otherwise `difflayer` is `None` and the caller falls back to the standard
-    /// hashed-state + trie-updates path.
-    ///
-    /// MDBX branch additionally honors `self.precomputed_state_root` (set via
-    /// [`BscBlockBuilder::with_precomputed_state_root`] or routed through `fn finish`)
-    /// to skip the blocking `state_root_with_updates` call when a sparse-trie task has
-    /// already computed the root concurrently with execution.
-    fn finish_with_difflayer(
-        mut self,
-        state: impl StateProvider,
-    ) -> Result<BlockBuilderOutcomeWithDiffLayer<BscPrimitives>, BlockExecutionError> {
         let finish_start = std::time::Instant::now();
         // `executor.finish()` runs BSC's post-execution system txs (slash spoiled
         // validator, distribute fees / finality rewards, breathe-block validator-set
@@ -278,47 +246,7 @@ where
         let state_root_start = std::time::Instant::now();
         let hashed_state = state.hashed_post_state(&db.bundle_state);
 
-        // Use triedb to calculate state root
-        let (state_root, trie_updates, produced_difflayer) = if rust_eth_triedb::triedb_manager::is_triedb_active() {
-            let mut triedb = get_global_triedb();
-            // Miner-side: try to use triedb prefetcher + parent difflayers from execution ctx.
-            let prefetch_state = self.ctx.triedb_prefetcher.take().and_then(|p| p.finish());
-            let parent_state_root = (**self.parent).state_root();
-            let trie_hashed_state = hashed_state.to_triedb_hashed_post_state();
-            let difflayers_opt = self.ctx.parent_difflayers.as_ref();
-
-            let triedb_calc_started = std::time::Instant::now();
-            let (new_root, new_difflayer) = triedb
-                .intermediate_and_commit_hashed_post_state(
-                    parent_state_root,
-                    difflayers_opt,
-                    &trie_hashed_state,
-                    prefetch_state,
-                )
-                .map_err(BlockExecutionError::other)?;
-            let triedb_calc_with_prefetch_ms = triedb_calc_started.elapsed().as_millis();
-
-            tracing::debug!(
-                target: "bsc::builder",
-                parent_hash = %self.parent.hash(),
-                block_number = %(self.parent.number + 1),
-                parent_state_root = %parent_state_root,
-                new_state_root = %new_root,
-                has_parent_difflayers = difflayers_opt.is_some(),
-                user_tx_count = self.transactions.len(),
-                hashed_accounts = hashed_state.accounts.len(),
-                hashed_storages = hashed_state.storages.len(),
-                hashed_storage_slots = hashed_state
-                    .storages
-                    .values()
-                    .map(|s| s.storage.len())
-                    .sum::<usize>(),
-                triedb_calc_ms = triedb_calc_with_prefetch_ms,
-                triedb_calc_us = triedb_calc_started.elapsed().as_micros(),
-                "Calculated state root using triedb"
-            );
-            (new_root, TrieUpdates::default(), Some(new_difflayer))
-        } else if let Some((root, updates)) = self
+        let (state_root, trie_updates) = if let Some((root, updates)) = self
             .ctx
             .state_root_precomputed_sink
             .as_ref()
@@ -332,7 +260,7 @@ where
             //
             // Preferred source is the sink on `self.ctx` (filled by the payload layer
             // post-exec); the field on `Self` is a fallback that `fn finish` populates
-            // when callers route through the trait method.
+            // when called with `state_root_precomputed`.
             tracing::debug!(
                 target: "bsc::builder",
                 parent_hash = %self.parent.hash(),
@@ -342,11 +270,9 @@ where
                 hashed_storages = hashed_state.storages.len(),
                 "Using precomputed state root from sparse-trie task"
             );
-            (root, updates, None)
+            (root, updates)
         } else {
-            let (root, updates) =
-                state.state_root_with_updates(hashed_state.clone()).map_err(BlockExecutionError::other)?;
-            (root, updates, None)
+            state.state_root_with_updates(hashed_state.clone()).map_err(BlockExecutionError::other)?
         };
         let state_root_duration = state_root_start.elapsed();
 
@@ -410,10 +336,7 @@ where
         );
 
         let block = RecoveredBlock::new_unhashed(block, senders);
-        Ok(BlockBuilderOutcomeWithDiffLayer {
-            inner: BlockBuilderOutcome { execution_result: result, hashed_state, trie_updates, block },
-            difflayer: produced_difflayer,
-        })
+        Ok(BlockBuilderOutcome { execution_result: result, hashed_state, trie_updates, block })
     }
 
     fn executor_mut(&mut self) -> &mut Self::Executor {
@@ -427,22 +350,4 @@ where
     fn into_executor(self) -> Self::Executor {
         self.executor
     }
-}
-
-/// Request the parent block's diff layers from the engine (TrieDB mode only).
-///
-/// Diff layers capture the trie-node changes produced by prior blocks and serve as
-/// incremental input for computing the next state root via TrieDB, avoiding a full
-/// trie traversal from disk.
-pub async fn request_difflayer(
-    engine_api_tx: &BscEngineApiTx,
-    parent_hash: BlockHash,
-) -> Result<DiffLayers, BSCEngineMessageError> {
-    let (tx, rx) = oneshot::channel();
-    let _ = engine_api_tx.send(EngineApiRequest::Custom(CustomRequestMessage::RequestDiffLayer {
-        parent_hash,
-        tx,
-        _phantom: std::marker::PhantomData,
-    }));
-    rx.await.map_err(BSCEngineMessageError::internal)?.map_err(BSCEngineMessageError::internal)
 }

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -52,23 +52,13 @@ pub type StateRootPrecomputedSink =
 
 /// BSC wrapper around [`NextBlockEnvAttributes`].
 ///
-/// Extends the upstream attributes with TrieDB-specific context for the miner:
-/// - `parent_difflayers`: incremental trie diffs from the engine tree, used as input for
-///   the next state-root calculation via TrieDB.
-/// - `triedb_prefetcher`: a background trie-prefetch handle started before block execution
-///   so that trie nodes are warmed up by the time `finish()` computes the state root.
-///
-/// The struct still satisfies upstream RPC trait bounds via a delegating [`BuildPendingEnv`]
-/// implementation, keeping reth's base attributes unchanged.
+/// Extends the upstream attributes with sparse-trie sinks and validator/turn-length
+/// transport sinks needed by the BSC miner. The struct still satisfies upstream RPC
+/// trait bounds via a delegating [`BuildPendingEnv`] implementation, keeping reth's
+/// base attributes unchanged.
 #[derive(Debug, Clone)]
 pub struct BscNextBlockEnvAttributes {
     pub inner: NextBlockEnvAttributes,
-    /// Parent difflayers (from engine tree), used by triedb state root calculation and miner-side
-    /// triedb prefetcher.
-    pub parent_difflayers: Option<rust_eth_triedb_common::DiffLayers>,
-    /// Miner-side triedb prefetcher handle. This is started before execution and consumed in
-    /// `finish()` to obtain `prefetch_state` for triedb root calculation.
-    pub triedb_prefetcher: Option<crate::node::evm::MinerTrieDbPrefetcher>,
     /// Sink for transporting `current_validators` from builder to payload layer without writing
     /// to VALIDATOR_CACHE prematurely (hash not yet final at build time).
     pub validator_cache_sink: Option<ValidatorCacheSink>,
@@ -76,11 +66,11 @@ pub struct BscNextBlockEnvAttributes {
     /// TURN_LENGTH_CACHE prematurely.
     pub turn_length_sink: Option<Arc<Mutex<Option<u8>>>>,
     /// Sink for precomputed `(state_root, trie_updates)` from a sparse-trie background
-    /// task. Filled by payload layer between exec and `finish_with_difflayer` so the
-    /// builder's MDBX branch can skip the blocking `state_root_with_updates` call. See
+    /// task. Filled by the payload layer between exec and `finish` so the builder can
+    /// skip the blocking `state_root_with_updates` call. See
     /// [`BscBlockExecutionCtx::state_root_precomputed_sink`] for full semantics.
     pub state_root_precomputed_sink: Option<StateRootPrecomputedSink>,
-    /// Sparse-trie state-root handle, threaded through to `finish_with_difflayer`.
+    /// Sparse-trie state-root handle, threaded through to `finish`.
     ///
     /// Stored here (in `Arc<Mutex<Option<_>>>` so `Clone` works for the type-erased
     /// builder path) so that `state_root()` can be called **after** `executor.finish()`
@@ -89,16 +79,14 @@ pub struct BscNextBlockEnvAttributes {
     /// that has the `state_hook` installed; the hook is dropped naturally when the
     /// executor is consumed by `finish()`, which sends `FinishedStateUpdates` to the
     /// background task. Only after that drop is it safe to await `state_root()`.
-    ///
-    /// `None` when sparse-trie is disabled or in TrieDB mode.
     pub trie_handle: Option<
         Arc<Mutex<Option<reth_engine_tree::tree::multiproof::StateRootHandle>>>,
     >,
-    /// R2: absolute wall-clock deadline (epoch ms) for bounding the sparse-trie
-    /// `state_root()` wait in `finish_with_difflayer`. Past it the builder stops
-    /// waiting and falls back to synchronous `state_root_with_updates`, so an
-    /// in-turn block never blocks unboundedly past its slot. `None` = legacy
-    /// unbounded blocking wait (out-of-turn / bid-sim / import paths).
+    /// Absolute wall-clock deadline (epoch ms) for bounding the sparse-trie
+    /// `state_root()` wait in `finish`. Past it the builder stops waiting and falls
+    /// back to synchronous `state_root_with_updates`, so an in-turn block never
+    /// blocks unboundedly past its slot. `None` = legacy unbounded blocking wait
+    /// (out-of-turn / bid-sim / import paths).
     pub state_root_deadline_ms: Option<u64>,
 }
 
@@ -106,8 +94,6 @@ impl<H: BlockHeader> BuildPendingEnv<H> for BscNextBlockEnvAttributes {
     fn build_pending_env(parent: &SealedHeader<H>) -> Self {
         Self {
             inner: NextBlockEnvAttributes::build_pending_env(parent),
-            parent_difflayers: None,
-            triedb_prefetcher: None,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -159,13 +145,8 @@ pub struct BscBlockExecutionCtx<'a> {
     pub header_hash: Option<BlockHash>,
     /// Whether the block is being mined.
     pub is_miner: bool,
-    /// Parent difflayers (from engine tree), used by triedb state root calculation and miner-side
-    /// triedb prefetcher.
-    pub parent_difflayers: Option<rust_eth_triedb_common::DiffLayers>,
-    /// Miner-side triedb prefetcher handle (consumed in `finish()`).
-    pub triedb_prefetcher: Option<crate::node::evm::MinerTrieDbPrefetcher>,
-    /// Sink for `current_validators` — written by builder in `finish_with_difflayer()` and
-    /// read by payload layer after the builder is consumed.  `None` for non-miner paths.
+    /// Sink for `current_validators` — written by builder in `finish()` and read by the
+    /// payload layer after the builder is consumed. `None` for non-miner paths.
     pub validator_cache_sink: Option<ValidatorCacheSink>,
     /// Sink for `turn_length` — same lifecycle as `validator_cache_sink`.
     pub turn_length_sink: Option<Arc<Mutex<Option<u8>>>>,
@@ -173,10 +154,10 @@ pub struct BscBlockExecutionCtx<'a> {
     /// task (reth 2.0 mechanism).
     ///
     /// Write direction is **reversed** vs the other sinks: the payload layer fills this
-    /// **before** calling `finish_with_difflayer`, and the builder's MDBX branch reads
-    /// it to skip the synchronous `state_root_with_updates` call. `None` in the bid
-    /// simulator path and when the `--mining.use-sparse-trie-state-root` flag is off,
-    /// triggering the legacy state-root path.
+    /// **before** calling `finish`, and the builder reads it to skip the synchronous
+    /// `state_root_with_updates` call. `None` in the bid simulator path and when the
+    /// `--mining.use-sparse-trie-state-root` flag is off, triggering the legacy
+    /// state-root path.
     pub state_root_precomputed_sink: Option<StateRootPrecomputedSink>,
     /// Sparse-trie state-root handle. The builder consumes this **after**
     /// `executor.finish()` runs BSC's post-execution system transactions (slash,
@@ -190,8 +171,8 @@ pub struct BscBlockExecutionCtx<'a> {
     pub trie_handle: Option<
         Arc<Mutex<Option<reth_engine_tree::tree::multiproof::StateRootHandle>>>,
     >,
-    /// R2: see [`BscNextBlockEnvAttributes::state_root_deadline_ms`]. Bounds the
-    /// sparse-trie `state_root()` wait in `finish_with_difflayer`.
+    /// See [`BscNextBlockEnvAttributes::state_root_deadline_ms`]. Bounds the
+    /// sparse-trie `state_root()` wait in `finish`.
     pub state_root_deadline_ms: Option<u64>,
 }
 
@@ -494,8 +475,6 @@ where
             header: Some(block.header().clone()),
             header_hash: Some(block.hash()),
             is_miner: false,
-            parent_difflayers: None,
-            triedb_prefetcher: None,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -523,8 +502,6 @@ where
             header: None, // No header available for next block context
             header_hash: None,
             is_miner: true,
-            parent_difflayers: attributes.parent_difflayers,
-            triedb_prefetcher: attributes.triedb_prefetcher,
             validator_cache_sink: attributes.validator_cache_sink,
             turn_length_sink: attributes.turn_length_sink,
             state_root_precomputed_sink: attributes.state_root_precomputed_sink,
@@ -551,14 +528,7 @@ where
         let shared_ctx = BscExecutionSharedCtx::default();
         let bsc_executor = BscBlockExecutor::new(
             evm,
-            {
-                // Avoid cloning miner-only helpers into the executor context. The block builder keeps
-                // the full ctx and consumes these in `finish()`.
-                let mut exec_ctx = ctx.clone();
-                exec_ctx.parent_difflayers = None;
-                exec_ctx.triedb_prefetcher = None;
-                exec_ctx
-            },
+            ctx.clone(),
             shared_ctx.clone(),
             self.executor_factory.spec().clone(),
             *self.executor_factory.receipt_builder(),
@@ -601,8 +571,6 @@ where
             header: Some(block.header.clone()),
             header_hash: Some(payload.block_hash_cached()),
             is_miner: false,
-            parent_difflayers: None,
-            triedb_prefetcher: None,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -29,9 +29,6 @@ mod assembler;
 mod builder;
 pub mod config;
 pub use config::BscEvmConfig;
-/// Miner-side triedb prefetcher type (reused from `reth-engine-tree`).
-pub type MinerTrieDbPrefetcher = reth_engine_tree::tree::triedb_prefetcher::TrieDBStatePrefetcher;
-pub(crate) use builder::request_difflayer;
 mod executor;
 pub use executor::BscBlockExecutor;
 mod factory;

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -34,14 +34,10 @@ use reth_primitives_traits::SignerRecoverable;
 use reth_provider::StateProviderFactory;
 use reth_provider::{BlockHashReader, HeaderProvider};
 use reth_revm::{database::StateProviderDatabase, db::State};
-use rust_eth_triedb::get_global_triedb;
-use rust_eth_triedb_common::DiffLayers;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::{debug, trace};
-use alloy_consensus::BlockHeader as _;
-use crate::node::evm::MinerTrieDbPrefetcher;
 const NO_INTERRUPT_LEFT_OVER: u64 = 500;
 const PAY_BID_TX_GAS_LIMIT: u64 = 25000;
 const TX_GAS: u64 = 21000;
@@ -79,7 +75,6 @@ pub struct BidSimulator<Client, Pool> {
     parlia: Arc<crate::consensus::parlia::Parlia<crate::chainspec::BscChainSpec>>,
     pool: Pool,
     validator_address: Address,
-    task_executor: reth_tasks::TaskExecutor,
 
     // Each map has its own lock for fine-grained concurrency control
     // This avoids writer starvation when one operation needs write access
@@ -118,14 +113,12 @@ where
         snapshot_provider: Arc<dyn SnapshotProvider + Send + Sync>,
         validator_commission: u64,
         greedy_merge: bool,
-        task_executor: reth_tasks::TaskExecutor,
     ) -> Self {
         Self {
             client,
             parlia,
             pool,
             validator_address,
-            task_executor,
             chain_spec,
             snapshot_provider,
             best_bid_to_run: Arc::new(RwLock::new(HashMap::new())),
@@ -356,7 +349,6 @@ where
     pub fn bid_simulate(
         &self,
         mut bid_runtime: BidRuntime<Pool, BscEvmConfig>,
-        parent_difflayers: Option<DiffLayers>,
     ) {
         if !self.bid_receiving {
             return;
@@ -400,39 +392,6 @@ where
             return;
         }
 
-        // Two execution paths for state-root computation:
-        //
-        // TrieDB mode (is_triedb_active):
-        //   - `parent_difflayers` feeds `finish_with_difflayer` so triedb can compute the
-        //     state root incrementally without a full disk trie traversal.
-        //   - A `MinerTrieDbPrefetcher` is also spun up to pre-load trie nodes in the
-        //     background using the difflayer warm-cache, reducing `finish()` latency.
-        //     (Per-tx state hook is not wired here; bid txs are externally pre-built so
-        //     incremental prefetching is less valuable than for miner-built payloads.)
-        //
-        // Non-TrieDB mode (original path):
-        //   - Both fields stay `None`; `finish_with_difflayer` falls through to the standard
-        //     `state_root_with_updates` calculation, identical to the pre-triedb behavior.
-        let (triedb_env_difflayers, triedb_prefetcher) =
-            if rust_eth_triedb::triedb_manager::is_triedb_active() {
-                let prefetcher = parent_difflayers.clone().and_then(|difflayers| {
-                    let mut triedb = get_global_triedb();
-                    let path_db = triedb.get_mut_path_db_ref().clone();
-                    MinerTrieDbPrefetcher::new(
-                        parent_header.state_root(),
-                        path_db,
-                        Some(difflayers),
-                        self.task_executor.clone(),
-                    )
-                    .ok()
-                });
-                (parent_difflayers, prefetcher)
-            } else {
-                // Non-triedb: discard any difflayers passed in and use the original
-                // state_root_with_updates path inside finish_with_difflayer.
-                (None, None)
-            };
-
         // Sinks transport current_validators / turn_length from the builder so that
         // pick_best_payload() can write to VALIDATOR_CACHE / TURN_LENGTH_CACHE with the
         // definitive block hash after finalize_new_header() runs.
@@ -455,8 +414,6 @@ where
                         extra_data: builder_config.extra_data.clone(),
                         slot_number: None,
                     },
-                    parent_difflayers: triedb_env_difflayers,
-                    triedb_prefetcher,
                     validator_cache_sink: Some(bid_validator_cache_sink.clone()),
                     turn_length_sink: Some(bid_turn_length_sink.clone()),
                     // Bid simulation does not run alongside a sparse-trie task —
@@ -568,21 +525,16 @@ where
             return;
         }
 
-        // Finish the builder (also returns triedb difflayer when enabled).
-        // Bid simulation does not run alongside a sparse-trie task — no precomputed root,
-        // so the builder uses the legacy state_root_with_updates path inside
-        // finish_with_difflayer.
-        let out =
-            match builder.finish_with_difflayer(&state_provider).map_err(PayloadBuilderError::other)
-            {
+        // Finish the builder. Bid simulation does not run alongside a sparse-trie task —
+        // no precomputed root, so the builder falls through to state_root_with_updates.
+        let out = match builder.finish(&state_provider, None).map_err(PayloadBuilderError::other) {
             Ok(outcome) => outcome,
             Err(e) => {
                 debug!("Failed to finish builder: {:?}", e);
                 return;
             }
         };
-        let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } = out.inner;
-        let difflayer = out.difflayer;
+        let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } = out;
         let mut sealed_block = Arc::new(block.sealed_block().clone());
 
         // Check if any un_revertible transaction failed
@@ -620,8 +572,7 @@ where
             hashed_state: Either::Left(Arc::new(hashed_state)),
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };
-        let mut executed_block = executed.into_executed_payload();
-        executed_block.difflayer = difflayer;
+        let executed_block = executed.into_executed_payload();
 
         // Read validator/turn-length data transported via sinks from the now-consumed builder.
         let pending_validators = bid_validator_cache_sink.lock().unwrap().take();

--- a/src/node/miner/bsc_miner.rs
+++ b/src/node/miner/bsc_miner.rs
@@ -561,7 +561,6 @@ pub struct MainWorkWorker<Pool, Provider> {
     simulator: Arc<BidSimulator<Provider, Pool>>, // No outer RwLock, each map has its own lock
     desired_gas_limit: u64,
     desired_min_gas_tip: u128,
-    task_executor: reth_tasks::TaskExecutor,
 }
 
 impl<Pool, Provider> MainWorkWorker<Pool, Provider>
@@ -590,7 +589,6 @@ where
         payload_tx: mpsc::UnboundedSender<SubmitContext>,
         desired_gas_limit: u64,
         desired_min_gas_tip: u128,
-        task_executor: reth_tasks::TaskExecutor,
     ) -> Self {
         Self {
             pool,
@@ -605,7 +603,6 @@ where
             payload_job_join_set: JoinSet::new(),
             desired_gas_limit,
             desired_min_gas_tip,
-            task_executor,
         }
     }
 
@@ -719,7 +716,6 @@ where
             self.chain_spec.clone(),
             self.parlia.clone(),
             mining_ctx.clone(),
-            self.task_executor.clone(),
         );
         let build_args = BscBuildArguments {
             cached_reads: mining_ctx.cached_reads.clone().unwrap_or_default(),
@@ -729,7 +725,6 @@ where
             min_gas_tip: crate::shared::get_miner_gas_tip()
                 .map(|v| v as u128)
                 .unwrap_or(self.desired_min_gas_tip),
-            parent_difflayers: None, // populated once at job start via fetch_triedb_difflayers
             // Filled in by BscPayloadJob::start when sparse-trie state-root is enabled
             // and the engine has registered a spawner. Falls back to legacy path when None.
             state_root_precomputed: std::sync::Arc::new(std::sync::Mutex::new(None)),
@@ -1140,10 +1135,7 @@ where
                 bid_runtime = self.bid_simulate_req_rx.recv() => {
                     match bid_runtime {
                         Some(bid_runtime) => {
-                            let parent_difflayers =
-                                Self::fetch_parent_difflayers_for_bid(&bid_runtime.bid.parent_hash)
-                                    .await;
-                            self.simulator.bid_simulate(bid_runtime, parent_difflayers);
+                            self.simulator.bid_simulate(bid_runtime);
                         }
                         None => {
                             warn!("Bid simulate request channel closed");
@@ -1162,32 +1154,6 @@ where
                     let last_block_number = self.provider.last_block_number().unwrap_or(0);
                     self.simulator.clear(last_block_number);
                 }
-            }
-        }
-    }
-
-    /// Fetch parent difflayers for a bid simulation (TrieDB mode only).
-    ///
-    /// Returns `None` when TrieDB is inactive, engine_api_tx is unavailable, or the
-    /// request fails. In all fallback cases `bid_simulate` degrades gracefully (slower
-    /// state root via full trie traversal, no triedb prefetching).
-    async fn fetch_parent_difflayers_for_bid(
-        parent_hash: &alloy_primitives::B256,
-    ) -> Option<rust_eth_triedb_common::DiffLayers> {
-        if !rust_eth_triedb::triedb_manager::is_triedb_active() {
-            return None;
-        }
-        let engine_api_tx = crate::shared::get_engine_api_tx()?;
-        match crate::node::evm::request_difflayer(&engine_api_tx, *parent_hash).await {
-            Ok(difflayers) => Some(difflayers),
-            Err(e) => {
-                warn!(
-                    target: "bsc::mev",
-                    %parent_hash,
-                    error = %e,
-                    "Failed to fetch parent difflayers for bid simulation; triedb state root will fall back to full trie traversal"
-                );
-                None
             }
         }
     }
@@ -1286,7 +1252,6 @@ where
             snapshot_provider.clone(),
             mining_config.validator_commission.unwrap_or(100),
             mining_config.greedy_merge,
-            task_executor.clone(),
         ));
         let main_work_worker = MainWorkWorker::new(
             validator_address,
@@ -1299,7 +1264,6 @@ where
             payload_tx,
             desired_gas_limit,
             desired_min_gas_tip,
-            task_executor.clone(),
         );
 
         let result_work_worker = ResultWorkWorker::new(

--- a/src/node/miner/config.rs
+++ b/src/node/miner/config.rs
@@ -42,15 +42,14 @@ pub struct MiningConfig {
     /// List of allowed builder addresses (whitelist)
     pub allowed_builders: Option<Vec<Address>>,
     /// Use the reth 2.0 sparse-trie background task for state-root computation
-    /// during MDBX-mode payload build.
+    /// during payload build.
     ///
-    /// When `true` (and the node is not in `--statedb.triedb` mode), the BSC miner
-    /// spawns a `StateRootHandle` per payload job, streams per-tx state diffs into
-    /// it via `set_state_hook`, and consumes the precomputed `(state_root,
-    /// trie_updates)` at finish time — mirroring upstream
-    /// `crates/ethereum/payload`'s flow. Falls back to the legacy synchronous
-    /// `state_root_with_updates` path when the global spawner has not been
-    /// registered or returns `None`.
+    /// When `true`, the BSC miner spawns a `StateRootHandle` per payload job,
+    /// streams per-tx state diffs into it via `set_state_hook`, and consumes the
+    /// precomputed `(state_root, trie_updates)` at finish time — mirroring
+    /// upstream `crates/ethereum/payload`'s flow. Falls back to the legacy
+    /// synchronous `state_root_with_updates` path when the global spawner has
+    /// not been registered or returns `None`.
     pub use_sparse_trie_state_root: bool,
 }
 

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -8,7 +8,6 @@ use crate::metrics::{BscConsensusMetrics, BscMinerMetrics};
 use crate::node::engine::{BscBuiltPayload, BuildKind};
 use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes, ValidatorCacheSink};
 use crate::node::evm::pre_execution::{TURN_LENGTH_CACHE, VALIDATOR_CACHE};
-use crate::node::evm::{request_difflayer, MinerTrieDbPrefetcher};
 use crate::node::miner::bid_simulator::BidSimulator;
 use crate::node::miner::bsc_miner::{MiningContext, SubmitContext};
 use crate::node::miner::util::finalize_new_header;
@@ -43,10 +42,7 @@ use reth_primitives_traits::{BlockBody, RecoveredBlock, SignerRecoverable};
 use reth_provider::StateProviderFactory;
 use reth_revm::cached::CachedReads;
 use reth_revm::cancelled::ManualCancel;
-use reth_revm::state::EvmState as RethEvmState;
 use reth_revm::{database::StateProviderDatabase, db::State};
-use rust_eth_triedb::get_global_triedb;
-use rust_eth_triedb_common::DiffLayers;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -56,7 +52,7 @@ use tracing::{debug, info, trace, warn};
 /// Milliseconds reserved at the end of each block period for state-root computation.
 ///
 /// Geth-BSC uses 50ms because its native hashdb-based trie is faster and more predictable.
-/// reth-bsc's TrieDB root calculation has higher and less stable latency, so we reserve
+/// reth-bsc's MDBX-based root calculation has higher and less stable latency, so we reserve
 /// 120ms to avoid missing the block deadline or eating into the next block's time budget.
 pub const DELAY_LEFT_OVER: u64 = 120;
 
@@ -286,18 +282,13 @@ pub struct BscBuildArguments<Attributes> {
     pub trace_id: u64,
     /// Minimum gas tip
     pub min_gas_tip: u128,
-    /// Parent block diff layers for triedb state root computation.
-    ///
-    /// Fetched once at job creation and shared across all build attempts for the same parent.
-    /// `None` when triedb is inactive or the fetch failed (graceful degradation to full trie).
-    pub parent_difflayers: Option<DiffLayers>,
     /// Precomputed `(state_root, trie_updates)` from a sparse-trie background task.
     ///
     /// Filled in by `BscPayloadJob::start` after exec completes, by calling
     /// `StateRootHandle::state_root()` on the handle obtained from
     /// `crate::shared::spawn_sparse_trie_state_root`. The builder consumes this in
-    /// `finish_with_difflayer` to skip the blocking `state_root_with_updates` call when
-    /// a value is present. `None` triggers the legacy synchronous path (fallback).
+    /// `finish` to skip the blocking `state_root_with_updates` call when a value is
+    /// present. `None` triggers the legacy synchronous path (fallback).
     ///
     /// `Arc<Mutex<...>>` so `#[derive(Clone)]` on `BscBuildArguments` still works; the
     /// builder takes (`Option::take`) the value, retries see `None`.
@@ -306,24 +297,24 @@ pub struct BscBuildArguments<Attributes> {
     /// Sparse-trie state-root handle for this job.
     ///
     /// Spawned once in `BscPayloadJob::start` (gated by
-    /// `MiningConfig::use_sparse_trie_state_root` + non-triedb mode) and consumed by the
-    /// first build attempt inside `build_payload`:
+    /// `MiningConfig::use_sparse_trie_state_root`) and consumed by the first build attempt
+    /// inside `build_payload`:
     ///   1. take handle from this slot
     ///   2. `handle.state_hook()` → install via `executor.set_state_hook(Some(_))`
     ///   3. run tx exec (state diffs flow to the background task)
     ///   4. drop hook (`set_state_hook(None)`) to signal task to finalize
     ///   5. `handle.state_root()` → write the `(state_root, trie_updates)` into
-    ///      [`Self::state_root_precomputed`], which finish_with_difflayer then consumes
+    ///      [`Self::state_root_precomputed`], which `finish` then consumes
     ///
     /// `Arc<Mutex<Option<_>>>` because `StateRootHandle` is `!Clone` (it owns
     /// single-consumer channels) and `BscBuildArguments` derives `Clone`. First retry
     /// takes the handle; subsequent retries see `None` and fall back to the legacy
     /// synchronous state-root path (still correct, just slower for that retry).
     pub trie_handle: Arc<Mutex<Option<reth_engine_tree::tree::multiproof::StateRootHandle>>>,
-    /// R2: absolute wall-clock deadline (epoch ms) for bounding the sparse-trie
-    /// `state_root()` wait in `finish_with_difflayer`; threaded into the build ctx.
-    /// Set from `MiningContext::end_mining_timestamp_ms` minus
-    /// [`STATE_ROOT_WAIT_MARGIN_MS`]. `None` = legacy unbounded blocking wait.
+    /// Absolute wall-clock deadline (epoch ms) for bounding the sparse-trie
+    /// `state_root()` wait in `finish`; threaded into the build ctx. Set from
+    /// `MiningContext::end_mining_timestamp_ms` minus [`STATE_ROOT_WAIT_MARGIN_MS`].
+    /// `None` = legacy unbounded blocking wait.
     pub state_root_deadline_ms: Option<u64>,
 }
 
@@ -344,8 +335,6 @@ pub struct BscPayloadBuilder<Pool, Client, EvmConfig = BscEvmConfig> {
     parlia: Arc<Parlia<BscChainSpec>>,
     // Mining context containing header information for blob fee calculation
     ctx: MiningContext,
-    /// Task executor for spawning blocking tasks (e.g., trie prefetcher).
-    task_executor: reth_tasks::TaskExecutor,
 }
 
 impl<Pool, Client, EvmConfig> BscPayloadBuilder<Pool, Client, EvmConfig>
@@ -369,9 +358,8 @@ where
         chain_spec: Arc<BscChainSpec>,
         parlia: Arc<Parlia<BscChainSpec>>,
         ctx: MiningContext,
-        task_executor: reth_tasks::TaskExecutor,
     ) -> Self {
-        Self { client, pool, evm_config, builder_config, chain_spec, parlia, ctx, task_executor }
+        Self { client, pool, evm_config, builder_config, chain_spec, parlia, ctx }
     }
 
     /// Builds a payload with the given arguments.
@@ -400,7 +388,6 @@ where
             cancel,
             trace_id,
             min_gas_tip,
-            parent_difflayers,
             state_root_precomputed,
             // R3: the job-level handle is ignored here; build_payload spawns a fresh one
             // per attempt below, so retries (value-gated rebuilds) also get the
@@ -411,52 +398,22 @@ where
         let PayloadConfig { parent_header, attributes, payload_id: _ } = config;
 
         let parent_hash = parent_header.hash_slow();
-        // Parent difflayers were fetched once at job start; reuse across all retry attempts.
-        let triedb_parent_difflayers = parent_difflayers;
 
         // R3: spawn a fresh sparse-trie state-root handle for THIS build attempt. The
         // job-level handle was single-use — the first attempt consumed it and any retry
         // (e.g. a value-gated rebuild) fell back to the synchronous `state_root_with_updates`,
         // so ~half of in-turn blocks paid the full sync root cost. A fresh handle per attempt
         // is cheap now that R1 shares the engine's proof pools. `None` keeps the sync path
-        // (sparse-trie disabled, triedb mode, or no spawner registered).
+        // (sparse-trie disabled or no spawner registered).
         let trie_handle: Arc<Mutex<Option<reth_engine_tree::tree::multiproof::StateRootHandle>>> = {
             let use_sparse_trie = crate::node::miner::config::get_global_mining_config()
-                .is_some_and(|c| c.use_sparse_trie_state_root)
-                && !rust_eth_triedb::triedb_manager::is_triedb_active();
+                .is_some_and(|c| c.use_sparse_trie_state_root);
             Arc::new(Mutex::new(if use_sparse_trie {
                 crate::shared::spawn_sparse_trie_state_root(parent_hash, parent_header.state_root())
             } else {
                 None
             }))
         };
-
-        // Safety guard: when triedb is active but no difflayers are available, verify that the
-        // parent state root matches the pathdb disk layer.  If they diverge (e.g. after a
-        // restart where in-memory difflayers were lost), building on this parent would produce
-        // a block with an incorrect state root.  Skip building to avoid polluting the network.
-        if rust_eth_triedb::triedb_manager::is_triedb_active() && triedb_parent_difflayers.is_none()
-        {
-            let triedb = get_global_triedb();
-            let (persist_block, persist_root) = triedb
-                .latest_persist_state()
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-            if parent_header.state_root() != persist_root {
-                warn!(
-                    target: "payload_builder",
-                    trace_id,
-                    parent_hash = %parent_hash,
-                    parent_number = parent_header.number(),
-                    parent_state_root = %parent_header.state_root(),
-                    pathdb_block = persist_block,
-                    pathdb_root = %persist_root,
-                    "Skipping build_payload: no difflayers and parent state root diverges from pathdb disk layer"
-                );
-                return Err(Box::from(
-                    "triedb pathdb gap: no difflayers and parent state root != pathdb disk layer root",
-                ));
-            }
-        }
 
         let state_provider = self.client.state_by_block_hash(parent_header.hash_slow())?;
         let state = StateProviderDatabase::new(&state_provider);
@@ -465,31 +422,16 @@ where
             .with_bundle_update()
             .build();
 
-        // Build triedb prefetcher before creating the block builder so it can be carried via the
-        // custom next-block env ctx into the execution ctx and consumed in `finish()`.
-        let triedb_prefetcher = triedb_parent_difflayers.clone().and_then(|difflayers| {
-            let mut triedb = get_global_triedb();
-            let path_db = triedb.get_mut_path_db_ref().clone();
-            MinerTrieDbPrefetcher::new(
-                parent_header.state_root(),
-                path_db,
-                Some(difflayers),
-                self.task_executor.clone(),
-            )
-            .ok()
-        });
-
         // Sinks transport current_validators / turn_length from the builder (which is consumed by
-        // finish_with_difflayer) back to this layer so they can be written to cache after
+        // `finish`) back to this layer so they can be written to cache after
         // finalize_new_header() assigns the definitive block hash.
         let validator_cache_sink: ValidatorCacheSink = Arc::new(Mutex::new(None));
         let turn_length_sink: Arc<Mutex<Option<u8>>> = Arc::new(Mutex::new(None));
 
         // Sink for the sparse-trie precomputed state root. The same Arc<Mutex<>> from
-        // `state_root_precomputed` is threaded into ctx so builder.rs's MDBX branch can
-        // read it during finish_with_difflayer. When the sparse-trie path is not
-        // active (flag off or triedb mode), this Mutex stays `None` and the builder
-        // falls through to `state_root_with_updates`.
+        // `state_root_precomputed` is threaded into ctx so builder.rs can read it during
+        // `finish`. When the sparse-trie path is not active (flag off), this Mutex stays
+        // `None` and the builder falls through to `state_root_with_updates`.
         let state_root_precomputed_sink = state_root_precomputed.clone();
 
         let next_env_attributes = BscNextBlockEnvAttributes {
@@ -505,15 +447,13 @@ where
                     .unwrap_or_else(|| self.builder_config.extra_data.clone()),
                 slot_number: None,
             },
-            parent_difflayers: triedb_parent_difflayers.clone(),
-            triedb_prefetcher: triedb_prefetcher.clone(),
             validator_cache_sink: Some(validator_cache_sink.clone()),
             turn_length_sink: Some(turn_length_sink.clone()),
             state_root_precomputed_sink: Some(state_root_precomputed_sink),
-            // Forward the Arc<Mutex<>> holding the StateRootHandle into ctx so
-            // `finish_with_difflayer` can take it after executor.finish() runs the BSC
-            // post-execution system txs (slash / reward / validator-set updates) with
-            // the state_hook installed. See `BscBlockExecutionCtx::trie_handle` doc.
+            // Forward the Arc<Mutex<>> holding the StateRootHandle into ctx so `finish`
+            // can take it after executor.finish() runs the BSC post-execution system txs
+            // (slash / reward / validator-set updates) with the state_hook installed.
+            // See `BscBlockExecutionCtx::trie_handle` doc.
             trie_handle: Some(trie_handle.clone()),
             state_root_deadline_ms,
         };
@@ -523,39 +463,22 @@ where
             .builder_for_next_block(&mut db, &parent_header, next_env_attributes)
             .map_err(PayloadBuilderError::other)?;
 
-        // Wire either the miner triedb prefetcher OR the sparse-trie state-root task as
-        // the executor's state hook. The two paths are mutually exclusive at runtime:
-        // the prefetcher exists only in triedb mode, the sparse-trie handle exists only
-        // in MDBX mode (gated by `--mining.use-sparse-trie-state-root`).
+        // Wire the sparse-trie state-root task's state hook onto the executor.
         //
-        // For the sparse-trie path: the `state_hook` is installed here on the executor;
-        // it stays installed through `executor.finish()` (BSC post-execution system txs
-        // — slash / reward / validator-set updates) inside `finish_with_difflayer`.
-        // When `finish_with_difflayer` consumes the executor, the hook is dropped,
-        // which sends `FinishedStateUpdates` to the sparse-trie task. `state_root()`
-        // is then called on the handle from inside `finish_with_difflayer` (via
-        // `ctx.trie_handle`) — calling it any earlier would deadlock the task.
+        // The `state_hook` is installed here; it stays installed through `executor.finish()`
+        // (BSC post-execution system txs — slash / reward / validator-set updates) inside
+        // `finish`. When `finish` consumes the executor, the hook is dropped, which sends
+        // `FinishedStateUpdates` to the sparse-trie task. `state_root()` is then called on
+        // the handle from inside `finish` (via `ctx.trie_handle`) — calling it any earlier
+        // would deadlock the task.
         //
         // NOTE: This must be set before `apply_pre_execution_changes()` so any state
         // access/touches performed during pre-execution are also captured by the hook.
-        if let Some(prefetcher) = triedb_prefetcher.clone() {
-            let pf = prefetcher.clone();
-            builder.executor_mut().set_state_hook(Some(Box::new(
-                move |_, update: &RethEvmState| {
-                    pf.on_state_update(update);
-                },
-            )));
-            debug!(
-                target: "payload_builder",
-                trace_id,
-                parent_hash = ?parent_hash,
-                "Started triedb prefetcher for miner payload build"
-            );
-        } else if let Some(handle_guard) = trie_handle.lock().unwrap().as_ref() {
+        if let Some(handle_guard) = trie_handle.lock().unwrap().as_ref() {
             // Install hook from the handle while it's still in the Arc<Mutex<>>.
-            // The handle itself is forwarded via `attrs.trie_handle` (Arc clone)
-            // into `ctx.trie_handle` so `finish_with_difflayer` can take it after
-            // executor.finish() and call `state_root()`.
+            // The handle itself is forwarded via `attrs.trie_handle` (Arc clone) into
+            // `ctx.trie_handle` so `finish` can take it after executor.finish() and
+            // call `state_root()`.
             builder.executor_mut().set_state_hook(Some(Box::new(handle_guard.state_hook())));
             debug!(
                 target: "payload_builder",
@@ -892,23 +815,21 @@ where
         // add system txs to payload.
         let finalize_start = std::time::Instant::now();
 
-        // Sparse-trie state-root collection happens INSIDE `finish_with_difflayer`, NOT
-        // here. The reason: BSC's post-execution (slash, fee distribution, validator-set
-        // updates) runs as system txs via `executor.finish()` inside
-        // `finish_with_difflayer`. Those system txs change state and must be captured by
-        // the `state_hook` we installed before exec. If we dropped the hook here
-        // (before finish_with_difflayer), the sparse-trie task would compute a state
-        // root missing those changes — diverging from the canonical state-root and
-        // causing consensus split / slashing.
+        // Sparse-trie state-root collection happens INSIDE `finish`, NOT here. The reason:
+        // BSC's post-execution (slash, fee distribution, validator-set updates) runs as
+        // system txs via `executor.finish()` inside `finish`. Those system txs change state
+        // and must be captured by the `state_hook` we installed before exec. If we dropped
+        // the hook here (before `finish`), the sparse-trie task would compute a state root
+        // missing those changes — diverging from the canonical state-root and causing
+        // consensus split / slashing.
         //
         // The handle was forwarded into `ctx.trie_handle` via attrs; builder.rs takes
         // it after executor.finish() and calls `state_root()` once the hook is
         // naturally dropped (executor consumption triggers `StateHookSender::drop`
         // which sends `FinishedStateUpdates`).
         let _ = &state_root_precomputed; // sink referenced for trace; written by builder
-        let out = builder.finish_with_difflayer(&state_provider)?;
-        let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } = out.inner;
-        let difflayer = out.difflayer;
+        let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } =
+            builder.finish(&state_provider, None)?;
 
         let mut sealed_block = Arc::new(block.sealed_block().clone());
 
@@ -984,8 +905,7 @@ where
             hashed_state: Either::Left(Arc::new(hashed_state)),
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };
-        let mut executed_block = executed.into_executed_payload();
-        executed_block.difflayer = difflayer;
+        let executed_block = executed.into_executed_payload();
 
         // Read validator/turn-length data transported via sinks from the now-consumed builder.
         let pending_validators = validator_cache_sink.lock().unwrap().take();
@@ -1019,7 +939,6 @@ where
             cancel: _,
             trace_id,
             min_gas_tip: _,
-            parent_difflayers,
             state_root_precomputed,
             trie_handle,
             state_root_deadline_ms: _,
@@ -1027,33 +946,7 @@ where
         let PayloadConfig { parent_header, attributes, payload_id: _ } = config;
 
         let parent_hash = parent_header.hash_slow();
-        // Parent difflayers were fetched once at job start; reuse across all retry attempts.
-        let triedb_parent_difflayers = parent_difflayers;
-
-        // Safety guard: same as build_payload — refuse to build on a parent whose state root
-        // cannot be correctly resolved by pathdb without difflayers.
-        if rust_eth_triedb::triedb_manager::is_triedb_active() && triedb_parent_difflayers.is_none()
-        {
-            let triedb = get_global_triedb();
-            let (persist_block, persist_root) = triedb
-                .latest_persist_state()
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-            if parent_header.state_root() != persist_root {
-                warn!(
-                    target: "payload_builder",
-                    trace_id,
-                    parent_hash = %parent_hash,
-                    parent_number = parent_header.number(),
-                    parent_state_root = %parent_header.state_root(),
-                    pathdb_block = persist_block,
-                    pathdb_root = %persist_root,
-                    "Skipping build_empty_payload: no difflayers and parent state root diverges from pathdb disk layer"
-                );
-                return Err(Box::from(
-                    "triedb pathdb gap: no difflayers and parent state root != pathdb disk layer root",
-                ));
-            }
-        }
+        let _ = parent_hash;
 
         let state_provider = self.client.state_by_block_hash(parent_header.hash_slow())?;
         let state = StateProviderDatabase::new(&state_provider);
@@ -1061,20 +954,6 @@ where
             .with_database(cached_reads.as_db_mut(state))
             .with_bundle_update()
             .build();
-
-        // Build triedb prefetcher before creating the block builder so it can be carried via the
-        // custom next-block env ctx into the execution ctx and consumed in `finish()`.
-        let triedb_prefetcher = triedb_parent_difflayers.clone().and_then(|difflayers| {
-            let mut triedb = get_global_triedb();
-            let path_db = triedb.get_mut_path_db_ref().clone();
-            MinerTrieDbPrefetcher::new(
-                parent_header.state_root(),
-                path_db,
-                Some(difflayers),
-                self.task_executor.clone(),
-            )
-            .ok()
-        });
 
         // Sinks for empty-payload builds (same delayed-seal mechanism as normal builds).
         let validator_cache_sink: ValidatorCacheSink = Arc::new(Mutex::new(None));
@@ -1101,8 +980,6 @@ where
                             .unwrap_or_else(|| self.builder_config.extra_data.clone()),
                         slot_number: None,
                     },
-                    parent_difflayers: triedb_parent_difflayers.clone(),
-                    triedb_prefetcher: triedb_prefetcher.clone(),
                     validator_cache_sink: Some(validator_cache_sink.clone()),
                     turn_length_sink: Some(turn_length_sink.clone()),
                     state_root_precomputed_sink: Some(state_root_precomputed.clone()),
@@ -1113,25 +990,6 @@ where
                 },
             )
             .map_err(PayloadBuilderError::other)?;
-
-        // Wire miner triedb prefetcher via state hook (if enabled).
-        //
-        // NOTE: This must be set before `apply_pre_execution_changes()` so any state access/touches
-        // performed during pre-execution are also prefetched.
-        if let Some(prefetcher) = triedb_prefetcher.clone() {
-            let pf = prefetcher.clone();
-            builder.executor_mut().set_state_hook(Some(Box::new(
-                move |_, update: &RethEvmState| {
-                    pf.on_state_update(update);
-                },
-            )));
-            debug!(
-                target: "payload_builder",
-                trace_id,
-                parent_hash = ?parent_hash,
-                "Started triedb prefetcher for miner empty payload build"
-            );
-        }
 
         // Total time spent executing pre-execution changes (no user txs for empty payloads).
         let exec_start = std::time::Instant::now();
@@ -1161,9 +1019,8 @@ where
         // legacy `state_root_with_updates` cost is acceptable. The handle (if any)
         // stays in `trie_handle` and is dropped when the spawned task ends.
         let _ = (&state_root_precomputed, &trie_handle);
-        let out = builder.finish_with_difflayer(&state_provider)?;
-        let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } = out.inner;
-        let difflayer = out.difflayer;
+        let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } =
+            builder.finish(&state_provider, None)?;
         let finalize_elapsed = finalize_start.elapsed();
 
         let sealed_block = Arc::new(block.sealed_block().clone());
@@ -1198,8 +1055,7 @@ where
             hashed_state: Either::Left(Arc::new(hashed_state)),
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };
-        let mut executed_block = executed.into_executed_payload();
-        executed_block.difflayer = difflayer;
+        let executed_block = executed.into_executed_payload();
 
         // Read validator/turn-length data transported via sinks from the now-consumed builder.
         let pending_validators = validator_cache_sink.lock().unwrap().take();
@@ -1218,43 +1074,6 @@ where
             is_bid: false,
         };
         Ok(payload)
-    }
-}
-
-/// Fetch the parent block's diff layers for triedb state-root computation.
-///
-/// Called once per payload job at startup; the result is stored in [`BscBuildArguments`] and
-/// shared across all build attempts (normal and empty) for the same parent block.
-/// Returns `None` on any failure — callers degrade gracefully to the full-trie path.
-async fn fetch_triedb_difflayers(
-    trace_id: u64,
-    parent_hash: alloy_primitives::B256,
-) -> Option<DiffLayers> {
-    if !rust_eth_triedb::triedb_manager::is_triedb_active() {
-        return None;
-    }
-    let Some(engine_api_tx) = crate::shared::get_engine_api_tx() else {
-        warn!(
-            target: "payload_builder",
-            trace_id,
-            %parent_hash,
-            "engine_api_tx not available; proceeding without triedb difflayers"
-        );
-        return None;
-    };
-    match request_difflayer(&engine_api_tx, parent_hash).await {
-        Ok(difflayers) => Some(difflayers),
-        Err(e) => {
-            warn!(
-                target: "payload_builder",
-                trace_id,
-                %parent_hash,
-                error = %e,
-                "Failed to fetch parent difflayers; triedb state root falls back to full trie traversal \
-                 (typically only seen shortly after node startup, before difflayers for recent blocks have been cached)"
-            );
-            None
-        }
     }
 }
 
@@ -1417,21 +1236,13 @@ where
 
     /// Runs the payload job asynchronously with timeout support
     pub async fn start(mut self) -> Result<(), Box<BscPayloadJobError>> {
-        // Fetch parent difflayers once for all build attempts in this job.
-        // Stored in build_args so retries and empty-payload fallback share the same value.
-        self.build_args.parent_difflayers = fetch_triedb_difflayers(
-            self.trace_id,
-            self.build_args.config.parent_header.hash_slow(),
-        )
-        .await;
-
-        // Sparse-trie state-root (MDBX mode, `--mining.use-sparse-trie-state-root`):
+        // Sparse-trie state-root (`--mining.use-sparse-trie-state-root`):
         // R3 spawns a fresh background task PER build attempt inside `build_payload`
         // (not once here), so every attempt — including value-gated rebuilds — gets the
         // precomputed root rather than only the first attempt. Each attempt installs
-        // `handle.state_hook()` before exec, drops it after to finalize, then
-        // `finish_with_difflayer` calls `state_root()` (bounded by R2's slot deadline)
-        // and falls back to synchronous `state_root_with_updates` on miss / no spawner.
+        // `handle.state_hook()` before exec, drops it after to finalize, then `finish`
+        // calls `state_root()` (bounded by R2's slot deadline) and falls back to
+        // synchronous `state_root_with_updates` on miss / no spawner.
 
         let mut start_time = std::time::Instant::now();
         let initial_wait = initial_out_of_turn_build_wait(&self.parlia, &self.mining_ctx);
@@ -1441,17 +1252,17 @@ where
                 trace_id = self.trace_id,
                 block_number = self.build_args.config.parent_header.number() + 1,
                 wait_ms = initial_wait.as_millis(),
-                "Applying out-of-turn backoff; starting speculative build to warm TrieDB prefetcher"
+                "Applying out-of-turn backoff; starting speculative build"
             );
 
-            // Kick off a speculative build before sleeping so the TrieDB prefetcher
-            // can warm the storage slots state-root will need. Without this the
-            // prefetcher only starts after the backoff ends, leaving ~one slot for
-            // both cache warm-up and state-root computation over thousands of txs —
-            // which repeatedly times out and degrades the block to EmptyFallback.
-            // The spawned build's result is picked up by the outer loop's
-            // join_next() branch, so the try_build_tx kickoff below is skipped when
-            // a speculative build is already in flight.
+            // Kick off a speculative build before sleeping so the sparse-trie
+            // background task can warm the storage slots state-root will need.
+            // Without this the speculative work only starts after the backoff ends,
+            // leaving ~one slot for both cache warm-up and state-root computation
+            // over thousands of txs — which repeatedly times out and degrades the
+            // block to EmptyFallback. The spawned build's result is picked up by
+            // the outer loop's join_next() branch, so the try_build_tx kickoff
+            // below is skipped when a speculative build is already in flight.
             self.retries += 1;
             start_time = std::time::Instant::now();
             {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -921,9 +921,6 @@ pub fn get_engine_api_tx() -> Option<BscEngineApiTx> {
     ENGINE_API_TX.get().cloned()
 }
 
-// Note: difflayers are now returned directly from the BSC block builder (`finish_bsc`) and carried
-// through `BscBuiltPayload` / `ExecutedBlockWithTrieUpdates`. We no longer use a global cache.
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,30 +14,30 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate branch to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "mdbx",
     "test-utils",
     "disable-lock",
 ] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "test-utils",
 ] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "develop", features = [
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
     "std",
 ] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "develop" }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
 
 # revm
 revm = { version = "38.0.0", features = [

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,30 +14,30 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate branch to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "mdbx",
     "test-utils",
     "disable-lock",
 ] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "test-utils",
 ] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2", features = [
     "std",
 ] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "6dcb09c0090e046eea6440fbeb58cce5db0476b2" }
 
 # revm
 revm = { version = "38.0.0", features = [


### PR DESCRIPTION
## Summary

- Removes all triedb code paths from reth-bsc; MDBX is now the only state backend
- Pins `bnb-chain/reth` to `6dcb09c0090e046eea6440fbeb58cce5db0476b2` (head of bnb-chain/reth#202, which removes the same backend upstream)
- Drops the four `rust-eth-triedb*` git deps from `Cargo.toml` and the bsc-ef-tests crate

## Notable shape changes

- `BscBlockBuilder` loses the `finish_with_difflayer` override; the sparse-trie precomputed-root fast path + `state_root_with_updates` fallback now live in `fn finish`. `request_difflayer` helper is gone.
- `BscNextBlockEnvAttributes` / `BscBlockExecutionCtx` lose `parent_difflayers` and `triedb_prefetcher` fields.
- `BscBuildArguments` loses `parent_difflayers`; `fetch_triedb_difflayers` + `fetch_parent_difflayers_for_bid` are deleted.
- `BscBuiltPayload::executed_block` no longer carries a `difflayer` (upstream `ExecutedBlock.difflayer` field removed).
- Removed the now-unused `task_executor` field from `BscPayloadBuilder`, `BidSimulator`, and `MainWorkWorker` (it was only used to spawn the triedb prefetcher).
- `--statedb.triedb` references stripped from README.md, CLAUDE.md, main.rs CLI doc-comments, and miner/config.rs.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --tests --all-features` (no warnings)
- [x] `cargo test --all -- --test-threads=1` (286 passed)
- [ ] Smoke-test mainnet sync on the resulting binary
- [ ] Smoke-test miner build path (`--mining.enabled` + `--mining.use-sparse-trie-state-root`)
- [ ] Smoke-test MEV bid-simulator path

🤖 Generated with [Claude Code](https://claude.com/claude-code)