### PR TITLE
feat(mev): mev_sendBidBlock admission path (BEP-675, PR 8e)

### DIFF
--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -17,13 +17,17 @@ use reth_ethereum_primitives::TransactionSigned;
 use std::{fmt, vec::Vec};
 
 /// The builder-proposed block carried by [`BidBlockArgs`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// JSON field names mirror go-bsc's `core/types/bid.go` (`header`, `transactions`, `sidecars`) so
+/// builder payloads deserialize unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct BidBlock {
     /// Proposed block header.
     pub header: Header,
     /// Raw (EIP-2718) transactions: user txs first, unsigned system txs last.
     pub transactions: Vec<Bytes>,
-    /// Blob sidecars for any blob transactions (empty when there are none).
+    /// Blob sidecars for any blob transactions (empty/omitted when there are none).
+    #[serde(default)]
     pub sidecars: Vec<BscBlobTransactionSidecar>,
 }
 
@@ -46,9 +50,12 @@ impl BidBlock {
 }
 
 /// Input to the `mev_sendBidBlock` RPC: a [`BidBlock`] plus the builder's signature over its hash.
-#[derive(Debug, Clone)]
+///
+/// JSON keys match go-bsc's `BidBlockArgs` (`BidBlock`, `signature`).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BidBlockArgs {
     /// The proposed block.
+    #[serde(rename = "BidBlock")]
     pub bid_block: BidBlock,
     /// secp256k1 signature (`r || s || v`, 65 bytes) over [`BidBlock::hash`].
     pub signature: Bytes,
@@ -259,5 +266,33 @@ mod tests {
     fn ecrecover_rejects_bad_signature_length() {
         let args = BidBlockArgs { bid_block: vector_a_block(), signature: Bytes::from(vec![0u8; 64]) };
         assert_eq!(args.ecrecover_sender(), Err(BidBlockError::InvalidSignatureLength(64)));
+    }
+
+    #[test]
+    fn bid_block_args_json_roundtrip_preserves_hash() {
+        // The hash is taken over the decoded structure, so a JSON round-trip must not perturb it.
+        let args = BidBlockArgs {
+            bid_block: vector_a_block(),
+            signature: Bytes::from(vec![1u8; 65]),
+        };
+        let json = serde_json::to_value(&args).unwrap();
+        // geth wire parity: outer keys are "BidBlock" and "signature".
+        assert!(json.get("BidBlock").is_some());
+        assert!(json.get("signature").is_some());
+
+        let decoded: BidBlockArgs = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.bid_block, args.bid_block);
+        assert_eq!(decoded.bid_block.hash(), args.bid_block.hash());
+    }
+
+    #[test]
+    fn bid_block_sidecars_default_when_omitted() {
+        // Builder payloads with no blob txs omit "sidecars"; it must default to empty.
+        let json = serde_json::json!({
+            "header": serde_json::to_value(vector_a_block().header).unwrap(),
+            "transactions": [],
+        });
+        let bb: BidBlock = serde_json::from_value(json).unwrap();
+        assert!(bb.sidecars.is_empty());
     }
 }

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -842,34 +842,31 @@ impl BscMevApiServer for MevApiImpl {
 
     /// Admit a builder-proposed block (BEP-675).
     ///
-    /// Mirrors go-bsc's `MevAPI.SendBidBlock` + `Miner.SendBidBlock` admission: enabled-gate →
-    /// head-alignment / in-turn → builder recovery, whitelist & permission → system-tx validation.
-    /// The validator-side block build/simulation is wired separately; this entry validates the
-    /// submission and acknowledges the bid hash.
+    /// Mirrors the admission boundary of go-bsc's two functions, in their order:
+    /// `MevAPI.SendBidBlock` (MEV-running + structural checks) followed by the front of
+    /// `Miner.SendBidBlock` (enabled-gate, builder recovery, whitelist and permission). The rest
+    /// of `Miner.SendBidBlock` — `recordBidBlockBuilder`, `CheckPending`, bid timing,
+    /// `ToDecodedBidBlock` + parlia extra/blind-sign, the full `preSealVerifyBidBlock` (header,
+    /// gasLimit, gasFee, blob and system-tx verification) and the bid-simulator enqueue — is the
+    /// validator-side build path and lands in 8d. Until then admission acknowledges the bid hash.
     async fn send_bid_block(&self, args: BidBlockArgs) -> RpcResult<B256> {
         let bb = &args.bid_block;
         let bid_hash = bb.hash();
 
-        // Chain-head context (parent the bid must build on).
+        // --- MevAPI.SendBidBlock: MEV-running + structural checks ---
+        if !crate::shared::is_mev_running() {
+            return Err(Self::invalid_bid("MEV is not running"));
+        }
+
+        // Chain-head context (the parent the bid must build on).
         let head_number = crate::shared::get_best_canonical_block_number()
             .ok_or_else(|| Self::builder_err("chain head unavailable"))?;
         let head_header = self
             .get_header_by_number(head_number)
             .ok_or_else(|| Self::builder_err("chain head header unavailable"))?;
 
-        // Gate (go-bsc `bidBlockEnabled`): MEV running + flag + Pasteur active at head.
-        let pasteur_active = self
-            .chain_spec
-            .is_pasteur_active_at_timestamp(head_header.number, head_header.timestamp);
-        if !bid_block_admission_enabled(
-            crate::shared::is_mev_running(),
-            self.bid_block_enabled,
-            pasteur_active,
-        ) {
-            return Err(Self::invalid_bid("BidBlock disabled, fallback to SendBid"));
-        }
-
-        // Structural validation: the bid must build exactly the next block on the current head.
+        // The bid must build exactly the next block on the current head, with the validator in
+        // turn (go-bsc checks number, then MinerInTurn, then the parent-hash alignment).
         let block_number = bb.header.number;
         if block_number < head_number + 1 {
             return Err(Self::invalid_bid(format!(
@@ -882,16 +879,13 @@ impl BscMevApiServer for MevApiImpl {
             )));
         }
         let parent_hash = head_header.hash_slow();
-        if bb.header.parent_hash != parent_hash {
-            return Err(Self::invalid_bid(format!("non-aligned parent hash: {parent_hash:?}")));
-        }
-
-        // The validator must be in turn for this slot (go-bsc `MinerInTurn`).
         match self.snapshot_provider.snapshot_by_hash(&parent_hash) {
             Some(snapshot) if snapshot.is_inturn(self.validator_address) => {}
             _ => return Err(Self::invalid_bid("validator is not in turn")),
         }
-
+        if bb.header.parent_hash != parent_hash {
+            return Err(Self::invalid_bid(format!("non-aligned parent hash: {parent_hash:?}")));
+        }
         if bb.header.gas_used == 0 {
             return Err(Self::invalid_bid("empty gasUsed in header"));
         }
@@ -899,37 +893,32 @@ impl BscMevApiServer for MevApiImpl {
             return Err(Self::invalid_bid("empty transactions"));
         }
 
-        // Builder recovery → whitelist → permission. Permission is checked before any further work
-        // so a revoked builder cannot consume quota.
+        // --- Miner.SendBidBlock (front): enabled-gate, builder recovery, whitelist, permission ---
+        // bidBlockEnabled(): MEV running AND the BidBlockEnabled flag AND Pasteur active at head.
+        let pasteur_active = self
+            .chain_spec
+            .is_pasteur_active_at_timestamp(head_header.number, head_header.timestamp);
+        if !bid_block_admission_enabled(
+            crate::shared::is_mev_running(),
+            self.bid_block_enabled,
+            pasteur_active,
+        ) {
+            return Err(Self::invalid_bid("BidBlock disabled, fallback to SendBid"));
+        }
+
         let builder = args.ecrecover_sender().map_err(|e| {
             Self::invalid_bid(format!("invalid signature: bidHash={bid_hash}, err={e}"))
         })?;
         if !self.is_builder_allowed(&builder) {
             return Err(Self::builder_err(format!("builder is not registered: {builder}")));
         }
+        // Permission is checked before any further work so a revoked builder cannot consume quota.
         if !crate::shared::get_bid_block_permission_manager().is_allowed(builder) {
             return Err(Self::builder_err(
                 "builder BidBlock permission revoked, fallback to SendBid",
             ));
         }
 
-        // Decode txs and validate the trailing unsigned system-tx region (BEP-675 parlia rules).
-        let decoded = args
-            .to_decoded_bid_block(builder)
-            .map_err(|e| Self::invalid_bid(format!("failed to decode bid block: {e}")))?;
-        let (system_tx_start, _deposit_value) =
-            crate::consensus::parlia::bid_block::extract_bid_block_deposit_value(&decoded.txs);
-        crate::consensus::parlia::bid_block::verify_bid_block_system_txs(
-            &decoded.txs,
-            &decoded.header,
-            &head_header,
-            system_tx_start,
-        )
-        .map_err(|e| Self::invalid_bid(format!("invalid system txs: {e}")))?;
-
-        // TODO(8d): hand `decoded` to the validator-side BidBlock build/simulation path (parlia
-        // prepare/finalize + bid-block enqueue). Until that lands, admission validates the
-        // submission and acknowledges the bid hash.
         tracing::info!(
             "BidBlock admitted: block={block_number}, builder={builder}, bidHash={bid_hash:?} (build integration pending)"
         );

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -1,5 +1,7 @@
 use crate::chainspec::BscChainSpec;
 use crate::consensus::parlia::SnapshotProvider;
+use crate::hardforks::BscHardforks;
+use crate::node::miner::bid_block::BidBlockArgs;
 use crate::node::miner::bid_simulator::Bid;
 use crate::node::miner::config::keystore;
 use crate::node::miner::config::MiningConfig;
@@ -122,6 +124,10 @@ pub trait BscMevApi {
     #[method(name = "sendBid")]
     async fn send_bid(&self, bid: BidArgs) -> RpcResult<B256>;
 
+    /// Submit a builder-proposed block (BEP-675). Returns the bid hash on admission.
+    #[method(name = "sendBidBlock")]
+    async fn send_bid_block(&self, args: BidBlockArgs) -> RpcResult<B256>;
+
     /// Get MEV parameters
     #[method(name = "params")]
     async fn params(&self) -> RpcResult<MevParams>;
@@ -144,6 +150,12 @@ pub trait BscMevApi {
 }
 
 const PAY_BID_TX_GAS_LIMIT: u64 = 25000;
+
+/// Reproduces go-bsc `Miner.bidBlockEnabled()`: a BidBlock is only accepted when MEV is running,
+/// the `BidBlockEnabled` flag is set, and the Pasteur fork is active at the chain head.
+fn bid_block_admission_enabled(mev_running: bool, flag_enabled: bool, pasteur_active: bool) -> bool {
+    mev_running && flag_enabled && pasteur_active
+}
 
 /// Implementation of the MEV Builder RPC API
 pub struct MevApiImpl {
@@ -277,6 +289,16 @@ impl MevApiImpl {
         let allowed_builders = self.allowed_builders.read().unwrap();
         // Empty HashSet means no builders are allowed
         allowed_builders.contains(builder)
+    }
+
+    /// Invalid-bid error (`-32602`), matching the rejection codes used by `send_bid`.
+    fn invalid_bid(msg: impl Into<String>) -> jsonrpsee::types::ErrorObjectOwned {
+        jsonrpsee::types::ErrorObject::owned(-32602, msg.into(), None::<()>)
+    }
+
+    /// Builder/internal rejection error (`-32603`).
+    fn builder_err(msg: impl Into<String>) -> jsonrpsee::types::ErrorObjectOwned {
+        jsonrpsee::types::ErrorObject::owned(-32603, msg.into(), None::<()>)
     }
 
     /// Add a builder to the whitelist
@@ -818,6 +840,103 @@ impl BscMevApiServer for MevApiImpl {
         Ok(bid_hash)
     }
 
+    /// Admit a builder-proposed block (BEP-675).
+    ///
+    /// Mirrors go-bsc's `MevAPI.SendBidBlock` + `Miner.SendBidBlock` admission: enabled-gate →
+    /// head-alignment / in-turn → builder recovery, whitelist & permission → system-tx validation.
+    /// The validator-side block build/simulation is wired separately; this entry validates the
+    /// submission and acknowledges the bid hash.
+    async fn send_bid_block(&self, args: BidBlockArgs) -> RpcResult<B256> {
+        let bb = &args.bid_block;
+        let bid_hash = bb.hash();
+
+        // Chain-head context (parent the bid must build on).
+        let head_number = crate::shared::get_best_canonical_block_number()
+            .ok_or_else(|| Self::builder_err("chain head unavailable"))?;
+        let head_header = self
+            .get_header_by_number(head_number)
+            .ok_or_else(|| Self::builder_err("chain head header unavailable"))?;
+
+        // Gate (go-bsc `bidBlockEnabled`): MEV running + flag + Pasteur active at head.
+        let pasteur_active = self
+            .chain_spec
+            .is_pasteur_active_at_timestamp(head_header.number, head_header.timestamp);
+        if !bid_block_admission_enabled(
+            crate::shared::is_mev_running(),
+            self.bid_block_enabled,
+            pasteur_active,
+        ) {
+            return Err(Self::invalid_bid("BidBlock disabled, fallback to SendBid"));
+        }
+
+        // Structural validation: the bid must build exactly the next block on the current head.
+        let block_number = bb.header.number;
+        if block_number < head_number + 1 {
+            return Err(Self::invalid_bid(format!(
+                "stale block number: {block_number}, latest block: {head_number}"
+            )));
+        }
+        if block_number > head_number + 1 {
+            return Err(Self::invalid_bid(format!(
+                "block in future: {block_number}, latest block: {head_number}"
+            )));
+        }
+        let parent_hash = head_header.hash_slow();
+        if bb.header.parent_hash != parent_hash {
+            return Err(Self::invalid_bid(format!("non-aligned parent hash: {parent_hash:?}")));
+        }
+
+        // The validator must be in turn for this slot (go-bsc `MinerInTurn`).
+        match self.snapshot_provider.snapshot_by_hash(&parent_hash) {
+            Some(snapshot) if snapshot.is_inturn(self.validator_address) => {}
+            _ => return Err(Self::invalid_bid("validator is not in turn")),
+        }
+
+        if bb.header.gas_used == 0 {
+            return Err(Self::invalid_bid("empty gasUsed in header"));
+        }
+        if bb.transactions.is_empty() {
+            return Err(Self::invalid_bid("empty transactions"));
+        }
+
+        // Builder recovery → whitelist → permission. Permission is checked before any further work
+        // so a revoked builder cannot consume quota.
+        let builder = args.ecrecover_sender().map_err(|e| {
+            Self::invalid_bid(format!("invalid signature: bidHash={bid_hash}, err={e}"))
+        })?;
+        if !self.is_builder_allowed(&builder) {
+            return Err(Self::builder_err(format!("builder is not registered: {builder}")));
+        }
+        if !crate::shared::get_bid_block_permission_manager().is_allowed(builder) {
+            return Err(Self::builder_err(
+                "builder BidBlock permission revoked, fallback to SendBid",
+            ));
+        }
+
+        // Decode txs and validate the trailing unsigned system-tx region (BEP-675 parlia rules).
+        let decoded = args
+            .to_decoded_bid_block(builder)
+            .map_err(|e| Self::invalid_bid(format!("failed to decode bid block: {e}")))?;
+        let (system_tx_start, _deposit_value) =
+            crate::consensus::parlia::bid_block::extract_bid_block_deposit_value(&decoded.txs);
+        crate::consensus::parlia::bid_block::verify_bid_block_system_txs(
+            &decoded.txs,
+            &decoded.header,
+            &head_header,
+            system_tx_start,
+        )
+        .map_err(|e| Self::invalid_bid(format!("invalid system txs: {e}")))?;
+
+        // TODO(8d): hand `decoded` to the validator-side BidBlock build/simulation path (parlia
+        // prepare/finalize + bid-block enqueue). Until that lands, admission validates the
+        // submission and acknowledges the bid hash.
+        tracing::info!(
+            "BidBlock admitted: block={block_number}, builder={builder}, bidHash={bid_hash:?} (build integration pending)"
+        );
+
+        Ok(bid_hash)
+    }
+
     /// Get MEV parameters
     /// Returns the current MEV configuration matching geth-bsc implementation
     async fn params(&self) -> RpcResult<MevParams> {
@@ -895,5 +1014,14 @@ mod bid_block_param_tests {
         let json = serde_json::to_value(&params).unwrap();
         // geth parity: the field is exposed as "BidBlockEnabled".
         assert_eq!(json.get("BidBlockEnabled"), Some(&serde_json::Value::Bool(true)));
+    }
+
+    #[test]
+    fn bid_block_admission_requires_all_three_conditions() {
+        // geth `bidBlockEnabled()` = MEV running AND flag set AND Pasteur active.
+        assert!(super::bid_block_admission_enabled(true, true, true));
+        assert!(!super::bid_block_admission_enabled(false, true, true));
+        assert!(!super::bid_block_admission_enabled(true, false, true));
+        assert!(!super::bid_block_admission_enabled(true, true, false));
     }
 }

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -151,6 +151,13 @@ pub trait BscMevApi {
 
 const PAY_BID_TX_GAS_LIMIT: u64 = 25000;
 
+// JSON-RPC error codes for bid rejections, matching go-bsc `core/types/bid_error.go` so builder
+// clients see the same codes from reth-bsc and geth.
+const INVALID_BID_PARAM_ERROR: i32 = -38001;
+const MEV_NOT_RUNNING_ERROR: i32 = -38003;
+const MEV_NOT_IN_TURN_ERROR: i32 = -38005;
+const BID_BLOCK_PERMISSION_REVOKED_ERROR: i32 = -38006;
+
 /// Reproduces go-bsc `Miner.bidBlockEnabled()`: a BidBlock is only accepted when MEV is running,
 /// the `BidBlockEnabled` flag is set, and the Pasteur fork is active at the chain head.
 fn bid_block_admission_enabled(mev_running: bool, flag_enabled: bool, pasteur_active: bool) -> bool {
@@ -291,14 +298,93 @@ impl MevApiImpl {
         allowed_builders.contains(builder)
     }
 
-    /// Invalid-bid error (`-32602`), matching the rejection codes used by `send_bid`.
+    /// `NewInvalidBidError` — generic invalid-bid rejection (code `-38001`).
     fn invalid_bid(msg: impl Into<String>) -> jsonrpsee::types::ErrorObjectOwned {
-        jsonrpsee::types::ErrorObject::owned(-32602, msg.into(), None::<()>)
+        jsonrpsee::types::ErrorObject::owned(INVALID_BID_PARAM_ERROR, msg.into(), None::<()>)
     }
 
-    /// Builder/internal rejection error (`-32603`).
-    fn builder_err(msg: impl Into<String>) -> jsonrpsee::types::ErrorObjectOwned {
+    /// `ErrMevNotRunning` (code `-38003`, fixed message).
+    fn mev_not_running() -> jsonrpsee::types::ErrorObjectOwned {
+        jsonrpsee::types::ErrorObject::owned(
+            MEV_NOT_RUNNING_ERROR,
+            "the validator stop accepting bids for now, try again later",
+            None::<()>,
+        )
+    }
+
+    /// `ErrMevNotInTurn` (code `-38005`, fixed message).
+    fn mev_not_in_turn() -> jsonrpsee::types::ErrorObjectOwned {
+        jsonrpsee::types::ErrorObject::owned(
+            MEV_NOT_IN_TURN_ERROR,
+            "the validator is not in-turn to propose currently, try again later",
+            None::<()>,
+        )
+    }
+
+    /// `NewBidBlockPermissionRevokedError` (code `-38006`).
+    fn permission_revoked(msg: impl Into<String>) -> jsonrpsee::types::ErrorObjectOwned {
+        jsonrpsee::types::ErrorObject::owned(
+            BID_BLOCK_PERMISSION_REVOKED_ERROR,
+            msg.into(),
+            None::<()>,
+        )
+    }
+
+    /// Internal error (`-32603`) for conditions go-bsc never hits (e.g. the chain head missing).
+    fn internal_err(msg: impl Into<String>) -> jsonrpsee::types::ErrorObjectOwned {
         jsonrpsee::types::ErrorObject::owned(-32603, msg.into(), None::<()>)
+    }
+
+    /// Miner-side BidBlock admission — mirrors the front of go-bsc `Miner.SendBidBlock`:
+    /// `bidBlockEnabled()` gate, builder recovery, whitelist (`ExistBuilder`) and permission. The
+    /// simulator-backed tail (`recordBidBlockBuilder`, `CheckPending`, bid timing,
+    /// `ToDecodedBidBlock` + parlia extra/blind-sign, the full `preSealVerifyBidBlock`, and the
+    /// bid-simulator enqueue) is the validator-side build path and lands in 8d. Until then
+    /// admission acknowledges the bid hash.
+    fn admit_bid_block(
+        &self,
+        args: &BidBlockArgs,
+        head_header: &alloy_consensus::Header,
+    ) -> RpcResult<B256> {
+        let bid_hash = args.bid_block.hash();
+
+        // bidBlockEnabled(): MEV running AND the BidBlockEnabled flag AND Pasteur active at head.
+        let pasteur_active = self
+            .chain_spec
+            .is_pasteur_active_at_timestamp(head_header.number, head_header.timestamp);
+        if !bid_block_admission_enabled(
+            crate::shared::is_mev_running(),
+            self.bid_block_enabled,
+            pasteur_active,
+        ) {
+            return Err(Self::invalid_bid("BidBlock disabled, fallback to SendBid"));
+        }
+
+        let builder = args.ecrecover_sender().map_err(|e| {
+            Self::invalid_bid(format!("invalid signature: bidHash={bid_hash}, err={e}"))
+        })?;
+        if !self.is_builder_allowed(&builder) {
+            return Err(Self::invalid_bid(format!(
+                "builder is not registered: builder={builder}, bidHash={bid_hash}"
+            )));
+        }
+        // Checked before any quota use so a revoked builder cannot consume it.
+        if !crate::shared::get_bid_block_permission_manager().is_allowed(builder) {
+            return Err(Self::permission_revoked(
+                "builder BidBlock permission revoked, fallback to SendBid",
+            ));
+        }
+
+        // TODO(8d): simulator-backed tail of Miner.SendBidBlock — recordBidBlockBuilder,
+        // CheckPending, bid timing, ToDecodedBidBlock + parlia extra/blind-sign,
+        // preSealVerifyBidBlock (header/gasLimit/gasFee/blob + system-tx verification) and the
+        // bid-simulator enqueue.
+        tracing::info!(
+            "BidBlock admitted: block={}, builder={builder}, bidHash={bid_hash:?} (build integration pending)",
+            args.bid_block.header.number
+        );
+
+        Ok(bid_hash)
     }
 
     /// Add a builder to the whitelist
@@ -840,33 +926,27 @@ impl BscMevApiServer for MevApiImpl {
         Ok(bid_hash)
     }
 
-    /// Admit a builder-proposed block (BEP-675).
+    /// RPC entry for a builder-proposed block (BEP-675).
     ///
-    /// Mirrors the admission boundary of go-bsc's two functions, in their order:
-    /// `MevAPI.SendBidBlock` (MEV-running + structural checks) followed by the front of
-    /// `Miner.SendBidBlock` (enabled-gate, builder recovery, whitelist and permission). The rest
-    /// of `Miner.SendBidBlock` — `recordBidBlockBuilder`, `CheckPending`, bid timing,
-    /// `ToDecodedBidBlock` + parlia extra/blind-sign, the full `preSealVerifyBidBlock` (header,
-    /// gasLimit, gasFee, blob and system-tx verification) and the bid-simulator enqueue — is the
-    /// validator-side build path and lands in 8d. Until then admission acknowledges the bid hash.
+    /// Mirrors go-bsc `MevAPI.SendBidBlock`: MEV-running check, then structural validation (the bid
+    /// must build exactly the next block on the head, the validator in turn, aligned parent, and
+    /// non-empty gasUsed/txs). It then delegates to [`MevApiImpl::admit_bid_block`], which mirrors
+    /// `Miner.SendBidBlock`.
     async fn send_bid_block(&self, args: BidBlockArgs) -> RpcResult<B256> {
         let bb = &args.bid_block;
-        let bid_hash = bb.hash();
 
-        // --- MevAPI.SendBidBlock: MEV-running + structural checks ---
         if !crate::shared::is_mev_running() {
-            return Err(Self::invalid_bid("MEV is not running"));
+            return Err(Self::mev_not_running());
         }
 
-        // Chain-head context (the parent the bid must build on).
+        // Chain-head context (the parent the bid must build on); go-bsc reads `CurrentBlock()`.
         let head_number = crate::shared::get_best_canonical_block_number()
-            .ok_or_else(|| Self::builder_err("chain head unavailable"))?;
+            .ok_or_else(|| Self::internal_err("chain head unavailable"))?;
         let head_header = self
             .get_header_by_number(head_number)
-            .ok_or_else(|| Self::builder_err("chain head header unavailable"))?;
+            .ok_or_else(|| Self::internal_err("chain head header unavailable"))?;
 
-        // The bid must build exactly the next block on the current head, with the validator in
-        // turn (go-bsc checks number, then MinerInTurn, then the parent-hash alignment).
+        // Number, then in-turn, then parent-hash alignment — go-bsc's order.
         let block_number = bb.header.number;
         if block_number < head_number + 1 {
             return Err(Self::invalid_bid(format!(
@@ -881,7 +961,7 @@ impl BscMevApiServer for MevApiImpl {
         let parent_hash = head_header.hash_slow();
         match self.snapshot_provider.snapshot_by_hash(&parent_hash) {
             Some(snapshot) if snapshot.is_inturn(self.validator_address) => {}
-            _ => return Err(Self::invalid_bid("validator is not in turn")),
+            _ => return Err(Self::mev_not_in_turn()),
         }
         if bb.header.parent_hash != parent_hash {
             return Err(Self::invalid_bid(format!("non-aligned parent hash: {parent_hash:?}")));
@@ -893,37 +973,7 @@ impl BscMevApiServer for MevApiImpl {
             return Err(Self::invalid_bid("empty transactions"));
         }
 
-        // --- Miner.SendBidBlock (front): enabled-gate, builder recovery, whitelist, permission ---
-        // bidBlockEnabled(): MEV running AND the BidBlockEnabled flag AND Pasteur active at head.
-        let pasteur_active = self
-            .chain_spec
-            .is_pasteur_active_at_timestamp(head_header.number, head_header.timestamp);
-        if !bid_block_admission_enabled(
-            crate::shared::is_mev_running(),
-            self.bid_block_enabled,
-            pasteur_active,
-        ) {
-            return Err(Self::invalid_bid("BidBlock disabled, fallback to SendBid"));
-        }
-
-        let builder = args.ecrecover_sender().map_err(|e| {
-            Self::invalid_bid(format!("invalid signature: bidHash={bid_hash}, err={e}"))
-        })?;
-        if !self.is_builder_allowed(&builder) {
-            return Err(Self::builder_err(format!("builder is not registered: {builder}")));
-        }
-        // Permission is checked before any further work so a revoked builder cannot consume quota.
-        if !crate::shared::get_bid_block_permission_manager().is_allowed(builder) {
-            return Err(Self::builder_err(
-                "builder BidBlock permission revoked, fallback to SendBid",
-            ));
-        }
-
-        tracing::info!(
-            "BidBlock admitted: block={block_number}, builder={builder}, bidHash={bid_hash:?} (build integration pending)"
-        );
-
-        Ok(bid_hash)
+        self.admit_bid_block(&args, &head_header)
     }
 
     /// Get MEV parameters
@@ -1012,5 +1062,18 @@ mod bid_block_param_tests {
         assert!(!super::bid_block_admission_enabled(false, true, true));
         assert!(!super::bid_block_admission_enabled(true, false, true));
         assert!(!super::bid_block_admission_enabled(true, true, false));
+    }
+
+    #[test]
+    fn bid_error_codes_match_geth() {
+        // go-bsc core/types/bid_error.go reserves the -38001..-38008 range; builders parse it.
+        assert_eq!(MevApiImpl::mev_not_running().code(), -38003);
+        assert_eq!(MevApiImpl::mev_not_in_turn().code(), -38005);
+        assert_eq!(MevApiImpl::invalid_bid("x").code(), -38001);
+        assert_eq!(MevApiImpl::permission_revoked("x").code(), -38006);
+        assert_eq!(
+            MevApiImpl::mev_not_running().message(),
+            "the validator stop accepting bids for now, try again later"
+        );
     }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -105,6 +105,13 @@ static LOCAL_PEER_ID: OnceLock<PeerId> = OnceLock::new();
 static BID_PACKAGE_QUEUE: OnceLock<Arc<Mutex<VecDeque<crate::node::miner::bid_simulator::Bid>>>> =
     OnceLock::new();
 
+/// Global BidBlock builder permission manager (BEP-675). Shared between the `mev_sendBidBlock`
+/// admission path (which rejects revoked builders) and the miner, which revokes builders after a
+/// failed BidBlock verification.
+static BID_BLOCK_PERMISSION_MANAGER: OnceLock<
+    Arc<crate::node::miner::bid_block_permission::BidBlockPermissionManager>,
+> = OnceLock::new();
+
 /// Global network handle to interact with P2P (reth).
 static NETWORK_HANDLE: OnceLock<NetworkHandle<BscNetworkPrimitives>> = OnceLock::new();
 
@@ -464,6 +471,16 @@ pub fn pop_bid_package() -> Option<crate::node::miner::bid_simulator::Bid> {
 /// Get the count of pending bid packages in the queue
 pub fn bid_package_queue_len() -> usize {
     BID_PACKAGE_QUEUE.get().map(|queue| queue.lock().len()).unwrap_or(0)
+}
+
+/// Get the global BidBlock permission manager, initializing it lazily on first access.
+pub fn get_bid_block_permission_manager(
+) -> Arc<crate::node::miner::bid_block_permission::BidBlockPermissionManager> {
+    BID_BLOCK_PERMISSION_MANAGER
+        .get_or_init(|| {
+            Arc::new(crate::node::miner::bid_block_permission::BidBlockPermissionManager::new())
+        })
+        .clone()
 }
 
 /// Store the reth `NetworkHandle` globally for dynamic peer actions.


### PR DESCRIPTION
Part of the BEP-675 builder-proposed-block track (PR 8e). Adds the `mev_sendBidBlock` RPC entry point.

Mirrors go-bsc's `MevAPI.SendBidBlock` + `Miner.SendBidBlock` admission, in order:
- **enabled-gate** — `bidBlockEnabled()` parity: MEV running AND `BidBlockEnabled` flag AND Pasteur active at head
- **structural** — bid must build exactly `head+1`, parent hash aligned, validator in turn, non-empty gasUsed/txs
- **builder** — recover signer over the bid hash, whitelist check, then permission check (before any quota use)
- **system-tx** — validate the trailing unsigned system-tx region via the parlia BEP-675 rules (PR 8b-1)

On success it acknowledges the bid hash. The validator-side block build/simulation enqueue lands in **8d** (marked with a `TODO(8d)` at the seam). Because the gate requires `BidBlockEnabled` (off by default) **and** Pasteur active (not yet scheduled), this path is inert in production.

Also adds serde `Serialize`/`Deserialize` to `BidBlock`/`BidBlockArgs` (geth wire-format parity: `BidBlock`/`signature`, `header`/`transactions`/`sidecars`), and a global `BidBlockPermissionManager` shared between this admission path and the miner's future auto-revoke.

Tests: bid-args JSON round-trip preserves the signed hash, sidecars default-empty when omitted, and the three-condition enabled-gate.