### PR TITLE
feat(miner): BidBlockEnabled config + mev_params exposure (PR 8f)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,12 @@ pub struct BscCliArgs {
     #[arg(long = "mining.use-sparse-trie-state-root")]
     pub mining_use_sparse_trie_state_root: bool,
 
+    /// Accept BEP-675 builder-proposed blocks via `mev_sendBidBlock`.
+    ///
+    /// Env alternative: `BSC_MINING_BID_BLOCK_ENABLED=true`.
+    #[arg(long = "mining.bid-block-enabled")]
+    pub mining_bid_block_enabled: bool,
+
     /// Private key for mining (hex format, for testing only)
     /// The validator address will be automatically derived from this key
     #[arg(long = "mining.private-key")]
@@ -227,6 +233,11 @@ fn main() -> eyre::Result<()> {
                 // CLI takes precedence over env BSC_MINING_USE_SPARSE_TRIE_STATE_ROOT.
                 if args.mining_use_sparse_trie_state_root {
                     mining_config.use_sparse_trie_state_root = true;
+                }
+
+                // CLI takes precedence over env BSC_MINING_BID_BLOCK_ENABLED.
+                if args.mining_bid_block_enabled {
+                    mining_config.bid_block_enabled = true;
                 }
 
                 // Ensure keys are available if enabled but none provided

--- a/src/node/miner/config.rs
+++ b/src/node/miner/config.rs
@@ -41,6 +41,9 @@ pub struct MiningConfig {
     pub builder_fee_ceil: Option<u128>,
     /// List of allowed builder addresses (whitelist)
     pub allowed_builders: Option<Vec<Address>>,
+    /// Whether the `mev_sendBidBlock` RPC (BEP-675 builder-proposed blocks) is accepted.
+    /// Off by default; enable with `--mining.bid-block-enabled` or `BSC_MINING_BID_BLOCK_ENABLED`.
+    pub bid_block_enabled: bool,
     /// Use the reth 2.0 sparse-trie background task for state-root computation
     /// during MDBX-mode payload build.
     ///
@@ -71,6 +74,7 @@ impl std::fmt::Debug for MiningConfig {
             .field("max_bids_per_builder", &self.max_bids_per_builder)
             .field("builder_fee_ceil", &self.builder_fee_ceil)
             .field("allowed_builders", &self.allowed_builders)
+            .field("bid_block_enabled", &self.bid_block_enabled)
             .field("use_sparse_trie_state_root", &self.use_sparse_trie_state_root)
             .finish()
     }
@@ -96,6 +100,7 @@ impl Default for MiningConfig {
             max_bids_per_builder: Some(3),
             builder_fee_ceil: Some(1_000_000_000_000_000_000), // 1 BNB
             allowed_builders: None, // No whitelist by default (allow all)
+            bid_block_enabled: false, // BEP-675 BidBlock path off by default
             use_sparse_trie_state_root: false, // Opt-in for now (perf testing)
         }
     }
@@ -173,6 +178,11 @@ impl MiningConfig {
         self.builder_fee_ceil.unwrap_or(1_000_000_000_000_000_000) // Default: 1 BNB
     }
 
+    /// Whether the `mev_sendBidBlock` RPC (BEP-675) is accepted.
+    pub fn get_bid_block_enabled(&self) -> bool {
+        self.bid_block_enabled
+    }
+
     /// Generate a new validator configuration with random keys
     pub fn generate_for_development() -> Self {
         // use rand::Rng;
@@ -205,6 +215,7 @@ impl MiningConfig {
                 max_bids_per_builder: Some(3),
                 builder_fee_ceil: Some(1_000_000_000_000_000_000),
                 allowed_builders: None,
+                bid_block_enabled: false,
                 greedy_merge: true,
                 use_sparse_trie_state_root: false,
             }
@@ -299,6 +310,11 @@ impl MiningConfig {
             .map(|v| v.to_lowercase() == "true")
             .unwrap_or(false);
 
+        let bid_block_enabled = std::env::var("BSC_MINING_BID_BLOCK_ENABLED")
+            .ok()
+            .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(false);
+
         let mut cfg = Self {
             enabled,
             private_key_hex,
@@ -314,6 +330,7 @@ impl MiningConfig {
             max_bids_per_builder,
             builder_fee_ceil,
             allowed_builders,
+            bid_block_enabled,
             use_sparse_trie_state_root,
             ..Default::default()
         };
@@ -416,6 +433,11 @@ pub mod keystore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bid_block_disabled_by_default() {
+        assert!(!MiningConfig::default().get_bid_block_enabled());
+    }
 
     #[test]
     fn test_mining_config_validation() {

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -87,6 +87,9 @@ pub struct MevParams {
     /// Maximum builder fee allowed - decimal number
     #[serde(rename = "BuilderFeeCeil", serialize_with = "serialize_u256_as_decimal")]
     pub builder_fee_ceil: U256,
+    /// Whether the `mev_sendBidBlock` (BEP-675) path is accepted
+    #[serde(rename = "BidBlockEnabled")]
+    pub bid_block_enabled: bool,
     /// MEV service version
     #[serde(rename = "Version")]
     pub version: String,
@@ -154,6 +157,7 @@ pub struct MevApiImpl {
     gas_ceil: u64,
     min_gas_price: U256,
     builder_fee_ceil: U256,
+    bid_block_enabled: bool,
     version: String,
     /// Whitelist of allowed builders (shared with miner_ namespace via shared.rs)
     allowed_builders: Arc<RwLock<HashSet<Address>>>,
@@ -211,6 +215,7 @@ impl MevApiImpl {
         let no_interrupt_left_over = mining_config.get_no_interrupt_left_over();
         let max_bids_per_builder = mining_config.get_max_bids_per_builder();
         let builder_fee_ceil = U256::from(mining_config.get_builder_fee_ceil());
+        let bid_block_enabled = mining_config.get_bid_block_enabled();
 
         // Version string
         let version = env!("CARGO_PKG_VERSION").to_string();
@@ -256,6 +261,7 @@ impl MevApiImpl {
             gas_ceil,
             min_gas_price,
             builder_fee_ceil,
+            bid_block_enabled,
             version,
             allowed_builders,
         }
@@ -826,6 +832,7 @@ impl BscMevApiServer for MevApiImpl {
             gas_ceil: self.gas_ceil,
             gas_price: self.min_gas_price,
             builder_fee_ceil: self.builder_fee_ceil,
+            bid_block_enabled: self.bid_block_enabled,
             version: self.version.clone(),
         })
     }
@@ -865,5 +872,28 @@ impl BscMevApiServer for MevApiImpl {
             tracing::info!("Builder {} was not in whitelist", builder);
         }
         Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod bid_block_param_tests {
+    use super::*;
+
+    #[test]
+    fn mev_params_exposes_bid_block_enabled_field() {
+        let params = MevParams {
+            validator_commission: 100,
+            bid_simulation_left_over: 0,
+            no_interrupt_left_over: 0,
+            max_bids_per_builder: 3,
+            gas_ceil: 0,
+            gas_price: U256::ZERO,
+            builder_fee_ceil: U256::ZERO,
+            bid_block_enabled: true,
+            version: "test".to_string(),
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        // geth parity: the field is exposed as "BidBlockEnabled".
+        assert_eq!(json.get("BidBlockEnabled"), Some(&serde_json::Value::Bool(true)));
     }
 }


### PR DESCRIPTION
Slice of the **BEP-675 / Builder-Proposed Block** track (bnb-chain/bsc #3691).

Adds the `BidBlockEnabled` gate:
- `MiningConfig::bid_block_enabled` — off by default; set via `--mining.bid-block-enabled`
  (CLI > env `BSC_MINING_BID_BLOCK_ENABLED` > default), with a `get_bid_block_enabled()` accessor.
- Threaded into `MevApiImpl` and exposed on `MevParams` as `"BidBlockEnabled"` so builders can query
  whether `mev_sendBidBlock` is accepted — matching geth-bsc's `MevParams`.

Self-contained prerequisite for the BidBlock RPC admission path (8e). Tests: default-off + the
`MevParams` serde field-name (`"BidBlockEnabled"`) parity. `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)