### PR TITLE
feat(miner): BidBlock intake queue + admission enqueue (PR 8d-2a)

### DIFF
--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -866,4 +866,23 @@ mod tests {
             Err(PreSealVerifyError::EmptyGasFee)
         );
     }
+
+    #[test]
+    fn bid_block_intake_queue_is_fifo() {
+        // Drain any residue first (the queue is a process-global; tests run single-threaded).
+        while crate::shared::pop_bid_block_package().is_some() {}
+
+        let first = decoded_block(valid_bid_header(Address::ZERO, 30_000_000), vec![], vec![]);
+        let mut second_header = valid_bid_header(Address::ZERO, 30_000_000);
+        second_header.number = 2;
+        let second = decoded_block(second_header, vec![], vec![]);
+
+        crate::shared::push_bid_block_package(first);
+        crate::shared::push_bid_block_package(second);
+        assert_eq!(crate::shared::bid_block_queue_len(), 2);
+
+        assert_eq!(crate::shared::pop_bid_block_package().unwrap().block_number(), 1);
+        assert_eq!(crate::shared::pop_bid_block_package().unwrap().block_number(), 2);
+        assert!(crate::shared::pop_bid_block_package().is_none());
+    }
 }

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -375,12 +375,17 @@ impl MevApiImpl {
             ));
         }
 
-        // TODO(8d): simulator-backed tail of Miner.SendBidBlock — recordBidBlockBuilder,
-        // CheckPending, bid timing, ToDecodedBidBlock + parlia extra/blind-sign,
-        // preSealVerifyBidBlock (header/gasLimit/gasFee/blob + system-tx verification) and the
-        // bid-simulator enqueue.
+        // Decode and hand to the miner via the global intake queue. The simulator-backed tail of
+        // Miner.SendBidBlock — pre-seal verification, execution, selection against the local block,
+        // and revoke-on-invalid — runs miner-side when the block is popped (8d-2b), matching the
+        // legacy SendBid layering where the RPC enqueues and the miner verifies/executes.
+        let decoded = args
+            .to_decoded_bid_block(builder)
+            .map_err(|e| Self::invalid_bid(format!("failed to decode bid block: {e}")))?;
+        crate::shared::push_bid_block_package(decoded);
+
         tracing::info!(
-            "BidBlock admitted: block={}, builder={builder}, bidHash={bid_hash:?} (build integration pending)",
+            "BidBlock queued: block={}, builder={builder}, bidHash={bid_hash:?}",
             args.bid_block.header.number
         );
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -112,6 +112,13 @@ static BID_BLOCK_PERMISSION_MANAGER: OnceLock<
     Arc<crate::node::miner::bid_block_permission::BidBlockPermissionManager>,
 > = OnceLock::new();
 
+/// Global intake queue for admitted BEP-675 BidBlocks. `mev_sendBidBlock` pushes a decoded block
+/// here after admission; the miner pops it to pre-seal verify, execute, and select against the
+/// local block (mirrors the legacy [`BID_PACKAGE_QUEUE`] SendBid intake).
+static BID_BLOCK_QUEUE: OnceLock<
+    Arc<Mutex<VecDeque<crate::node::miner::bid_block::DecodedBidBlock>>>,
+> = OnceLock::new();
+
 /// Global network handle to interact with P2P (reth).
 static NETWORK_HANDLE: OnceLock<NetworkHandle<BscNetworkPrimitives>> = OnceLock::new();
 
@@ -481,6 +488,26 @@ pub fn get_bid_block_permission_manager(
             Arc::new(crate::node::miner::bid_block_permission::BidBlockPermissionManager::new())
         })
         .clone()
+}
+
+fn bid_block_queue() -> &'static Arc<Mutex<VecDeque<crate::node::miner::bid_block::DecodedBidBlock>>>
+{
+    BID_BLOCK_QUEUE.get_or_init(|| Arc::new(Mutex::new(VecDeque::new())))
+}
+
+/// Push an admitted BidBlock onto the global intake queue for the miner to process.
+pub fn push_bid_block_package(decoded: crate::node::miner::bid_block::DecodedBidBlock) {
+    bid_block_queue().lock().push_back(decoded);
+}
+
+/// Pop the next admitted BidBlock from the global intake queue (FIFO).
+pub fn pop_bid_block_package() -> Option<crate::node::miner::bid_block::DecodedBidBlock> {
+    bid_block_queue().lock().pop_front()
+}
+
+/// Number of admitted BidBlocks waiting in the global intake queue.
+pub fn bid_block_queue_len() -> usize {
+    bid_block_queue().lock().len()
 }
 
 /// Store the reth `NetworkHandle` globally for dynamic peer actions.


### PR DESCRIPTION
Part of the BEP-675 builder-proposed-block track (PR 8d-2a) — the first cut of the miner build integration.

Mirroring go-bsc's two-phase BidBlock flow (admission → enqueue, then a separate build cycle that selects/builds/seals), this wires the merged `mev_sendBidBlock` admission path into a process-global **BidBlock intake queue** in `shared.rs` (`push_bid_block_package` / `pop_bid_block_package` / `bid_block_queue_len`), analogous to the legacy SendBid `BID_PACKAGE_QUEUE`.

`admit_bid_block` now decodes the admitted block and enqueues a `DecodedBidBlock` instead of dropping it. Pre-seal verification (`pre_seal_verify_bid_block`, 8d-1b), execution (reusing `bid_simulate`), selection against the local block (`pick_best_payload_and_finalize`), and revoke-on-invalid all run **miner-side when the block is popped** — that's 8d-2b. This matches reth-bsc's existing SendBid layering, where the RPC enqueues and the miner verifies/executes.

The mapping confirmed all downstream machinery already exists and is reusable: validator tx-signing (`sign_system_transaction`), the execute-ordered-block path, fee-based selection, `finalize_new_header` seal, and block submission. So 8d-2 is wiring, not new infrastructure.

Test: FIFO round-trip of the intake queue.

Next — **8d-2b**: the miner-side consumer loop (pop → `pre_seal_verify_bid_block` → bind-sign system txs via `sign_system_transaction` → execute via the `bid_simulate` path → store best-per-parent → select vs local → seal → submit, with revoke-on-invalid).