### PR TITLE
feat(miner): BidBlock consumer loop — pop, simulate, store best (PR 8d-2b-iv)

### DIFF
--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -531,10 +531,10 @@ pub fn bid_block_env_attributes(header: &Header) -> EthPayloadAttributes {
 
 /// The validator-finalized, sealed block produced from an admitted BidBlock, ready to execute.
 ///
-/// Mirrors the bid-block fields of go-bsc's `task` / `bidBlockTaskInfo` (`miner/bid_block.go`):
-/// `block` + `gasFee` + `systemTxStart`. (`builder`/`bidHash` are added when the consumer loop needs
-/// them for revoke-on-mismatch; receipts/state live on the caller's payload since execution is
-/// deferred.)
+/// Mirrors go-bsc's `task` / `bidBlockTaskInfo` (`miner/bid_block.go`): `block` + `gasFee` +
+/// `systemTxStart` + `builder` + `bidHash`. (Receipts/state live on the caller's payload, since
+/// execution is deferred.)
+#[derive(Clone)]
 pub struct BidBlockTask {
     /// Sealed block with the validator's extra/seal and the bind-signed system txs.
     pub block: RecoveredBlock<BscBlock>,
@@ -542,6 +542,10 @@ pub struct BidBlockTask {
     pub gas_fee: U256,
     /// Index where the trailing system-tx region begins.
     pub system_tx_start: usize,
+    /// Builder that submitted the BidBlock (for selection logging / revoke-on-mismatch).
+    pub builder: Address,
+    /// Hash of the original BidBlock payload.
+    pub bid_hash: B256,
 }
 
 /// Why simulating an admitted BidBlock failed.
@@ -649,7 +653,7 @@ pub fn simulate_bid_block(
         BscBlockBody { inner: BlockBody { transactions: txs, ommers: Vec::new(), withdrawals }, sidecars };
     let block = RecoveredBlock::new_unhashed(BscBlock { header, body }, senders);
 
-    Ok(BidBlockTask { block, gas_fee, system_tx_start })
+    Ok(BidBlockTask { block, gas_fee, system_tx_start, builder: decoded.builder, bid_hash: decoded.hash() })
 }
 
 #[cfg(test)]

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -13,7 +13,9 @@ use alloy_consensus::BlobTransactionSidecar;
 use alloy_consensus::Transaction;
 use alloy_evm::Evm;
 use alloy_primitives::U256;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, Bytes, B256};
+use crate::consensus::parlia::util::calculate_millisecond_timestamp;
+use crate::node::miner::bid_block::{simulate_bid_block, BidBlockTask, DecodedBidBlock};
 use parking_lot::RwLock;
 use reth_node_ethereum::engine::EthPayloadAttributes;
 use reth::transaction_pool::BestTransactionsAttributes;
@@ -86,6 +88,8 @@ pub struct BidSimulator<Client, Pool> {
     best_bid_to_run: Arc<RwLock<HashMap<B256, Bid>>>,
     simulating_bid: Arc<RwLock<HashMap<B256, Bid>>>,
     best_bid: Arc<RwLock<HashMap<B256, BidRuntime<Pool, BscEvmConfig>>>>,
+    /// Best simulated BEP-675 BidBlock per parent hash (go-bsc `AddBidBlock`/`GetBestBidBlock`).
+    best_bid_block: Arc<RwLock<HashMap<B256, BidBlockTask>>>,
     pending_bid: Arc<RwLock<HashMap<String, u8>>>,
     bid_receiving: bool,
     chain_spec: Arc<BscChainSpec>,
@@ -131,6 +135,7 @@ where
             best_bid_to_run: Arc::new(RwLock::new(HashMap::new())),
             simulating_bid: Arc::new(RwLock::new(HashMap::new())),
             best_bid: Arc::new(RwLock::new(HashMap::new())),
+            best_bid_block: Arc::new(RwLock::new(HashMap::new())),
             pending_bid: Arc::new(RwLock::new(HashMap::new())),
             bid_receiving: true,
             min_gas_price: U256::ZERO,
@@ -701,6 +706,64 @@ where
     /// Get the best bid for a given parent hash
     pub fn get_best_bid(&self, parent_hash: B256) -> Option<BidRuntime<Pool, BscEvmConfig>> {
         self.best_bid.read().get(&parent_hash).cloned()
+    }
+
+    /// Verify, blind-sign, and seal an admitted BEP-675 BidBlock, keeping the highest-fee one per
+    /// parent hash (go-bsc `AddBidBlock`). Execution and selection against the locally-built block
+    /// happen in the build cycle (a follow-on slice); this is the intake half.
+    pub fn commit_bid_block(&self, decoded: DecodedBidBlock) {
+        let parent_hash = decoded.parent_hash();
+        let parent = match self.client.header(parent_hash) {
+            Ok(Some(h)) => SealedHeader::new(h, parent_hash),
+            _ => {
+                debug!("BidBlock: parent header not found: {parent_hash}");
+                return;
+            }
+        };
+        let Some(parent_snap) = self.snapshot_provider.snapshot_by_hash(&parent_hash) else {
+            debug!("BidBlock: no snapshot for parent {parent_hash}");
+            return;
+        };
+        let gas_ceil = crate::shared::get_miner_gas_limit().unwrap_or(parent.gas_limit);
+        let expected_gas_limit =
+            EthereumBuilderConfig::new().with_gas_limit(gas_ceil).gas_limit(parent.gas_limit);
+        // TODO: use the operator-configured extra vanity instead of zero bytes.
+        let vanity = Bytes::from(vec![0u8; 32]);
+        let block_timestamp_ms = calculate_millisecond_timestamp(&decoded.header);
+
+        match simulate_bid_block(
+            self.parlia.clone(),
+            &self.chain_spec,
+            &decoded,
+            &parent,
+            &parent_snap,
+            &self.snapshot_provider,
+            self.validator_address,
+            expected_gas_limit,
+            vanity,
+            block_timestamp_ms,
+        ) {
+            Ok(task) => {
+                debug!(
+                    "BidBlock simulated: builder={}, bidHash={}, gasFee={}",
+                    task.builder, task.bid_hash, task.gas_fee
+                );
+                let mut best = self.best_bid_block.write();
+                let replace = best.get(&parent_hash).is_none_or(|t| task.gas_fee > t.gas_fee);
+                if replace {
+                    best.insert(parent_hash, task);
+                }
+            }
+            Err(e) => {
+                debug!("BidBlock rejected in simulate: {e}");
+                // TODO(8d-2c): revoke the builder on verification failure.
+            }
+        }
+    }
+
+    /// The best stored BidBlock for a parent hash (go-bsc `GetBestBidBlock`).
+    pub fn best_bid_block(&self, parent_hash: B256) -> Option<BidBlockTask> {
+        self.best_bid_block.read().get(&parent_hash).cloned()
     }
 }
 

--- a/src/node/miner/bsc_miner.rs
+++ b/src/node/miner/bsc_miner.rs
@@ -1156,6 +1156,8 @@ where
                 _ = send_bid_interval.tick() => {
                     // Attempt to send bids
                     self.get_bid_and_send();
+                    // Process any admitted BEP-675 BidBlocks.
+                    self.process_bid_block();
                 }
 
                 _ = clear_bid_interval.tick() => {
@@ -1205,6 +1207,19 @@ where
                     error!("Failed to send bid simulate request due to channel closed: {}", e);
                 }
             }
+        }
+    }
+
+    /// Pop an admitted BEP-675 BidBlock (from `mev_sendBidBlock`) and verify/blind-sign/seal it into
+    /// the simulator's best-bid-block store (go-bsc `newBidBlockLoop` → `AddBidBlock`).
+    fn process_bid_block(&self) {
+        if let Some(decoded) = crate::shared::pop_bid_block_package() {
+            debug!(
+                "Popped BidBlock from queue, block: {}, builder: {}",
+                decoded.block_number(),
+                decoded.builder
+            );
+            self.simulator.commit_bid_block(decoded);
         }
     }
 }


### PR DESCRIPTION
Wires the admitted-BidBlock intake queue into the miner — `pop_bid_block_package` finally gets its production caller. Mirrors go-bsc `newBidBlockLoop` → `AddBidBlock`.

`MevWorkWorker` now pops a `DecodedBidBlock` on each send-bid tick (`process_bid_block`) and calls `BidSimulator::commit_bid_block`, which:
- resolves the parent header (`client.header`) and parent snapshot,
- derives the expected gas limit from the miner's configured ceil (`shared::get_miner_gas_limit`),
- runs `simulate_bid_block` (verify → blind-sign → set-extra → finalize/seal — proven byte-exact in #406),
- keeps the highest-fee sealed `BidBlockTask` per parent in a new `best_bid_block` store (`GetBestBidBlock`).

Also adds `builder`/`bid_hash` to `BidBlockTask` (for selection logging + revoke-on-mismatch).

Scope: this is the **intake half** of the consumer (queue → simulate → store), matching go-bsc, where the loop stores and the build cycle selects/seals. The **build-cycle side** — execute the stored BidBlock → `BscBuiltPayload`, select it against the local block by fee, submit, and revoke-on-mismatch — is the remaining follow-on (it needs the miner-env state-root path).

clippy clean, 35 bid_block unit tests pass. Two `TODO`s flagged: operator-configured extra vanity (currently 32 zero bytes), and revoke-on-verification-failure (8d-2c).