### PR TITLE
fix(miner): use saturating_sub in bid gas-limit check

### DIFF
--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -395,7 +395,9 @@ where
             parent_header.number + 1,
             attributes.timestamp,
         );
-        if bid_runtime.bid.gas_used > gas_limit - system_txs_gas - PAY_BID_TX_GAS_LIMIT {
+        if bid_runtime.bid.gas_used
+            > gas_limit.saturating_sub(system_txs_gas).saturating_sub(PAY_BID_TX_GAS_LIMIT)
+        {
             debug!("bidSimulator: gas limit exceeded, ignore");
             return;
         }


### PR DESCRIPTION
## Summary

The bid gas-limit guard in `BidSimulator` (`src/node/miner/bid_simulator.rs`) computed `gas_limit - system_txs_gas - PAY_BID_TX_GAS_LIMIT` with plain `u64` subtraction. The sibling check ~80 lines below already uses `saturating_sub` for the same quantity, so this is an inconsistency.

If the reserved system-tx gas estimate plus `PAY_BID_TX_GAS_LIMIT` exceeds the block gas limit, the plain subtraction underflows — panicking in debug builds, and wrapping to a near-`u64::MAX` value in release, which inverts the check so the "gas limit exceeded" guard never fires. Mainnet gas limits are large so the trigger probability is low, but it's an unguarded arithmetic op on the MEV bid path fed by external builders.

Fix: use `saturating_sub`, matching the neighbouring code.
