### PR TITLE
feat(evm/precompiles): reject duplicate pubkeys in BLS 0x66 at Pasteur

### DIFF
--- a/src/evm/precompiles/bls.rs
+++ b/src/evm/precompiles/bls.rs
@@ -5,12 +5,15 @@ use bls_on_arkworks as bls;
 use revm::precompile::{
     u64_to_address, PrecompileHalt, PrecompileOutput, PrecompileResult, Precompile, PrecompileId,
 };
-use std::{borrow::Cow, vec::Vec};
+use std::{borrow::Cow, collections::HashSet, vec::Vec};
 
 use super::error::BscPrecompileError;
 
 pub(crate) const BLS_SIGNATURE_VALIDATION: Precompile =
     Precompile::new(PrecompileId::Custom(Cow::Borrowed("BLS_SIGNATURE_VERIFY")), u64_to_address(102), bls_signature_validation_run);
+
+pub(crate) const BLS_SIGNATURE_VALIDATION_PASTEUR: Precompile =
+    Precompile::new(PrecompileId::Custom(Cow::Borrowed("BLS_SIGNATURE_VERIFY_PASTEUR")), u64_to_address(102), bls_signature_validation_run_pasteur);
 
 const BLS_MSG_HASH_LENGTH: u64 = 32;
 const BLS_SIGNATURE_LENGTH: u64 = 96;
@@ -23,6 +26,24 @@ const BLS_DST: &[u8] = bls::DST_ETHEREUM.as_bytes();
 /// | msg_hash |  signature  |  [{bls pubkey}]  |
 /// |    32    |      96     |      [{48}]      |
 fn bls_signature_validation_run(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
+    bls_signature_validation_run_inner(input, gas_limit, reservoir, false)
+}
+
+/// Pasteur variant: additionally rejects aggregated signer sets that repeat a pubkey.
+fn bls_signature_validation_run_pasteur(
+    input: &[u8],
+    gas_limit: u64,
+    reservoir: u64,
+) -> PrecompileResult {
+    bls_signature_validation_run_inner(input, gas_limit, reservoir, true)
+}
+
+fn bls_signature_validation_run_inner(
+    input: &[u8],
+    gas_limit: u64,
+    reservoir: u64,
+    require_unique_pubkeys: bool,
+) -> PrecompileResult {
     let cost = calc_gas_cost(input);
     if cost > gas_limit {
         return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir));
@@ -50,12 +71,17 @@ fn bls_signature_validation_run(input: &[u8], gas_limit: u64, reservoir: u64) ->
     let pub_key_count = (input_length - msg_and_sig_length) / BLS_SINGLE_PUBKEY_LENGTH;
     let mut pub_keys = Vec::with_capacity(pub_key_count as usize);
     let mut msg_hashes = Vec::with_capacity(pub_key_count as usize);
+    // From Pasteur, reject aggregated signer sets that repeat the same pubkey.
+    let mut seen_pub_keys = HashSet::with_capacity(pub_key_count as usize);
 
     // check pubkey format and push to pub_keys
     for i in 0..pub_key_count {
         let pub_key = &pub_keys_data[i as usize * BLS_SINGLE_PUBKEY_LENGTH as usize..
             (i + 1) as usize * BLS_SINGLE_PUBKEY_LENGTH as usize];
         if !bls::key_validate(&pub_key.to_vec()) {
+            return revert()
+        }
+        if require_unique_pubkeys && !seen_pub_keys.insert(pub_key.to_vec()) {
             return revert()
         }
         pub_keys.push(pub_key.to_vec());
@@ -256,5 +282,33 @@ mod tests {
             Err(e) => panic!("BLS signature validation failed, {e:?}"),
         };
         assert_eq!(result, excepted_output);
+    }
+
+    #[test]
+    fn pasteur_rejects_duplicate_pubkeys() {
+        // Same input as the legacy "duplicate pubkey" case: pub_key1 == pub_key2.
+        let msg_hash = hex!("6377c7e66081cb65e473c1b95db5195a27d04a7108b468890224bedbe1a8a6eb");
+        let signature = hex!("876ac46847e82a2f2887bbeb855916e05bd259086fda5553e4e5e5ee0dcda6869c10e2aa539e265b492015d1bd1b553815a42ea9daf6713b6a0002c6f1aacfa51e55b931745638c0552d7fab4a499bbd6ba71f9be36d35ffa527f77b2a6cebda");
+        let pub_key1 = hex!("8bec004e938668c67aa0fab6f555282efdf213817e455d9eaa6a0897211eae5f79db5cdc626d1cd5759a0c1c10cf7aa0");
+        let pub_key2 = hex!("8bec004e938668c67aa0fab6f555282efdf213817e455d9eaa6a0897211eae5f79db5cdc626d1cd5759a0c1c10cf7aa0");
+        let pub_key3 = hex!("af952757f442d7240a4cec62de638973a24fde8eb0ad5217be61eea53211c19859c03a299125ea8520f015f6f8865076");
+        let mut input = Vec::<u8>::new();
+        input.extend_from_slice(&msg_hash);
+        input.extend_from_slice(&signature);
+        input.extend_from_slice(&pub_key1);
+        input.extend_from_slice(&pub_key2);
+        input.extend_from_slice(&pub_key3);
+        let input = Bytes::from(input);
+
+        // Pasteur rejects the duplicate signer set outright (revert, cost preserved: 1000 + 3*3500).
+        let pasteur = bls_signature_validation_run_pasteur(&input, 100_000_000, 0)
+            .expect("precompile should not fatally error");
+        assert_eq!(pasteur, PrecompileOutput::revert(11500, Default::default(), 0));
+
+        // Pre-Pasteur keeps the legacy behavior: a successful run with empty (failed) output.
+        let legacy = bls_signature_validation_run(&input, 100_000_000, 0)
+            .expect("precompile should not fatally error");
+        assert!(legacy.is_success());
+        assert_eq!(legacy.bytes, Bytes::from(vec![]));
     }
 }

--- a/src/evm/precompiles/mod.rs
+++ b/src/evm/precompiles/mod.rs
@@ -424,9 +424,13 @@ fn build_mendel_precompiles() -> Precompiles {
 
 fn build_pasteur_precompiles() -> Precompiles {
     let mut precompiles = build_mendel_precompiles();
-    // Override 0x67 with the Pasteur cometBFT light-block precompile, which rejects
-    // duplicate validator identities in the consensus state and light-block validator sets.
-    precompiles.extend([cometbft::COMETBFT_LIGHT_BLOCK_VALIDATION_PASTEUR]);
+    // Override the bridge precompiles with their Pasteur variants:
+    // - 0x66 BLS signature verify: reject duplicate pubkeys in the aggregated signer set.
+    // - 0x67 cometBFT light block: reject duplicate validator identities.
+    precompiles.extend([
+        bls::BLS_SIGNATURE_VALIDATION_PASTEUR,
+        cometbft::COMETBFT_LIGHT_BLOCK_VALIDATION_PASTEUR,
+    ]);
     precompiles
 }
 
@@ -636,25 +640,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pasteur_shares_mendel_addresses_but_overrides_cometbft() {
+    fn pasteur_shares_mendel_addresses_but_overrides_bridge_precompiles() {
         let pasteur = traced_precompiles_for_spec(BscHardfork::Pasteur).precompiles();
         let mendel = traced_precompiles_for_spec(BscHardfork::Mendel).precompiles();
 
         // Pasteur keeps the same address set as Mendel...
         assert_eq!(pasteur.addresses_set(), mendel.addresses_set());
 
-        // ...but 0x67 now resolves to the Pasteur cometBFT light-block variant.
-        let addr = u64_to_address(103);
-        let id = pasteur.get(&addr).expect("0x67 present in Pasteur set").id();
-        assert!(
-            matches!(id, PrecompileId::Custom(c) if c.as_ref() == "COMET_BFT_LIGHT_BLOCK_VALIDATE_PASTEUR"),
-            "0x67 should be the Pasteur cometBFT variant, got {id:?}"
-        );
-        // Mendel keeps the Hertz variant.
-        let mendel_id = mendel.get(&addr).expect("0x67 present in Mendel set").id();
-        assert!(
-            matches!(mendel_id, PrecompileId::Custom(c) if c.as_ref() == "COMET_BFT_LIGHT_BLOCK_VALIDATE_HERTZ"),
-            "0x67 should remain the Hertz variant pre-Pasteur, got {mendel_id:?}"
-        );
+        let id_of = |p: &Precompiles, addr| {
+            p.get(&addr).unwrap_or_else(|| panic!("{addr:?} present")).id().clone()
+        };
+        let is_custom = |id: &PrecompileId, name: &str| {
+            matches!(id, PrecompileId::Custom(c) if c.as_ref() == name)
+        };
+
+        // ...but 0x66 (BLS) and 0x67 (cometBFT) resolve to their Pasteur variants,
+        // while Mendel keeps the prior implementations.
+        let bls = u64_to_address(102);
+        let cometbft = u64_to_address(103);
+        assert!(is_custom(&id_of(pasteur, bls), "BLS_SIGNATURE_VERIFY_PASTEUR"));
+        assert!(is_custom(&id_of(mendel, bls), "BLS_SIGNATURE_VERIFY"));
+        assert!(is_custom(&id_of(pasteur, cometbft), "COMET_BFT_LIGHT_BLOCK_VALIDATE_PASTEUR"));
+        assert!(is_custom(&id_of(mendel, cometbft), "COMET_BFT_LIGHT_BLOCK_VALIDATE_HERTZ"));
     }
 }


### PR DESCRIPTION
PR 4 of the BSC **Pasteur** hardfork series.

Adds the Pasteur BLS signature-verify precompile (`0x66`) that rejects aggregated
signer sets repeating a pubkey. The run path is factored into an inner fn gated
by `require_unique_pubkeys`; on a duplicate it reverts with cost preserved,
consistent with the existing invalid-key handling. Pre-Pasteur behavior is
unchanged.

Ports bnb-chain/bsc #3623 (BLS signer path). Completes the #3623 dedup work
(0x67 landed in PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)