### PR TITLE
fix(parlia): don't panic on malformed vote signature in attestation assembly

### DIFF
--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -873,10 +873,14 @@ where
             return Ok(()); // If not enough unique votes, do not append attestation
         }
         // Aggregate signatures
+        // Vote signatures come from the peer-fed vote pool and are not BLS-verified at ingest, so
+        // a spoofed/malformed signature must not panic block production here. Surface it as a
+        // consensus error; the caller logs and continues without the attestation.
         let sigs: Vec<blst::min_pk::Signature> = ordered_unique
             .iter()
-            .map(|(_, _, sig)| blst::min_pk::Signature::from_bytes(sig.as_slice()).unwrap())
-            .collect();
+            .map(|(_, _, sig)| blst::min_pk::Signature::from_bytes(sig.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| ParliaConsensusError::AggregateSignatureError)?;
         let sigs_ref: Vec<&blst::min_pk::Signature> = sigs.iter().collect();
         let aggregate = blst::min_pk::AggregateSignature::aggregate(&sigs_ref, false)
             .map_err(|_| ParliaConsensusError::AggregateSignatureError)?;


### PR DESCRIPTION
## Summary

`Parlia::assemble_vote_attestation` (`src/consensus/parlia/consensus.rs`) deserializes pooled vote signatures with `blst::min_pk::Signature::from_bytes(..).unwrap()`. Votes enter the pool from peers (`node/network/votes.rs` -> vote pool) **without BLS signature verification at ingest**, and vote addresses are public. A peer can therefore broadcast a vote carrying a known validator's `vote_address` plus a malformed 96-byte signature; `from_bytes` rejects garbage / non-subgroup points with `Err`, so the `.unwrap()` panics a **block-producing** node during attestation assembly.

(Block *import* verifies attestation signatures fully — `pre_execution.rs::verify_vote_attestation` — so this is a producer-side liveness issue, not a validity hole.)

## Fix

Collect into a `Result` and propagate `ParliaConsensusError::AggregateSignatureError` instead of unwrapping. The caller (`node/miner/util.rs`) already handles the error gracefully:

```
tracing::warn!(target: "bsc::miner", error = %e, "Failed to assemble vote attestation, continuing without it");
```

so the validator keeps producing blocks (without that one attestation) instead of crashing.

A more complete defense is to verify vote signatures at pool ingest; this PR is the minimal no-panic fix.
