### PR TITLE
test(ef-tests): signable BSC test genesis for BidBlock harness (PR 8d-2b-genesis)

### DIFF
--- a/testing/bsc-ef-tests/tests/bid_block_harness.rs
+++ b/testing/bsc-ef-tests/tests/bid_block_harness.rs
@@ -15,11 +15,60 @@
 //! `simulate_bid_block`, and the round-trip assertion (build a block → repackage as a DecodedBidBlock
 //! → simulate → assert identical hash/state root) build on this foundation.
 
-use reth_bsc::chainspec::bsc::bsc_mainnet;
-use reth_chainspec::{ChainSpec, EthChainSpec};
+use alloy_primitives::{address, hex};
+use reth_bsc::chainspec::{bsc::bsc_mainnet, BscChainSpec};
+use reth_bsc::consensus::parlia::Parlia;
+use reth_chainspec::{
+    make_genesis_header, BaseFeeParams, BaseFeeParamsKind, Chain, ChainHardforks, ChainSpec,
+    EthChainSpec, EthereumHardfork, ForkCondition, Hardfork, NamedChain,
+};
 use reth_db_common::init::init_genesis;
+use reth_primitives_traits::SealedHeader;
 use reth_provider::test_utils::create_test_provider_factory_with_chain_spec;
 use std::sync::Arc;
+
+/// Address of Anvil dev key 0 (`ac0974…ff80`) — the validator whose key the harness controls, so it
+/// can build/seal blocks. The same key the miner tests initialize the global signer with.
+const TEST_VALIDATOR: alloy_primitives::Address =
+    address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+/// A **signable** BSC test chain spec: a genesis whose sole validator is [`TEST_VALIDATOR`], so the
+/// harness can build and seal blocks as that validator (unlike `bsc_mainnet`, whose validator keys
+/// we don't hold). Minimal hardforks (Frontier only) keep the validator encoding pre-Luban — a
+/// plain 32-byte vanity + 20-byte address + 65-byte seal — so genesis parsing is trivial.
+fn signable_test_chain_spec() -> Arc<BscChainSpec> {
+    let validator = hex::encode(TEST_VALIDATOR);
+    // extraData = vanity(32) ++ validator(20) ++ seal(65), all but the address zeroed.
+    let extra = format!("0x{}{}{}", "00".repeat(32), validator, "00".repeat(65));
+    let genesis_json = format!(
+        r#"{{
+            "config": {{ "chainId": 714 }},
+            "gasLimit": "0x2625a00",
+            "timestamp": "0x0",
+            "extraData": "{extra}",
+            "alloc": {{ "0x{validator}": {{ "balance": "0x21e19e0c9bab2400000" }} }}
+        }}"#
+    );
+    let genesis: alloy_genesis::Genesis =
+        serde_json::from_str(&genesis_json).expect("deserialize test genesis");
+
+    let hardforks =
+        ChainHardforks::new(vec![(EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0))]);
+    let genesis_header = {
+        let header = make_genesis_header(&genesis, &hardforks);
+        let hash = header.hash_slow();
+        SealedHeader::new(header, hash)
+    };
+    let spec = ChainSpec {
+        chain: Chain::from_named(NamedChain::BinanceSmartChain),
+        genesis,
+        hardforks,
+        base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::new(1, 1)),
+        genesis_header,
+        ..Default::default()
+    };
+    Arc::new(BscChainSpec::from(spec))
+}
 
 /// Stand up a fresh in-memory provider seeded with the BSC mainnet genesis.
 #[test]
@@ -31,4 +80,18 @@ fn harness_initializes_bsc_genesis() {
     // the genesis hash; it must match the chain spec's own genesis hash.
     let genesis_hash = init_genesis(&factory).expect("init BSC genesis");
     assert_eq!(genesis_hash, chain_spec.genesis_hash());
+}
+
+/// The signable test genesis parses to a snapshot whose validator is the key we control — the
+/// prerequisite for building/sealing blocks in the harness.
+#[test]
+fn signable_genesis_snapshot_has_known_validator() {
+    let chain_spec = signable_test_chain_spec();
+    let parlia = Parlia::new(chain_spec.clone(), 200);
+
+    // Genesis (block 0) is an epoch boundary, so its extra-data carries the validator set.
+    let validators = parlia
+        .parse_validators_from_header(chain_spec.genesis_header(), 200)
+        .expect("parse genesis validators");
+    assert_eq!(validators.consensus_addrs, vec![TEST_VALIDATOR]);
 }


### PR DESCRIPTION
Next step of the BEP-675 BidBlock execution harness.

Building a reference BidBlock requires **signing** its system txs as the genesis validator — but we don't hold `bsc_mainnet`'s (or rialto's) validator keys, and `genesis_local.json` is gitignored. So the harness needs a **signable** genesis: one whose validator is a key we control.

This adds `signable_test_chain_spec()` — a minimal BSC chain spec whose sole genesis validator is the Anvil dev key 0 (`0xf39Fd6…`, the same key the miner tests init the global signer with). Minimal hardforks (Frontier only) keep the validator encoding pre-Luban (32-byte vanity + 20-byte address + 65-byte seal), so genesis parsing is trivial. A test confirms the genesis parses to a snapshot containing exactly that validator.

The round-trip only checks **execution determinism** (build vs simulate produce the same state root), so this genesis doesn't need real system-contract bytecode — system-tx calls to empty accounts succeed as value transfers, and both build and simulate execute them identically.

Test-only, no production change. Next: drive `BscEvmConfig`'s builder on this genesis to produce the reference block (the trusted local build).