### PR TITLE
test(ef-tests): BidBlock execution-gate round-trip (PR 8d-2b-execgate)

### DIFF
--- a/testing/bsc-ef-tests/tests/bid_block_harness.rs
+++ b/testing/bsc-ef-tests/tests/bid_block_harness.rs
@@ -69,23 +69,74 @@ fn genesis_snapshot(chain_spec: Arc<BscChainSpec>) -> Snapshot {
 /// we don't hold). Minimal hardforks (Frontier only) keep the validator encoding pre-Luban — a
 /// plain 32-byte vanity + 20-byte address + 65-byte seal — so genesis parsing is trivial.
 fn signable_test_chain_spec() -> Arc<BscChainSpec> {
+    build_signable_chain_spec(vec![])
+}
+
+/// Signable test spec with Kepler active (timestamp 0). Post-Kepler skips the `distribute_to_system`
+/// system-reward tx, so a normal block's trailing system-tx region is exactly `[deposit]` — what the
+/// BidBlock validation expects. Kepler activates independently; Luban/Lorentz/London stay off, so
+/// the validator encoding and header format stay simple.
+fn kepler_signable_chain_spec() -> Arc<BscChainSpec> {
+    use reth_bsc::hardforks::bsc::BscHardfork;
+    // Kepler requires London active (is_kepler_active_at_timestamp gates on is_london_active_at_block).
+    // genesis baseFeePerGas=0 keeps the base fee 0 for all blocks (0 * adjustment = 0), so a
+    // gas_price=1 user tx still pays a fee — which is what funds the validator deposit.
     let validator = hex::encode(TEST_VALIDATOR);
-    // extraData = vanity(32) ++ validator(20) ++ seal(65), all but the address zeroed.
-    let extra = format!("0x{}{}{}", "00".repeat(32), validator, "00".repeat(65));
+    let extra_data = format!("0x{}{}{}", "00".repeat(32), validator, "00".repeat(65));
     let genesis_json = format!(
         r#"{{
             "config": {{ "chainId": 714 }},
             "gasLimit": "0x2625a00",
             "timestamp": "0x0",
-            "extraData": "{extra}",
+            "baseFeePerGas": "0x0",
+            "extraData": "{extra_data}",
+            "alloc": {{ "0x{validator}": {{ "balance": "0x21e19e0c9bab2400000" }} }}
+        }}"#
+    );
+    let genesis: alloy_genesis::Genesis =
+        serde_json::from_str(&genesis_json).expect("deserialize kepler genesis");
+    let hardforks = ChainHardforks::new(vec![
+        (EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::London.boxed(), ForkCondition::Block(0)),
+        (BscHardfork::Kepler.boxed(), ForkCondition::Timestamp(0)),
+    ]);
+    let genesis_header = {
+        let header = make_genesis_header(&genesis, &hardforks);
+        let hash = header.hash_slow();
+        SealedHeader::new(header, hash)
+    };
+    let spec = ChainSpec {
+        chain: Chain::from_named(NamedChain::BinanceSmartChain),
+        genesis,
+        hardforks,
+        base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::new(1, 1)),
+        genesis_header,
+        ..Default::default()
+    };
+    Arc::new(BscChainSpec::from(spec))
+}
+
+/// Build a signable test chain spec (sole genesis validator = [`TEST_VALIDATOR`], pre-Luban 20-byte
+/// encoding) with `extra` hardforks beyond Frontier@0.
+fn build_signable_chain_spec(extra: Vec<(Box<dyn Hardfork>, ForkCondition)>) -> Arc<BscChainSpec> {
+    let validator = hex::encode(TEST_VALIDATOR);
+    // extraData = vanity(32) ++ validator(20) ++ seal(65), all but the address zeroed.
+    let extra_data = format!("0x{}{}{}", "00".repeat(32), validator, "00".repeat(65));
+    let genesis_json = format!(
+        r#"{{
+            "config": {{ "chainId": 714 }},
+            "gasLimit": "0x2625a00",
+            "timestamp": "0x0",
+            "extraData": "{extra_data}",
             "alloc": {{ "0x{validator}": {{ "balance": "0x21e19e0c9bab2400000" }} }}
         }}"#
     );
     let genesis: alloy_genesis::Genesis =
         serde_json::from_str(&genesis_json).expect("deserialize test genesis");
 
-    let hardforks =
-        ChainHardforks::new(vec![(EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0))]);
+    let mut forks = vec![(EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0))];
+    forks.extend(extra);
+    let hardforks = ChainHardforks::new(forks);
     let genesis_header = {
         let header = make_genesis_header(&genesis, &hardforks);
         let hash = header.hash_slow();
@@ -149,12 +200,36 @@ fn execution_environment_is_wired() {
     );
 }
 
-/// Publish env globals (snapshot provider + signer), idempotent across tests.
+/// Shared, accumulating mock header provider, published once to the global header reader. Tests
+/// register their headers (genesis + built blocks) into it; the global reader is `OnceLock`-once
+/// (can't be per-test), so a single accumulating provider lets multiple chain specs / factories
+/// coexist across tests in one process.
+fn shared_header_provider() -> Arc<reth_provider::test_utils::MockEthProvider> {
+    static P: std::sync::OnceLock<Arc<reth_provider::test_utils::MockEthProvider>> =
+        std::sync::OnceLock::new();
+    P.get_or_init(|| {
+        let m = Arc::new(reth_provider::test_utils::MockEthProvider::default());
+        let _ = reth_bsc::shared::set_header_provider(m.clone());
+        m
+    })
+    .clone()
+}
+
+/// Publish env globals — accumulate the genesis snapshot + header (so multiple chain specs coexist
+/// across tests sharing the process-global providers) and init the validator signer.
 fn publish_env(chain_spec: Arc<BscChainSpec>) {
-    let provider = Arc::new(MockSnapshotProvider::default());
-    provider.insert(genesis_snapshot(chain_spec));
-    let _ = reth_bsc::shared::set_snapshot_provider(provider);
+    let snap = genesis_snapshot(chain_spec.clone());
+    match reth_bsc::shared::get_snapshot_provider() {
+        Some(p) => p.insert(snap),
+        None => {
+            let p = Arc::new(MockSnapshotProvider::default());
+            p.insert(snap);
+            let _ = reth_bsc::shared::set_snapshot_provider(p);
+        }
+    }
     let _ = init_global_signer(TEST_VALIDATOR_KEY);
+    shared_header_provider()
+        .add_header(chain_spec.genesis_hash(), chain_spec.genesis_header().clone());
 }
 
 /// Trusted local build: drive `BscEvmConfig`'s builder to produce block 1 on the signable genesis.
@@ -172,7 +247,6 @@ fn trusted_local_build_produces_block() {
     init_genesis(&factory).expect("init genesis");
     publish_env(chain_spec.clone());
     // BSC pre/post-execution looks the parent header up via the global header reader.
-    let _ = reth_bsc::shared::set_header_provider(Arc::new(factory.clone()));
 
     let parent = SealedHeader::new(chain_spec.genesis_header().clone(), chain_spec.genesis_hash());
     let provider = factory.database_provider_rw().expect("rw provider");
@@ -242,7 +316,6 @@ fn round_trip_build_finalize_reexecute_agree() {
     let factory = create_test_provider_factory_with_chain_spec(Arc::new(chain_spec.inner.clone()));
     init_genesis(&factory).expect("init genesis");
     publish_env(chain_spec.clone());
-    let _ = reth_bsc::shared::set_header_provider(Arc::new(factory.clone()));
 
     let parent = SealedHeader::new(chain_spec.genesis_header().clone(), chain_spec.genesis_hash());
     let snap = genesis_snapshot(chain_spec.clone());
@@ -330,5 +403,189 @@ fn round_trip_build_finalize_reexecute_agree() {
     .expect("compute state root");
 
     // Builder path and executor path must agree on the post-state root.
+    assert_eq!(computed_root, reference_root);
+}
+
+/// Full execution gate: with a real block-1→block-2 chain (Kepler active), build block 2 with a
+/// fee-paying user tx (validator generates the deposit), repackage it as a BidBlock with the
+/// deposit *unsigned*, run `simulate_bid_block` (which re-signs it), execute the sealed result, and
+/// assert the state root equals the reference build. This is the byte-exact verify-mode proof.
+#[test]
+fn execution_gate_round_trip() {
+    use alloy_consensus::TxLegacy;
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Signature, TxKind};
+    use reth_bsc::consensus::parlia::util::calculate_difficulty;
+    use reth_bsc::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes};
+    use reth_bsc::node::miner::bid_block::{simulate_bid_block, BidBlock, BidBlockArgs};
+    use reth_bsc::node::miner::signer::sign_system_transaction;
+    use reth_bsc::node::miner::util::finalize_new_header;
+    use reth_bsc::node::BscNode;
+    use reth_ethereum_primitives::TransactionSigned;
+    use reth_evm::execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionOutput, Executor};
+    use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
+    use reth_primitives_traits::{RecoveredBlock, SignerRecoverable};
+    use reth_provider::test_utils::create_test_provider_factory_with_node_types;
+    use reth_provider::{
+        BlockWriter, DBProvider, DatabaseProviderFactory, ExecutionOutcome, OriginalValuesKnown,
+        StateWriteConfig, StateWriter, StaticFileProviderFactory, StaticFileWriter,
+    };
+    use reth_revm::{database::StateProviderDatabase, db::State};
+    use reth_trie::{HashedPostState, KeccakKeyHasher, StateRoot};
+    use reth_trie_db::{
+        DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory, LegacyKeyAdapter,
+    };
+
+    let chain_spec = kepler_signable_chain_spec();
+    let factory = create_test_provider_factory_with_node_types::<BscNode>(chain_spec.clone());
+    init_genesis(&factory).expect("init genesis");
+    publish_env(chain_spec.clone());
+
+    let parlia = Arc::new(Parlia::new(chain_spec.clone(), 200));
+    let genesis = SealedHeader::new(chain_spec.genesis_header().clone(), chain_spec.genesis_hash());
+    let genesis_snap = genesis_snapshot(chain_spec.clone());
+    let snapshot_provider =
+        reth_bsc::shared::get_snapshot_provider().cloned().expect("snapshot provider");
+
+    let attrs = |ts: u64, diff: alloy_primitives::U256, gas_limit: u64| BscNextBlockEnvAttributes {
+        inner: NextBlockEnvAttributes {
+            timestamp: ts,
+            suggested_fee_recipient: TEST_VALIDATOR,
+            prev_randao: diff.into(),
+            gas_limit,
+            parent_beacon_block_root: None,
+            withdrawals: None,
+            extra_data: alloy_primitives::Bytes::from(vec![0u8; 32]),
+            slot_number: None,
+        },
+        parent_difflayers: None,
+        triedb_prefetcher: None,
+        validator_cache_sink: None,
+        turn_length_sink: None,
+        state_root_precomputed_sink: None,
+        trie_handle: None,
+        state_root_deadline_ms: None,
+    };
+
+    // --- Build + finalize + insert block 1 (absorbs the one-time system-contract init txs). ---
+    let (block1, out1): (RecoveredBlock<reth_bsc::BscBlock>, BlockExecutionOutput<_>) = {
+        let provider = factory.database_provider_rw().unwrap();
+        let state_provider = provider.latest();
+        let sp_db = StateProviderDatabase::new(&state_provider);
+        let mut db = State::builder().with_database(sp_db).with_bundle_update().build();
+        let evm_config = BscEvmConfig::new(chain_spec.clone());
+        let diff = calculate_difficulty(&genesis_snap, TEST_VALIDATOR);
+        let mut builder = evm_config
+            .builder_for_next_block(&mut db, &genesis, attrs(genesis.timestamp + 3, diff, genesis.gas_limit))
+            .expect("builder b1");
+        builder.apply_pre_execution_changes().expect("pre-exec b1");
+        let out = builder.finish_with_difflayer(&state_provider).expect("finish b1");
+        let BlockBuilderOutcome { execution_result, block, .. } = out.inner;
+        let senders = block.senders().to_vec();
+        let mut plain = block.sealed_block().clone_block();
+        finalize_new_header(parlia.clone(), &genesis_snap, &genesis, &mut plain.header, &snapshot_provider, (genesis.timestamp + 3) * 1000)
+            .expect("finalize b1");
+        let output = BlockExecutionOutput { state: db.take_bundle(), result: execution_result };
+        (RecoveredBlock::new_unhashed(plain, senders), output)
+    };
+    let block1_sealed = SealedHeader::new(block1.header().clone(), block1.header().hash_slow());
+    // Register block 1's header so the global reader resolves it when block 2 builds on it.
+    shared_header_provider().add_header(block1_sealed.hash(), block1.header().clone());
+    {
+        let mut snap1 = genesis_snap.clone();
+        snap1.block_number = 1;
+        snap1.block_hash = block1_sealed.hash();
+        snapshot_provider.insert(snap1);
+        let provider = factory.database_provider_rw().unwrap();
+        provider.insert_block(&block1).expect("insert b1");
+        provider.write_state(&ExecutionOutcome::single(1, out1), OriginalValuesKnown::Yes, StateWriteConfig::default())
+            .expect("write b1 state");
+        provider.static_file_provider().commit().expect("sf commit");
+        provider.commit().expect("commit b1");
+    }
+    let block1_snap = {
+        let mut s = genesis_snap.clone();
+        s.block_number = 1;
+        s.block_hash = block1_sealed.hash();
+        s
+    };
+
+    // --- Build block 2 (reference) with a fee-paying user tx -> [user, deposit]. ---
+    let user = sign_system_transaction(
+        TxLegacy { chain_id: None, nonce: 0, gas_price: 1, gas_limit: 21_000, to: TxKind::Call(alloy_primitives::Address::ZERO), value: alloy_primitives::U256::from(1u64), input: Default::default() }.into(),
+    )
+    .expect("sign user");
+    let (block2_ref, _out2): (RecoveredBlock<reth_bsc::BscBlock>, BlockExecutionOutput<_>) = {
+        let provider = factory.database_provider_rw().unwrap();
+        let state_provider = provider.latest();
+        let sp_db = StateProviderDatabase::new(&state_provider);
+        let mut db = State::builder().with_database(sp_db).with_bundle_update().build();
+        let evm_config = BscEvmConfig::new(chain_spec.clone());
+        let diff = calculate_difficulty(&block1_snap, TEST_VALIDATOR);
+        let mut builder = evm_config
+            .builder_for_next_block(&mut db, &block1_sealed, attrs(block1_sealed.timestamp + 3, diff, block1_sealed.gas_limit))
+            .expect("builder b2");
+        builder.apply_pre_execution_changes().expect("pre-exec b2");
+        builder.execute_transaction(user.clone().try_into_recovered().expect("recover user")).expect("exec user");
+        let out = builder.finish_with_difflayer(&state_provider).expect("finish b2");
+        let BlockBuilderOutcome { execution_result, block, .. } = out.inner;
+        let output = BlockExecutionOutput { state: db.take_bundle(), result: execution_result };
+        (block, output)
+    };
+    let reference_root = block2_ref.header().state_root;
+
+    // --- Repackage block 2 as a BidBlock: [user (signed), deposit (UNSIGNED placeholder)]. ---
+    let ref_txs: Vec<TransactionSigned> = block2_ref.body().transactions().cloned().collect();
+    // Post-Kepler, past the block-1 init: the trailing system-tx region is exactly the deposit.
+    assert_eq!(ref_txs.len(), 2, "block 2 should be [user, deposit]");
+    let unsigned_deposit = TransactionSigned::new_unhashed(
+        ref_txs[1].clone().into_typed_transaction(),
+        Signature::new(alloy_primitives::U256::ZERO, alloy_primitives::U256::ZERO, false),
+    );
+    let bid = BidBlock {
+        header: block2_ref.header().clone(),
+        transactions: vec![
+            alloy_primitives::Bytes::from(ref_txs[0].encoded_2718()),
+            alloy_primitives::Bytes::from(unsigned_deposit.encoded_2718()),
+        ],
+        sidecars: vec![],
+    };
+    let args = BidBlockArgs { bid_block: bid, signature: alloy_primitives::Bytes::from(vec![0u8; 65]) };
+    let decoded = args.to_decoded_bid_block(alloy_primitives::Address::repeat_byte(0xbb)).expect("decode bid");
+
+    // --- Simulate (re-signs the deposit, finalizes) and execute the sealed block. ---
+    let sim = simulate_bid_block(
+        parlia,
+        &chain_spec,
+        &decoded,
+        &block1_sealed,
+        &block1_snap,
+        &snapshot_provider,
+        TEST_VALIDATOR,
+        block1_sealed.gas_limit,
+        alloy_primitives::Bytes::from(vec![0u8; 32]),
+        (block1_sealed.timestamp + 3) * 1000,
+    )
+    .expect("simulate bid block");
+
+    {
+        let mut snap2 = block1_snap.clone();
+        snap2.block_number = 2;
+        snap2.block_hash = sim.block.header().hash_slow();
+        snapshot_provider.insert(snap2);
+    }
+
+    let provider = factory.database_provider_rw().unwrap();
+    let state_provider = provider.latest();
+    let evm_config = BscEvmConfig::new(chain_spec.clone());
+    let executor = evm_config.batch_executor(StateProviderDatabase::new(&state_provider));
+    let output = executor.execute(&sim.block).expect("execute simulated block 2");
+    let hashed = HashedPostState::from_bundle_state::<KeccakKeyHasher>(output.state.state());
+    let (computed_root, _) = <StateRoot<
+        DatabaseTrieCursorFactory<_, LegacyKeyAdapter>,
+        DatabaseHashedCursorFactory<_>,
+    > as DatabaseStateRoot<_>>::overlay_root_with_updates(provider.tx_ref(), &hashed.clone_into_sorted())
+        .expect("state root");
+
     assert_eq!(computed_root, reference_root);
 }


### PR DESCRIPTION
**The byte-exact verify-mode proof for `simulate_bid_block`** — the gate the whole BidBlock execution path was building toward.

On a Kepler-active signable chain (using a **BSC-typed** test provider so `BscBlock`s can be inserted):
1. build + insert **block 1** (absorbs the one-time block-1 system-contract init txs),
2. build **block 2** with a fee-paying user tx → the validator generates `[user, deposit]`,
3. repackage block 2 as a `BidBlock` with the deposit **unsigned**,
4. run `simulate_bid_block` (re-signs the deposit, sets the validator extra, finalizes/seals),
5. **execute** the sealed result and assert its state root equals the reference build.

Equal roots ⇒ the validator faithfully reproduces the builder's block, executing the validator-signed system txs in verify-mode. This closes the last correctness question on `simulate_bid_block`.

The three conditions that made a clean `[user, deposit]` possible (all diagnosed by running, documented in the test): **Kepler active** skips the `distribute_to_system` sys-reward tx; **block 2** is past the block-1 init; **genesis baseFeePerGas=0** keeps base fee 0 so a `gas_price=1` tx still funds the deposit. A shared accumulating mock header provider lets the multi-spec harness tests coexist on the process-global readers.

All 6 harness tests pass (parallel and `--test-threads=1`), clippy clean. Test-only.

With this, BidBlock is proven end-to-end through execution. Remaining: the consumer loop (`MevWorkWorker` pop → simulate → execute → store best) + revoke-on-mismatch.