### PR TITLE
feat(hardforks): define Pasteur hardfork

### DIFF
--- a/src/chainspec/parser.rs
+++ b/src/chainspec/parser.rs
@@ -222,6 +222,10 @@ fn add_hardforks_to_chainspec(
     if let Some(mendel_time) = config.get("mendelTime").and_then(|v| v.as_u64()) {
         chain_spec = chain_spec.with_fork(BscHardfork::Mendel, ForkCondition::Timestamp(mendel_time));
     }
-    
+
+    if let Some(pasteur_time) = config.get("pasteurTime").and_then(|v| v.as_u64()) {
+        chain_spec = chain_spec.with_fork(BscHardfork::Pasteur, ForkCondition::Timestamp(pasteur_time));
+    }
+
     Ok(chain_spec)
 }

--- a/src/evm/precompiles/mod.rs
+++ b/src/evm/precompiles/mod.rs
@@ -485,7 +485,11 @@ fn mendel_traced() -> &'static TracedPrecompiles {
 
 fn traced_precompiles_for_spec(spec: BscHardfork) -> &'static TracedPrecompiles {
     // Osaka uses updated precompiles (EIP-7823/7883 MODEXP, EIP-7951 P256VERIFY)
-    if spec >= BscHardfork::Mendel {
+    if spec >= BscHardfork::Pasteur {
+        // Pasteur currently reuses the Mendel precompile set; later PRs introduce
+        // a dedicated Pasteur set (validator-set dedup, suspended v1 precompiles, etc.).
+        mendel_traced()
+    } else if spec >= BscHardfork::Mendel {
         mendel_traced()
     } else if spec >= BscHardfork::Pascal {
         pascal_traced()
@@ -603,5 +607,19 @@ impl BscPrecompiles {
 impl Default for BscPrecompiles {
     fn default() -> Self {
         Self::new(BscHardfork::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pasteur_reuses_mendel_precompile_set() {
+        // PR 1 introduces the fork but must not change precompile behavior: the Pasteur
+        // set is identical to Mendel until later PRs add a dedicated set.
+        let pasteur = traced_precompiles_for_spec(BscHardfork::Pasteur).precompiles();
+        let mendel = traced_precompiles_for_spec(BscHardfork::Mendel).precompiles();
+        assert_eq!(pasteur.addresses_set(), mendel.addresses_set());
     }
 }

--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -69,6 +69,8 @@ hardfork!(
         Osaka,
         /// BSC `Mendel` hardfork
         Mendel,
+        /// BSC `Pasteur` hardfork - sequenced immediately after Mendel
+        Pasteur,
     }
 );
 
@@ -119,6 +121,8 @@ impl BscHardfork {
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1768357800)), /* 2026-01-14 02:30:00 AM UTC */
             (Self::Osaka.boxed(), ForkCondition::Timestamp(1777343400)),
             (Self::Mendel.boxed(), ForkCondition::Timestamp(1777343400)),
+            // TODO: real activation TBD; unscheduled (u64::MAX) until announced.
+            (Self::Pasteur.boxed(), ForkCondition::Timestamp(u64::MAX)),
         ])
     }
 
@@ -166,6 +170,8 @@ impl BscHardfork {
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1762741500)),
             (Self::Osaka.boxed(), ForkCondition::Timestamp(1774319400)),
             (Self::Mendel.boxed(), ForkCondition::Timestamp(1774319400)),
+            // TODO: real activation TBD; unscheduled (u64::MAX) until announced.
+            (Self::Pasteur.boxed(), ForkCondition::Timestamp(u64::MAX)),
         ])
     }
 
@@ -210,6 +216,8 @@ impl BscHardfork {
             (Self::Lorentz.boxed(), ForkCondition::Timestamp(1754967081)),
             (Self::Maxwell.boxed(), ForkCondition::Timestamp(1754967101)),
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1761030900)),
+            // TODO: real activation TBD; unscheduled (u64::MAX) until announced.
+            (Self::Pasteur.boxed(), ForkCondition::Timestamp(u64::MAX)),
         ])
     }
 
@@ -263,7 +271,7 @@ impl From<BscHardfork> for SpecId {
             | BscHardfork::Lorentz
             | BscHardfork::Maxwell
             | BscHardfork::Fermi => SpecId::PRAGUE,
-            BscHardfork::Osaka | BscHardfork::Mendel => SpecId::OSAKA,
+            BscHardfork::Osaka | BscHardfork::Mendel | BscHardfork::Pasteur => SpecId::OSAKA,
         }
     }
 }
@@ -272,6 +280,56 @@ impl From<BscHardfork> for SpecId {
 mod tests {
     use super::*;
     use crate::chainspec::{bsc::bsc_mainnet, bsc_chapel::bsc_testnet};
+
+    #[test]
+    fn test_pasteur_is_sequenced_after_mendel() {
+        // Derived ordering must place Pasteur as the highest fork so that
+        // `spec >= BscHardfork::Pasteur` is the first/highest dispatcher check.
+        assert!(BscHardfork::Pasteur > BscHardfork::Mendel);
+        assert!(BscHardfork::Pasteur > BscHardfork::Osaka);
+        // Pasteur is a BSC-only precompile/system-contract fork with no new EVM spec.
+        assert_eq!(SpecId::from(BscHardfork::Pasteur), SpecId::OSAKA);
+    }
+
+    #[test]
+    fn test_pasteur_present_but_unscheduled_in_schedules() {
+        for hardforks in [
+            BscHardfork::bsc_mainnet(),
+            BscHardfork::bsc_testnet(),
+            BscHardfork::bsc_qanet(),
+        ] {
+            let activation = hardforks.fork(BscHardfork::Pasteur);
+            assert_eq!(
+                activation,
+                ForkCondition::Timestamp(u64::MAX),
+                "Pasteur should be defined but dormant until a real activation is set"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pasteur_resolves_at_its_timestamp() {
+        use crate::node::evm::config::revm_spec_by_timestamp_and_block_number;
+
+        // Give Pasteur a concrete activation just after Mendel (1777343400 on mainnet).
+        let pasteur_time = 1_777_343_400 + 1_000;
+        let mut cs = bsc_mainnet();
+        cs.hardforks.insert(BscHardfork::Pasteur, ForkCondition::Timestamp(pasteur_time));
+        let spec = crate::chainspec::BscChainSpec::from(cs);
+
+        let block = 50_000_000; // well past London activation (31302048)
+
+        // Just before Pasteur, the latest fork is still Mendel.
+        assert_eq!(
+            revm_spec_by_timestamp_and_block_number(spec.clone(), pasteur_time - 1, block),
+            BscHardfork::Mendel
+        );
+        // At/after Pasteur's timestamp, it resolves to Pasteur.
+        assert_eq!(
+            revm_spec_by_timestamp_and_block_number(spec.clone(), pasteur_time, block),
+            BscHardfork::Pasteur
+        );
+    }
 
     #[test]
     fn test_hardfork_activation_order_differences() {

--- a/src/hardforks/mod.rs
+++ b/src/hardforks/mod.rs
@@ -351,4 +351,18 @@ pub trait BscHardforks: EthereumHardforks {
         self.is_london_active_at_block(block_number) &&
         self.bsc_fork_activation(BscHardfork::Mendel).active_at_timestamp(timestamp)
     }
+
+    /// Convenience method to check if [`BscHardfork::Pasteur`] is firstly active at a given
+    /// timestamp and parent timestamp.
+    fn is_pasteur_transition_at_timestamp(&self, block_number: u64, timestamp: u64, parent_timestamp: u64) -> bool {
+        let parent_number = block_number.saturating_sub(1);
+        !self.is_pasteur_active_at_timestamp(parent_number, parent_timestamp)
+            && self.is_pasteur_active_at_timestamp(block_number, timestamp)
+    }
+
+    /// Convenience method to check if [`BscHardfork::Pasteur`] is active at a given timestamp.
+    fn is_pasteur_active_at_timestamp(&self, block_number: u64, timestamp: u64) -> bool {
+        self.is_london_active_at_block(block_number) &&
+        self.bsc_fork_activation(BscHardfork::Pasteur).active_at_timestamp(timestamp)
+    }
 }

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -626,7 +626,9 @@ pub fn revm_spec_by_timestamp_and_block_number(
     timestamp: u64,
     block_number: u64,
 ) -> BscHardfork {
-    if chain_spec.is_mendel_active_at_timestamp(block_number, timestamp) {
+    if chain_spec.is_pasteur_active_at_timestamp(block_number, timestamp) {
+        BscHardfork::Pasteur
+    } else if chain_spec.is_mendel_active_at_timestamp(block_number, timestamp) {
         BscHardfork::Mendel
     } else if BscHardforks::is_osaka_active_at_timestamp(&chain_spec, block_number, timestamp) {
         BscHardfork::Osaka


### PR DESCRIPTION
First PR in the series porting the BSC **Pasteur** hardfork to reth-bsc.

Defines `BscHardfork::Pasteur` (sequenced immediately after Mendel) with trait
accessors, `SpecId` mapping (→ Osaka), spec resolution, an explicit
Mendel-equivalent precompile dispatcher branch, and `pasteurTime` genesis
parsing. Scaffolding only: activation is unscheduled (`u64::MAX`) and behavior
is unchanged until later PRs add the dedicated Pasteur precompile set and
system-contract upgrade.

Ports bnb-chain/bsc #3552 + #3717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)