### PR TITLE
chore(deps): bump reth to feat/migrate-v2-resume for --resume flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
 reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.0.10" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", branch = "feat/migrate-v2-resume" }
 
 # triedb dependencies
 rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop" }


### PR DESCRIPTION
## Summary

Tracks https://github.com/bnb-chain/reth/pull/203 — adds the `migrate-v2 --resume` flag needed to finish a half-completed v1 → v2 storage migration without redoing the multi-day changeset/receipt phases.

## Why

On a 9.3 TB BSC archive the migration was OOM-killed after `StorageSettings` was already flipped to v2 but before `clear_recomputable_tables` did any writes. Re-running stock `migrate-v2` hits the "already v2, nothing to do" early-exit and leaves the DB in a half-migrated state (changesets/receipts in static files, MDBX still full of v1 tables, stage checkpoints not reset). `--resume` jumps straight to clear + compact + swap.

This PR only flips the bnb-chain/reth deps from `tag = "v0.0.10"` to `branch = "feat/migrate-v2-resume"`. Merge after https://github.com/bnb-chain/reth/pull/203 lands and is retagged (or change to point at the new tag).

## Test plan

- [ ] `cargo build --release`
- [ ] Run `reth-bsc db migrate-v2 --resume` on a half-migrated archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)