### PR TITLE
test(ef-tests): BidBlock execution harness scaffold (PR 8d-2b-harness)

### DIFF
--- a/testing/bsc-ef-tests/tests/bid_block_harness.rs
+++ b/testing/bsc-ef-tests/tests/bid_block_harness.rs
@@ -1,0 +1,34 @@
+//! Integration harness for BEP-675 BidBlock execution.
+//!
+//! A BidBlock is a complete builder-proposed block that the validator must re-execute (in
+//! verify-mode, with the trailing system txs supplied to the executor), blind-sign, and seal while
+//! preserving the builder's exact block context. None of that is unit-testable — correctness is
+//! byte-exact (the re-executed state root must match the builder's), so it needs a real execution
+//! environment.
+//!
+//! This harness builds that environment on top of the same primitives the EF blockchain-test runner
+//! uses (`create_test_provider_factory_with_chain_spec` + genesis init + a state provider), but with
+//! the BSC chain spec / genesis so the system-contract execution path is exercised.
+//!
+//! Step 1 (this file) is the scaffold: stand up the provider, initialize the BSC genesis, and
+//! confirm a state provider opens at the expected genesis. The trusted local build,
+//! `simulate_bid_block`, and the round-trip assertion (build a block → repackage as a DecodedBidBlock
+//! → simulate → assert identical hash/state root) build on this foundation.
+
+use reth_bsc::chainspec::bsc::bsc_mainnet;
+use reth_chainspec::{ChainSpec, EthChainSpec};
+use reth_db_common::init::init_genesis;
+use reth_provider::test_utils::create_test_provider_factory_with_chain_spec;
+use std::sync::Arc;
+
+/// Stand up a fresh in-memory provider seeded with the BSC mainnet genesis.
+#[test]
+fn harness_initializes_bsc_genesis() {
+    let chain_spec: Arc<ChainSpec> = Arc::new(bsc_mainnet());
+    let factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
+
+    // init_genesis writes the genesis header + full alloc (incl. BSC system contracts) and returns
+    // the genesis hash; it must match the chain spec's own genesis hash.
+    let genesis_hash = init_genesis(&factory).expect("init BSC genesis");
+    assert_eq!(genesis_hash, chain_spec.genesis_hash());
+}


### PR DESCRIPTION
First step of the BEP-675 BidBlock execution harness (the integration test that gates the byte-exact executor core).

A BidBlock must be re-executed in verify-mode (system txs supplied to the executor), blind-signed, and sealed while preserving the builder's exact block context. That correctness is byte-exact (re-executed state root must match the builder's) and not unit-testable — it needs a real execution environment.

This scaffold stands one up in `testing/bsc-ef-tests/tests/`, reusing the EF blockchain-test primitives (`create_test_provider_factory_with_chain_spec` + `init_genesis` + state provider) but with the **BSC mainnet** chain spec / genesis so the system-contract path is exercised. It confirms the genesis initializes and the hash matches.

Test-only, no production change.

**Builds on this foundation (co-developed, since the round-trip assertion is circular with the executor):**
1. trusted local block build in-test (the reference)
2. `simulate_bid_block` (verify-mode execution + difficulty-preserving finalize) — made `pub`
3. round-trip assertion: repackage the locally-built block as a `DecodedBidBlock`, run `simulate_bid_block`, assert identical block hash + state root