### PR TITLE
fix(network): guard empty buffer in UpgradeStatusExtension::decode

### DIFF
--- a/src/node/network/upgrade_status.rs
+++ b/src/node/network/upgrade_status.rs
@@ -67,6 +67,11 @@ impl Encodable for UpgradeStatusExtension {
 
 impl Decodable for UpgradeStatusExtension {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        // The buffer is peer-controlled during the handshake; guard before indexing so a
+        // truncated/empty message returns an error instead of panicking the connection task.
+        if buf.is_empty() {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
         // if got empty extension, return false
         if buf[0] == 0x80 {
             buf.advance(1);
@@ -104,5 +109,13 @@ mod tests {
             UpgradeStatus { extension: UpgradeStatusExtension { disable_peer_tx_broadcast: false } }.encode(&mut enc);
             println!("enc: {:x?}", enc.freeze());
         }
+    }
+
+    #[test]
+    fn test_decode_empty_extension_buffer_is_error_not_panic() {
+        // A peer could send a truncated handshake message; decoding an empty buffer must
+        // return an error rather than panic on indexing.
+        let mut empty: &[u8] = &[];
+        assert!(UpgradeStatusExtension::decode(&mut empty).is_err());
     }
 }


### PR DESCRIPTION
## Summary

The BSC handshake decodes a peer-controlled buffer into `UpgradeStatusExtension`, but `UpgradeStatusExtension::decode` (`src/node/network/upgrade_status.rs`) indexed `buf[0]` without an emptiness check. A truncated or empty `UpgradeStatus` message therefore panics the connection/handshake task with an index-out-of-bounds — and the buffer comes straight off the wire during the handshake, so **any peer can trigger it**.

The sibling `BscCapPacket::decode` already guards `buf.is_empty()` and returns `alloy_rlp::Error::InputTooShort`; this applies the same guard here.

Added a regression test asserting that decoding an empty buffer returns `Err` instead of panicking.
