### PR TITLE
feat(evm/precompiles): suspend legacy v1 Tendermint precompiles + reprice 0x67 at Pasteur

### DIFF
--- a/src/evm/precompiles/cometbft.rs
+++ b/src/evm/precompiles/cometbft.rs
@@ -49,8 +49,15 @@ const MAX_CONSENSUS_STATE_LENGTH: u64 = CHAIN_ID_LENGTH +
     VALIDATOR_SET_HASH_LENGTH +
     99 * SINGLE_VALIDATOR_BYTES_LENGTH;
 
+/// Base gas for the cometBFT light-block validation precompile.
+const COMETBFT_LIGHT_BLOCK_VALIDATION_BASE: u64 = 3_000;
+
+/// Per-input-byte gas charged from Pasteur, so cost scales with the validator/signature
+/// count instead of being a flat fee.
+const COMETBFT_LIGHT_BLOCK_VALIDATE_PER_BYTE_GAS: u64 = 16;
+
 fn cometbft_light_block_validation_run(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
-    cometbft_light_block_validation_run_inner(input, gas_limit, reservoir, true, false)
+    cometbft_light_block_validation_run_inner(input, gas_limit, reservoir, true, false, 0)
 }
 
 fn cometbft_light_block_validation_run_before_hertz(
@@ -58,7 +65,7 @@ fn cometbft_light_block_validation_run_before_hertz(
     gas_limit: u64,
     reservoir: u64,
 ) -> PrecompileResult {
-    cometbft_light_block_validation_run_inner(input, gas_limit, reservoir, false, false)
+    cometbft_light_block_validation_run_inner(input, gas_limit, reservoir, false, false, 0)
 }
 
 fn cometbft_light_block_validation_run_pasteur(
@@ -66,7 +73,15 @@ fn cometbft_light_block_validation_run_pasteur(
     gas_limit: u64,
     reservoir: u64,
 ) -> PrecompileResult {
-    cometbft_light_block_validation_run_inner(input, gas_limit, reservoir, true, true)
+    // From Pasteur the cost scales with input size and duplicate validators are rejected.
+    cometbft_light_block_validation_run_inner(
+        input,
+        gas_limit,
+        reservoir,
+        true,
+        true,
+        COMETBFT_LIGHT_BLOCK_VALIDATE_PER_BYTE_GAS,
+    )
 }
 
 fn cometbft_light_block_validation_run_inner(
@@ -75,10 +90,12 @@ fn cometbft_light_block_validation_run_inner(
     reservoir: u64,
     is_hertz: bool,
     require_unique_validators: bool,
+    per_byte_gas: u64,
 ) -> PrecompileResult {
-    const COMETBFT_LIGHT_BLOCK_VALIDATION_BASE: u64 = 3_000;
+    let cost = COMETBFT_LIGHT_BLOCK_VALIDATION_BASE
+        .saturating_add((input.len() as u64).saturating_mul(per_byte_gas));
 
-    if COMETBFT_LIGHT_BLOCK_VALIDATION_BASE > gas_limit {
+    if cost > gas_limit {
         return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir));
     }
 
@@ -115,7 +132,7 @@ fn cometbft_light_block_validation_run_inner(
     };
 
     Ok(PrecompileOutput::new(
-        COMETBFT_LIGHT_BLOCK_VALIDATION_BASE,
+        cost,
         encode_light_block_validation_result(validator_set_changed, consensus_state_bytes),
         reservoir,
     ))
@@ -888,5 +905,23 @@ mod tests {
         );
         let encoded = cs.encode().expect("encode consensus state");
         assert!(decode_consensus_state(&encoded, true).is_ok());
+    }
+
+    #[test]
+    fn pasteur_0x67_charges_per_byte_gas() {
+        // Gas is charged before decoding, so this needs no valid light block.
+        let input = vec![0u8; 1000];
+        let cost = COMETBFT_LIGHT_BLOCK_VALIDATION_BASE +
+            input.len() as u64 * COMETBFT_LIGHT_BLOCK_VALIDATE_PER_BYTE_GAS;
+
+        // Pasteur prices per input byte: a gas limit one below `cost` runs out of gas.
+        let pasteur = cometbft_light_block_validation_run_pasteur(&input, cost - 1, 0).unwrap();
+        assert_eq!(pasteur.halt_reason(), Some(&PrecompileHalt::OutOfGas));
+
+        // Hertz only ever charges the flat base, so the same limit clears the gas gate (it then
+        // halts on the undecodable input — a halt, but not OutOfGas).
+        let hertz = cometbft_light_block_validation_run(&input, cost - 1, 0).unwrap();
+        assert!(hertz.is_halt());
+        assert_ne!(hertz.halt_reason(), Some(&PrecompileHalt::OutOfGas));
     }
 }

--- a/src/evm/precompiles/iavl.rs
+++ b/src/evm/precompiles/iavl.rs
@@ -26,6 +26,10 @@ pub(crate) const IAVL_PROOF_VALIDATION_PLANCK: Precompile =
 pub(crate) const IAVL_PROOF_VALIDATION_PLATO: Precompile =
     Precompile::new(PrecompileId::Custom(Cow::Borrowed("IAVL_MERKLE_PROOF_VALIDATE_PLATO")), u64_to_address(101), iavl_proof_validation_run_plato);
 
+/// Iavl proof validation precompile disabled from Pasteur (legacy v1 light client deprecated).
+pub(crate) const IAVL_PROOF_VALIDATION_DEPRECATED: Precompile =
+    Precompile::new(PrecompileId::Custom(Cow::Borrowed("IAVL_MERKLE_PROOF_VALIDATE_DEPRECATED")), u64_to_address(101), iavl_proof_validation_run_deprecated);
+
 /// Run Iavl proof validation.
 fn iavl_proof_validation_run(input: &[u8], gas_limit: u64, reservoir: u64) -> PrecompileResult {
     iavl_proof_validation_run_inner(input, gas_limit, reservoir, false, false, false)
@@ -34,6 +38,11 @@ fn iavl_proof_validation_run(input: &[u8], gas_limit: u64, reservoir: u64) -> Pr
 /// Run Iavl proof validation with Nano hardfork.
 fn iavl_proof_validation_run_nano(_input: &[u8], _gas_limit: u64, reservoir: u64) -> PrecompileResult {
     Ok(PrecompileOutput::halt(PrecompileHalt::other("suspended"), reservoir))
+}
+
+/// Run the deprecated (Pasteur) Iavl proof validation precompile: rejects all input.
+fn iavl_proof_validation_run_deprecated(_input: &[u8], _gas_limit: u64, reservoir: u64) -> PrecompileResult {
+    Ok(PrecompileOutput::halt(PrecompileHalt::other("deprecated"), reservoir))
 }
 
 /// Run Iavl proof validation with Moran hardfork.
@@ -177,5 +186,11 @@ mod tests {
 
         let res = hex::encode(res.bytes);
         assert_eq!(res, "0000000000000000000000000000000000000000000000000000000000000001")
+    }
+
+    #[test]
+    fn deprecated_precompile_rejects_all_input() {
+        let res = iavl_proof_validation_run_deprecated(b"anything", 3_000, 0).unwrap();
+        assert!(res.is_halt());
     }
 }

--- a/src/evm/precompiles/mod.rs
+++ b/src/evm/precompiles/mod.rs
@@ -424,9 +424,16 @@ fn build_mendel_precompiles() -> Precompiles {
 
 fn build_pasteur_precompiles() -> Precompiles {
     let mut precompiles = build_mendel_precompiles();
-    // Override 0x67 with the Pasteur cometBFT light-block precompile, which rejects
-    // duplicate validator identities in the consensus state and light-block validator sets.
-    precompiles.extend([cometbft::COMETBFT_LIGHT_BLOCK_VALIDATION_PASTEUR]);
+    // Pasteur bridge-precompile changes:
+    // - 0x64/0x65: legacy v1 Tendermint header / IAVL proof precompiles are deprecated
+    //   (return an error for any input).
+    // - 0x67: cometBFT light-block validation rejects duplicate validator identities and is
+    //   repriced with per-input-byte gas.
+    precompiles.extend([
+        tendermint::TENDERMINT_HEADER_VALIDATION_DEPRECATED,
+        iavl::IAVL_PROOF_VALIDATION_DEPRECATED,
+        cometbft::COMETBFT_LIGHT_BLOCK_VALIDATION_PASTEUR,
+    ]);
     precompiles
 }
 
@@ -636,25 +643,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pasteur_shares_mendel_addresses_but_overrides_cometbft() {
+    fn pasteur_shares_mendel_addresses_but_overrides_bridge_precompiles() {
         let pasteur = traced_precompiles_for_spec(BscHardfork::Pasteur).precompiles();
         let mendel = traced_precompiles_for_spec(BscHardfork::Mendel).precompiles();
 
         // Pasteur keeps the same address set as Mendel...
         assert_eq!(pasteur.addresses_set(), mendel.addresses_set());
 
-        // ...but 0x67 now resolves to the Pasteur cometBFT light-block variant.
-        let addr = u64_to_address(103);
-        let id = pasteur.get(&addr).expect("0x67 present in Pasteur set").id();
-        assert!(
-            matches!(id, PrecompileId::Custom(c) if c.as_ref() == "COMET_BFT_LIGHT_BLOCK_VALIDATE_PASTEUR"),
-            "0x67 should be the Pasteur cometBFT variant, got {id:?}"
-        );
-        // Mendel keeps the Hertz variant.
-        let mendel_id = mendel.get(&addr).expect("0x67 present in Mendel set").id();
-        assert!(
-            matches!(mendel_id, PrecompileId::Custom(c) if c.as_ref() == "COMET_BFT_LIGHT_BLOCK_VALIDATE_HERTZ"),
-            "0x67 should remain the Hertz variant pre-Pasteur, got {mendel_id:?}"
-        );
+        let id_of = |p: &Precompiles, addr| {
+            p.get(&addr).unwrap_or_else(|| panic!("{addr:?} present")).id().clone()
+        };
+        let is_custom = |id: &PrecompileId, name: &str| {
+            matches!(id, PrecompileId::Custom(c) if c.as_ref() == name)
+        };
+
+        // ...but the bridge precompiles resolve to their Pasteur variants, while Mendel keeps
+        // the prior (live) implementations.
+        let tendermint = u64_to_address(100);
+        let iavl = u64_to_address(101);
+        let cometbft = u64_to_address(103);
+
+        assert!(is_custom(&id_of(pasteur, tendermint), "HEADER_VALIDATE_DEPRECATED"));
+        assert!(is_custom(&id_of(mendel, tendermint), "HEADER_VALIDATE"));
+        assert!(is_custom(&id_of(pasteur, iavl), "IAVL_MERKLE_PROOF_VALIDATE_DEPRECATED"));
+        assert!(is_custom(&id_of(mendel, iavl), "IAVL_MERKLE_PROOF_VALIDATE_PLATO"));
+        assert!(is_custom(&id_of(pasteur, cometbft), "COMET_BFT_LIGHT_BLOCK_VALIDATE_PASTEUR"));
+        assert!(is_custom(&id_of(mendel, cometbft), "COMET_BFT_LIGHT_BLOCK_VALIDATE_HERTZ"));
+
+        // 0x66 (BLS) is unchanged at Pasteur — it stays the generic verify (matches geth).
+        let bls = u64_to_address(102);
+        assert!(is_custom(&id_of(pasteur, bls), "BLS_SIGNATURE_VERIFY"));
     }
 }

--- a/src/evm/precompiles/tendermint.rs
+++ b/src/evm/precompiles/tendermint.rs
@@ -16,9 +16,18 @@ pub(crate) const TENDERMINT_HEADER_VALIDATION: Precompile =
 pub(crate) const TENDERMINT_HEADER_VALIDATION_NANO: Precompile =
     Precompile::new(PrecompileId::Custom(Cow::Borrowed("HEADER_VALIDATE_NANO")), u64_to_address(100), tendermint_header_validation_run_nano);
 
+/// Tendermint precompile disabled from Pasteur (legacy v1 light client deprecated).
+pub(crate) const TENDERMINT_HEADER_VALIDATION_DEPRECATED: Precompile =
+    Precompile::new(PrecompileId::Custom(Cow::Borrowed("HEADER_VALIDATE_DEPRECATED")), u64_to_address(100), tendermint_header_validation_run_deprecated);
+
 /// Run the Tendermint header validation precompile after Nano hardfork.
 fn tendermint_header_validation_run_nano(_input: &[u8], _gas_limit: u64, reservoir: u64) -> PrecompileResult {
     Ok(PrecompileOutput::halt(PrecompileHalt::other("suspended"), reservoir))
+}
+
+/// Run the deprecated (Pasteur) Tendermint header validation precompile: rejects all input.
+fn tendermint_header_validation_run_deprecated(_input: &[u8], _gas_limit: u64, reservoir: u64) -> PrecompileResult {
+    Ok(PrecompileOutput::halt(PrecompileHalt::other("deprecated"), reservoir))
 }
 
 /// Run the Tendermint header validation precompile.
@@ -53,5 +62,11 @@ mod tests {
 
         let output = hex::encode(res.bytes);
         assert_eq!(output, "000000000000000000000000000000000000000000000000000000000000022042696e616e63652d436861696e2d4e696c6500000000000000000000000000000000000003fc05e3a3e248bc209955054d880e4d89ff3c0419c0cd77681f4b4c6649ead5545054b980d9ab0fc10d18ca0e0832d5f4c063c5489ec1443dfb738252d038a82131b27ae17cbe9c20cdcfdf876b3b12978d3264a007fcaaa71c4cdb701d9ebc0323f44f000000174876e800184e7b103d34c41003f9b864d5f8c1adda9bd0436b253bb3c844bc739c1e77c9000000174876e8004d420aea843e92a0cfe69d89696dff6827769f9cb52a249af537ce89bf2a4b74000000174876e800bd03de9f8ab29e2800094e153fac6f696cfa512536c9c2f804dcb2c2c4e4aed6000000174876e8008f4a74a07351895ddf373057b98fae6dfaf2cd21f37a063e19601078fe470d53000000174876e8004a5d4753eb79f92e80efe22df7aca4f666a4f44bf81c536c4a09d4b9c5b654b5000000174876e800c80e9abef7ff439c10c68fe8f1303deddfc527718c3b37d8ba6807446e3c827a000000174876e8009142afcc691b7cc05d26c7b0be0c8b46418294171730e079f384fde2fa50bafc000000174876e80049b288e4ebbb3a281c2d546fc30253d5baf08993b6e5d295fb787a5b314a298e000000174876e80004224339688f012e649de48e241880092eaa8f6aa0f4f14bfcf9e0c76917c0b6000000174876e8004034b37ceda8a0bf13b1abaeee7a8f9383542099a554d219b93d0ce69e3970e8000000174876e800");
+    }
+
+    #[test]
+    fn deprecated_precompile_rejects_all_input() {
+        let res = tendermint_header_validation_run_deprecated(b"anything", 3_000, 0).unwrap();
+        assert!(res.is_halt());
     }
 }


### PR DESCRIPTION
PR 5 of the BSC **Pasteur** hardfork series.

From Pasteur:
- **0x64 / 0x65** — the legacy v1 Tendermint header and IAVL proof precompiles are deprecated and
  return an error for any input (new `*_DEPRECATED` variants).
- **0x67** — cometBFT light-block validation is repriced with per-input-byte gas
  (`base 3000 + 16/byte`) so cost scales with the validator/signature count.

Pre-Pasteur behavior is unchanged (live 0x64/0x65; flat 3000 for 0x67). 0x66/0x68/0x69 remain
present.

Ports bnb-chain/bsc #3726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)