### PR TITLE
feat(miner): BidBlock blob-sidecar validation + version field (PR 8d-1)

### DIFF
--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -8,13 +8,20 @@
 //! non-empty blob sidecars depends on [`BscBlobTransactionSidecar`]'s encoding and needs its own
 //! vector before the blob path is relied upon.
 
+use crate::chainspec::BscChainSpec;
+use crate::consensus::eip4844::is_blob_eligible_block;
 use crate::node::primitives::BscBlobTransactionSidecar;
 use alloy_consensus::Header;
 use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_rlp::Encodable;
+use reth_chainspec::EthChainSpec;
 use reth_ethereum_primitives::TransactionSigned;
 use std::{fmt, vec::Vec};
+
+/// Sidecar version carrying EIP-7594 cell proofs (PeerDAS). BSC does not support it yet, so a
+/// BidBlock declaring it is rejected; legacy EIP-4844 blob proofs are version `0`.
+const BLOB_SIDECAR_VERSION_CELL_PROOF: u8 = 1;
 
 /// The builder-proposed block carried by [`BidBlockArgs`].
 ///
@@ -185,6 +192,118 @@ fn recover_signer(hash: B256, signature: &[u8]) -> Result<Address, BidBlockError
     Ok(Address::from_slice(&hashed[12..]))
 }
 
+/// Cheap blob-sidecar invariants for an admitted BidBlock (go-bsc `validateBidBlockBlobSidecars`).
+///
+/// Walks the user-tx region (`txs[..system_tx_start]`) and, for each EIP-4844 tx, requires the next
+/// sidecar in order to: exist, be a legacy (v0) proof sidecar, match the tx by hash and index, and
+/// keep the running blob count within the per-block max. There must be exactly one sidecar per blob
+/// tx and no trailing extras. KZG proof verification is deliberately *not* done here — only at final
+/// block insertion — matching go-bsc, which runs only these cheap checks at admission.
+pub fn validate_bid_block_blob_sidecars(
+    header: &Header,
+    txs: &[TransactionSigned],
+    sidecars: &[BscBlobTransactionSidecar],
+    system_tx_start: usize,
+    chain_spec: &BscChainSpec,
+) -> Result<(), BlobSidecarError> {
+    let blob_eligible = is_blob_eligible_block(chain_spec, header.number, header.timestamp);
+    let max_blob_count =
+        chain_spec.blob_params_at_timestamp(header.timestamp).map(|p| p.max_blob_count).unwrap_or(0);
+
+    let mut sidecar_index = 0usize;
+    let mut blob_count: u64 = 0;
+    for (tx_index, tx) in txs[..system_tx_start].iter().enumerate() {
+        if !tx.is_eip4844() {
+            continue;
+        }
+        if !blob_eligible {
+            return Err(BlobSidecarError::NotEligible { block_number: header.number });
+        }
+        if sidecar_index >= sidecars.len() {
+            return Err(BlobSidecarError::CountMismatch {
+                sidecars: sidecars.len(),
+                blob_txs_at_least: sidecar_index + 1,
+            });
+        }
+        let sidecar = &sidecars[sidecar_index];
+        if sidecar.version == BLOB_SIDECAR_VERSION_CELL_PROOF {
+            return Err(BlobSidecarError::CellProofUnsupported { tx_index });
+        }
+        if sidecar.tx_hash != *tx.hash() {
+            return Err(BlobSidecarError::TxHashMismatch { tx_index });
+        }
+        if sidecar.tx_index != tx_index as u64 {
+            return Err(BlobSidecarError::TxIndexMismatch {
+                tx_index,
+                sidecar_tx_index: sidecar.tx_index,
+            });
+        }
+        blob_count += sidecar.inner.blobs.len() as u64;
+        if blob_count > max_blob_count {
+            return Err(BlobSidecarError::TooManyBlobs { have: blob_count, permitted: max_blob_count });
+        }
+        sidecar_index += 1;
+    }
+    if sidecar_index != sidecars.len() {
+        return Err(BlobSidecarError::TrailingSidecars {
+            sidecars: sidecars.len(),
+            blob_txs: sidecar_index,
+        });
+    }
+    Ok(())
+}
+
+/// Why a BidBlock's blob sidecars are invalid (see [`validate_bid_block_blob_sidecars`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlobSidecarError {
+    /// A blob tx appears in a block where blobs are not allowed (BEP-657 eligibility).
+    NotEligible { block_number: u64 },
+    /// Fewer sidecars than blob txs.
+    CountMismatch { sidecars: usize, blob_txs_at_least: usize },
+    /// The sidecar for the blob tx at `tx_index` declares an unsupported cell-proof (v1) version.
+    CellProofUnsupported { tx_index: usize },
+    /// The sidecar's `tx_hash` does not match the blob tx at `tx_index`.
+    TxHashMismatch { tx_index: usize },
+    /// The sidecar's `tx_index` does not match the blob tx's position.
+    TxIndexMismatch { tx_index: usize, sidecar_tx_index: u64 },
+    /// The cumulative blob count exceeds the per-block maximum.
+    TooManyBlobs { have: u64, permitted: u64 },
+    /// More sidecars than blob txs (trailing extras).
+    TrailingSidecars { sidecars: usize, blob_txs: usize },
+}
+
+impl fmt::Display for BlobSidecarError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotEligible { block_number } => {
+                write!(f, "blob transactions not allowed in block {block_number}")
+            }
+            Self::CountMismatch { sidecars, blob_txs_at_least } => write!(
+                f,
+                "blob info mismatch: sidecars {sidecars}, blob txs at least {blob_txs_at_least}"
+            ),
+            Self::CellProofUnsupported { tx_index } => {
+                write!(f, "cell proof is not supported yet (blob tx {tx_index})")
+            }
+            Self::TxHashMismatch { tx_index } => {
+                write!(f, "sidecar TxHash mismatch with blob tx at index {tx_index}")
+            }
+            Self::TxIndexMismatch { tx_index, sidecar_tx_index } => write!(
+                f,
+                "sidecar TxIndex {sidecar_tx_index} mismatch with blob tx at index {tx_index}"
+            ),
+            Self::TooManyBlobs { have, permitted } => {
+                write!(f, "too many blobs in block: have {have}, permitted {permitted}")
+            }
+            Self::TrailingSidecars { sidecars, blob_txs } => {
+                write!(f, "blob info mismatch: sidecars {sidecars}, blob txs {blob_txs}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BlobSidecarError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,6 +435,7 @@ mod tests {
             ),
             tx_index: 3,
             tx_hash: b256!("0x2222222222222222222222222222222222222222222222222222222222222222"),
+            version: 0,
         };
         let block = BidBlock {
             header: vector_a_block().header,
@@ -326,6 +446,150 @@ mod tests {
         assert_eq!(
             block.hash(),
             b256!("0x020136e0d39a0a27c9597e89c56f77170b1d43e6b391c4852a2138936184d9c5"),
+        );
+    }
+
+    // ---- blob sidecar validation ----
+
+    use alloy_primitives::{Signature, TxKind};
+
+    /// A mainnet spec with Cancun active (blob params present, max 6); BSC Mendel stays inactive so
+    /// every block is blob-eligible.
+    fn blob_chain_spec() -> BscChainSpec {
+        use reth_chainspec::ChainSpecBuilder;
+        BscChainSpec::from(ChainSpecBuilder::mainnet().cancun_activated().build())
+    }
+
+    fn dummy_sig() -> Signature {
+        Signature::new(U256::from(1), U256::from(1), false)
+    }
+
+    fn legacy_tx(nonce: u64) -> TransactionSigned {
+        use alloy_consensus::TxLegacy;
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        TransactionSigned::new_unhashed(tx.into(), dummy_sig())
+    }
+
+    fn blob_tx(nonce: u64) -> TransactionSigned {
+        use alloy_consensus::TxEip4844;
+        let tx = TxEip4844 {
+            chain_id: 1,
+            nonce,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            access_list: Default::default(),
+            blob_versioned_hashes: vec![B256::ZERO],
+            max_fee_per_blob_gas: 1,
+            input: Bytes::new(),
+        };
+        TransactionSigned::new_unhashed(tx.into(), dummy_sig())
+    }
+
+    fn sidecar_for(tx: &TransactionSigned, tx_index: u64, version: u8, blobs: usize) -> BscBlobTransactionSidecar {
+        use alloy_consensus::BlobTransactionSidecar;
+        use alloy_eips::eip4844::{Blob, Bytes48};
+        BscBlobTransactionSidecar {
+            inner: BlobTransactionSidecar {
+                blobs: vec![Blob::default(); blobs],
+                commitments: vec![Bytes48::default(); blobs],
+                proofs: vec![Bytes48::default(); blobs],
+            },
+            block_number: 10,
+            block_hash: B256::ZERO,
+            tx_index,
+            tx_hash: *tx.hash(),
+            version,
+        }
+    }
+
+    fn blob_header() -> Header {
+        Header { number: 10, timestamp: 1, ..Default::default() }
+    }
+
+    #[test]
+    fn blob_validation_accepts_no_blob_txs() {
+        let spec = blob_chain_spec();
+        let txs = vec![legacy_tx(0)];
+        assert_eq!(
+            validate_bid_block_blob_sidecars(&blob_header(), &txs, &[], 1, &spec),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn blob_validation_rejects_trailing_sidecars() {
+        let spec = blob_chain_spec();
+        let txs = vec![legacy_tx(0)];
+        let orphan = sidecar_for(&blob_tx(9), 0, 0, 1);
+        assert_eq!(
+            validate_bid_block_blob_sidecars(&blob_header(), &txs, &[orphan], 1, &spec),
+            Err(BlobSidecarError::TrailingSidecars { sidecars: 1, blob_txs: 0 })
+        );
+    }
+
+    #[test]
+    fn blob_validation_accepts_matching_v0() {
+        let spec = blob_chain_spec();
+        let tx = blob_tx(0);
+        let sidecar = sidecar_for(&tx, 0, 0, 1);
+        assert_eq!(
+            validate_bid_block_blob_sidecars(&blob_header(), &[tx], &[sidecar], 1, &spec),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn blob_validation_rejects_cell_proof_v1() {
+        let spec = blob_chain_spec();
+        let tx = blob_tx(0);
+        let sidecar = sidecar_for(&tx, 0, 1, 1);
+        assert_eq!(
+            validate_bid_block_blob_sidecars(&blob_header(), &[tx], &[sidecar], 1, &spec),
+            Err(BlobSidecarError::CellProofUnsupported { tx_index: 0 })
+        );
+    }
+
+    #[test]
+    fn blob_validation_rejects_missing_sidecar() {
+        let spec = blob_chain_spec();
+        let tx = blob_tx(0);
+        assert_eq!(
+            validate_bid_block_blob_sidecars(&blob_header(), &[tx], &[], 1, &spec),
+            Err(BlobSidecarError::CountMismatch { sidecars: 0, blob_txs_at_least: 1 })
+        );
+    }
+
+    #[test]
+    fn blob_validation_rejects_txhash_mismatch() {
+        let spec = blob_chain_spec();
+        let tx = blob_tx(0);
+        // Sidecar built for a different tx → tx_hash will not match.
+        let sidecar = sidecar_for(&blob_tx(99), 0, 0, 1);
+        assert_eq!(
+            validate_bid_block_blob_sidecars(&blob_header(), &[tx], &[sidecar], 1, &spec),
+            Err(BlobSidecarError::TxHashMismatch { tx_index: 0 })
+        );
+    }
+
+    #[test]
+    fn blob_validation_rejects_too_many_blobs() {
+        let spec = blob_chain_spec(); // Cancun max = 6
+        let tx = blob_tx(0);
+        let sidecar = sidecar_for(&tx, 0, 0, 7);
+        assert_eq!(
+            validate_bid_block_blob_sidecars(&blob_header(), &[tx], &[sidecar], 1, &spec),
+            Err(BlobSidecarError::TooManyBlobs { have: 7, permitted: 6 })
         );
     }
 }

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -937,6 +937,7 @@ where
                         block_hash: B256::ZERO, // Will be set when block is sealed
                         tx_index: index as u64,
                         tx_hash,
+                        version: 0,
                     };
                     self.blob_sidecars.push(bsc_sidecar);
                 }

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -966,6 +966,7 @@ where
                     block_hash: sealed_block.hash(),
                     tx_index: u64::try_from(index).unwrap_or(u64::MAX),
                     tx_hash: *tx.hash(),
+                    version: 0,
                 };
                 blob_sidecars.push(bsc_blob_tx_sidecar);
             }

--- a/src/node/primitives.rs
+++ b/src/node/primitives.rs
@@ -34,6 +34,11 @@ pub struct BscBlobTransactionSidecar {
     pub block_hash: B256,
     pub tx_index: u64,
     pub tx_hash: B256,
+    /// Sidecar proof version: `0` = legacy EIP-4844 blob proofs, `1` = EIP-7594 cell proofs.
+    /// Mirrors go-bsc `BlobTxSidecar.Version`, which is tagged `rlp:"-"` — excluded from the RLP
+    /// encoding (and therefore from the BidBlock hash) and carried only on the JSON wire.
+    #[serde(default)]
+    pub version: u8,
 }
 
 impl Encodable for BscBlobTransactionSidecar {
@@ -99,7 +104,8 @@ impl Decodable for BscBlobTransactionSidecar {
         if consumed != header.payload_length {
             return Err(alloy_rlp::Error::UnexpectedLength);
         }
-        Ok(Self { inner, block_number, block_hash, tx_index, tx_hash })
+        // `version` is rlp:"-" in go-bsc: not present in the RLP, defaults to 0 (legacy proofs).
+        Ok(Self { inner, block_number, block_hash, tx_index, tx_hash, version: 0 })
     }
 }
 
@@ -623,6 +629,7 @@ mod tests {
             block_hash: B256::repeat_byte(0xab),
             tx_index: 7,
             tx_hash: B256::repeat_byte(0xcd),
+            version: 0,
         };
 
         // Encode

--- a/src/node/storage.rs
+++ b/src/node/storage.rs
@@ -211,7 +211,14 @@ fn read_sidecars_from_blob_store(
                     "blob_store_read: sidecar has EMPTY fields!"
                 );
             }
-            Some(BscBlobTransactionSidecar { inner, block_number, block_hash, tx_index, tx_hash })
+            Some(BscBlobTransactionSidecar {
+                inner,
+                block_number,
+                block_hash,
+                tx_index,
+                tx_hash,
+                version: 0,
+            })
         })
         .collect();
 


### PR DESCRIPTION
Part of the BEP-675 builder-proposed-block track (PR 8d-1). Ports go-bsc `validateBidBlockBlobSidecars` (`miner/bid_simulator.go`).

For each EIP-4844 tx in the user-tx region (`txs[..system_tx_start]`), the next sidecar in order must: exist, be a legacy v0 proof sidecar (cell-proof v1 rejected — BSC doesn't support PeerDAS yet), match the tx by hash and index, and keep the running blob count within the per-block max. Exactly one sidecar per blob tx, no trailing extras. KZG proof verification is deliberately deferred to final block insertion — matching go-bsc, which runs only these cheap checks at admission.

Adds the sidecar `version` field to `BscBlobTransactionSidecar`, mirroring go-bsc `BlobTxSidecar.Version`: tagged `rlp:"-"`, so it's excluded from RLP and the BidBlock hash (verified — the #389 blob hash vector still passes) and carried only on the JSON wire (serde default 0). The other three construction sites set v0.

7 tests cover the accept path, no-blob path, and each rejection (trailing extras, v1 cell proof, missing sidecar, tx-hash mismatch, too-many-blobs).

This is the self-contained piece of `preSealVerifyBidBlock`. The assembled `pre_seal_verify_bid_block` (coinbase=validator, gas-limit, `VerifyUnsealedHeader` mapping, `block_time_upper_check`, gasFee bounds + this blob check + `verify_bid_block_system_txs`) is the next slice; the build/seal integration follows.