### PR TITLE
feat(miner): BidBlock build-cycle — execute, verify root, select (PR 8d-2b-v)

### DIFF
--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -88,8 +88,8 @@ pub struct BidSimulator<Client, Pool> {
     best_bid_to_run: Arc<RwLock<HashMap<B256, Bid>>>,
     simulating_bid: Arc<RwLock<HashMap<B256, Bid>>>,
     best_bid: Arc<RwLock<HashMap<B256, BidRuntime<Pool, BscEvmConfig>>>>,
-    /// Best simulated BEP-675 BidBlock per parent hash (go-bsc `AddBidBlock`/`GetBestBidBlock`).
-    best_bid_block: Arc<RwLock<HashMap<B256, BidBlockTask>>>,
+    /// Best executed BEP-675 BidBlock payload per parent hash (go-bsc `AddBidBlock`/`GetBestBidBlock`).
+    best_bid_block: Arc<RwLock<HashMap<B256, BscBuiltPayload>>>,
     pending_bid: Arc<RwLock<HashMap<String, u8>>>,
     bid_receiving: bool,
     chain_spec: Arc<BscChainSpec>,
@@ -731,7 +731,7 @@ where
         let vanity = Bytes::from(vec![0u8; 32]);
         let block_timestamp_ms = calculate_millisecond_timestamp(&decoded.header);
 
-        match simulate_bid_block(
+        let task = match simulate_bid_block(
             self.parlia.clone(),
             &self.chain_spec,
             &decoded,
@@ -743,26 +743,96 @@ where
             vanity,
             block_timestamp_ms,
         ) {
-            Ok(task) => {
-                debug!(
-                    "BidBlock simulated: builder={}, bidHash={}, gasFee={}",
-                    task.builder, task.bid_hash, task.gas_fee
-                );
-                let mut best = self.best_bid_block.write();
-                let replace = best.get(&parent_hash).is_none_or(|t| task.gas_fee > t.gas_fee);
-                if replace {
-                    best.insert(parent_hash, task);
-                }
-            }
+            Ok(task) => task,
             Err(e) => {
                 debug!("BidBlock rejected in simulate: {e}");
                 // TODO(8d-2c): revoke the builder on verification failure.
+                return;
             }
+        };
+
+        // Execute the sealed block to obtain its post-state + trie updates, and verify the builder's
+        // claimed state root before turning it into a selectable payload.
+        let Some(payload) = self.execute_bid_block_payload(parent_hash, task) else { return };
+        let mut best = self.best_bid_block.write();
+        let replace = best.get(&parent_hash).is_none_or(|p| payload.fees > p.fees);
+        if replace {
+            best.insert(parent_hash, payload);
         }
     }
 
-    /// The best stored BidBlock for a parent hash (go-bsc `GetBestBidBlock`).
-    pub fn best_bid_block(&self, parent_hash: B256) -> Option<BidBlockTask> {
+    /// Execute a sealed BidBlock against the parent state, verify its claimed state root, and
+    /// assemble a `BscBuiltPayload` (is_bid = true) for selection. Returns `None` on any failure
+    /// (missing state, execution error, or state-root mismatch — a dishonest builder).
+    fn execute_bid_block_payload(
+        &self,
+        parent_hash: B256,
+        task: BidBlockTask,
+    ) -> Option<BscBuiltPayload> {
+        use reth_evm::execute::Executor;
+        use reth_provider::StateRootProvider;
+        use reth_trie_common::{HashedPostState, KeccakKeyHasher};
+
+        let sealed = task.block;
+        let state_provider = match self.client.state_by_block_hash(parent_hash) {
+            Ok(sp) => sp,
+            Err(e) => {
+                debug!("BidBlock: state provider error: {e}");
+                return None;
+            }
+        };
+        let output = {
+            let evm_config = BscEvmConfig::new(self.chain_spec.clone());
+            let executor = evm_config.batch_executor(StateProviderDatabase::new(&state_provider));
+            match executor.execute(&sealed) {
+                Ok(o) => o,
+                Err(e) => {
+                    debug!("BidBlock: execution failed: {e}");
+                    return None;
+                }
+            }
+        };
+        let requests = output.result.requests.clone();
+        let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(output.state.state());
+        let (root, trie_updates) = match state_provider.state_root_with_updates(hashed_state.clone()) {
+            Ok(r) => r,
+            Err(e) => {
+                debug!("BidBlock: state root failed: {e}");
+                return None;
+            }
+        };
+        if root != sealed.header().state_root {
+            debug!(
+                "BidBlock: state root mismatch (dishonest builder): computed {root}, claimed {}",
+                sealed.header().state_root
+            );
+            // TODO(8d-2c): revoke the builder.
+            return None;
+        }
+        let sealed_block = Arc::new(sealed.sealed_block().clone());
+        let executed = BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(sealed.clone()),
+            execution_output: Arc::new(output),
+            hashed_state: Either::Left(Arc::new(hashed_state)),
+            trie_updates: Either::Left(Arc::new(trie_updates)),
+        }
+        .into_executed_payload();
+        Some(BscBuiltPayload {
+            block: sealed_block,
+            fees: task.gas_fee,
+            requests: Some(requests),
+            build_kind: crate::node::engine::BuildKind::NormalAttempt,
+            exec_duration: std::time::Duration::ZERO,
+            trie_root_duration: std::time::Duration::ZERO,
+            executed_block: executed,
+            pending_validators: None,
+            pending_turn_length: None,
+            is_bid: true,
+        })
+    }
+
+    /// The best stored BidBlock payload for a parent hash (go-bsc `GetBestBidBlock`).
+    pub fn best_bid_block(&self, parent_hash: B256) -> Option<BscBuiltPayload> {
         self.best_bid_block.read().get(&parent_hash).cloned()
     }
 }

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -1954,6 +1954,20 @@ where
         }
     }
 
+    /// Collect the best BEP-675 BidBlock payload (if any) so it competes with the local block and
+    /// any legacy SendBid by fee in `pick_best_payload_and_finalize` (go-bsc `selectBidBlock`).
+    fn collect_best_bid_block(&mut self) {
+        if let Some(payload) = self.simulator.best_bid_block(self.mining_ctx.parent_header.hash()) {
+            info!(
+                target: "bsc::miner::payload",
+                trace_id = self.trace_id,
+                payload_fees = %payload.fees(),
+                "Found best BidBlock payload"
+            );
+            self.potential_payloads.push(payload);
+        }
+    }
+
     /// Ensure `potential_payloads` has at least one candidate, then drain background build tasks
     /// within the submission deadline to maximise the chance of a better (non-empty / higher-fee)
     /// payload.
@@ -2204,6 +2218,7 @@ where
     /// Try to return the best payload to result channel
     fn try_return_best_payload(&mut self) -> Result<(), Box<BscPayloadJobError>> {
         self.collect_best_bid();
+        self.collect_best_bid_block();
 
         self.collect_payload_candidates()?;
 


### PR DESCRIPTION
Completes the BidBlock consumer — the build-cycle side that makes an admitted BidBlock actually get proposed.

`commit_bid_block` now, after `simulate_bid_block` seals the block:
- executes it against the parent state (`BscEvmConfig::batch_executor`),
- computes the post-state root **with updates** (`state_root_with_updates`) and **verifies it equals the builder's claimed root** — a mismatch means a dishonest builder and the block is dropped (revoke is the 8d-2c TODO),
- assembles a `BscBuiltPayload { is_bid: true }` and stores the highest-fee one per parent.

The payload builder's `try_return_best_payload` calls the new `collect_best_bid_block`, which pushes that payload into `potential_payloads` so it competes with the locally-built block (and any legacy SendBid) by fee in `pick_best_payload_and_finalize` — go-bsc's `selectBidBlock`.

**End-to-end now live:** `mev_sendBidBlock` → admission → queue → miner pop → `simulate_bid_block` → execute + verify root → select by fee. The execution path is the one proven byte-exact in #406.

clippy clean; 35 bid_block unit tests + 6 harness tests pass. Remaining: revoke-on-mismatch (8d-2c) and the operator-configured extra vanity.