### PR TITLE
fix(mev): add missing CheckPending quota and bidMustBefore timing to admit_bid_block

### DIFF
--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -17,6 +17,9 @@ use reth_ethereum_primitives::TransactionSigned;
 use reth_primitives_traits::SignerRecoverable;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+
+/// Per-block pending BidBlock tracking: block_number → builder → set of bid hashes.
+type PendingBidBlocks = Arc<RwLock<HashMap<u64, HashMap<Address, HashSet<B256>>>>>;
 use tracing::debug;
 
 /// Raw bid data structure from builder
@@ -183,7 +186,7 @@ pub struct MevApiImpl {
     /// Mirrors go-bsc `bidSimulator.pending`: blockNumber → builder → set of bid hashes.
     /// Used to enforce duplicate detection and the per-builder-per-block quota
     /// (`max_bids_per_builder`) at RPC admission time, before the bid enters the miner queue.
-    pending_bid_blocks: Arc<RwLock<HashMap<u64, HashMap<Address, HashSet<B256>>>>>,
+    pending_bid_blocks: PendingBidBlocks,
 }
 
 // NOTE: The allowed_builders is now also accessible via crate::shared::get_builder_whitelist()
@@ -431,7 +434,7 @@ impl MevApiImpl {
         // Must run before the timing check so rejected bids do not consume quota.
         let block_number = args.bid_block.header.number;
         self.check_pending_bid_block(block_number, builder, bid_hash)
-            .map_err(|e| Self::invalid_bid(e))?;
+            .map_err(Self::invalid_bid)?;
 
         // Mirrors go-bsc `bidSimulator.bidMustBefore`: reject bids that arrive after the
         // validator must have already started sealing (no time left to simulate).

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -15,7 +15,7 @@ use jsonrpsee::proc_macros::rpc;
 use reth_chainspec::EthChainSpec;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_primitives_traits::SignerRecoverable;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use tracing::debug;
 
@@ -180,6 +180,10 @@ pub struct MevApiImpl {
     version: String,
     /// Whitelist of allowed builders (shared with miner_ namespace via shared.rs)
     allowed_builders: Arc<RwLock<HashSet<Address>>>,
+    /// Mirrors go-bsc `bidSimulator.pending`: blockNumber → builder → set of bid hashes.
+    /// Used to enforce duplicate detection and the per-builder-per-block quota
+    /// (`max_bids_per_builder`) at RPC admission time, before the bid enters the miner queue.
+    pending_bid_blocks: Arc<RwLock<HashMap<u64, HashMap<Address, HashSet<B256>>>>>,
 }
 
 // NOTE: The allowed_builders is now also accessible via crate::shared::get_builder_whitelist()
@@ -283,7 +287,53 @@ impl MevApiImpl {
             bid_block_enabled,
             version,
             allowed_builders,
+            pending_bid_blocks: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Mirrors go-bsc `bidSimulator.CheckPending`: returns an error if `bid_hash` is already
+    /// registered for `(block_number, builder)` or if the builder has reached the per-block quota.
+    fn check_pending_bid_block(
+        &self,
+        block_number: u64,
+        builder: Address,
+        bid_hash: B256,
+    ) -> Result<(), String> {
+        let pending = self.pending_bid_blocks.read().unwrap();
+        if let Some(by_builder) = pending.get(&block_number) {
+            if let Some(hashes) = by_builder.get(&builder) {
+                if hashes.contains(&bid_hash) {
+                    return Err("bid already exists".to_string());
+                }
+                if hashes.len() >= self.max_bids_per_builder as usize {
+                    return Err(format!(
+                        "too many bids: exceeded limit of {} bids per builder per block",
+                        self.max_bids_per_builder
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Mirrors go-bsc `bidSimulator.AddPending`: registers `bid_hash` for `(block_number, builder)`.
+    fn add_pending_bid_block(&self, block_number: u64, builder: Address, bid_hash: B256) {
+        let mut pending = self.pending_bid_blocks.write().unwrap();
+        pending
+            .entry(block_number)
+            .or_default()
+            .entry(builder)
+            .or_default()
+            .insert(bid_hash);
+    }
+
+    /// Mirrors go-bsc `bidSimulator.bidMustBefore`: the deadline after which a bid is too late.
+    ///
+    /// `bid_must_before_ms = parent_timestamp_ms + block_interval_ms - no_interrupt_left_over_ms`
+    fn bid_must_before_ms(&self, parent_timestamp_secs: u64, block_interval_ms: u64) -> u128 {
+        (parent_timestamp_secs as u128) * 1000
+            + block_interval_ms as u128
+            - self.no_interrupt_left_over as u128
     }
 
     /// Get header by number from global header provider
@@ -368,25 +418,57 @@ impl MevApiImpl {
                 "builder is not registered: builder={builder}, bidHash={bid_hash}"
             )));
         }
-        // Checked before any quota use so a revoked builder cannot consume it.
+
+        // Mirrors go-bsc: permission check comes before CheckPending so a revoked builder cannot
+        // consume quota.
         if !crate::shared::get_bid_block_permission_manager().is_allowed(builder) {
             return Err(Self::permission_revoked(
                 "builder BidBlock permission revoked, fallback to SendBid",
             ));
         }
 
+        // Mirrors go-bsc `bidSimulator.CheckPending`: duplicate + per-builder quota guard.
+        // Must run before the timing check so rejected bids do not consume quota.
+        let block_number = args.bid_block.header.number;
+        self.check_pending_bid_block(block_number, builder, bid_hash)
+            .map_err(|e| Self::invalid_bid(e))?;
+
+        // Mirrors go-bsc `bidSimulator.bidMustBefore`: reject bids that arrive after the
+        // validator must have already started sealing (no time left to simulate).
+        let block_interval_ms = self
+            .snapshot_provider
+            .snapshot_by_hash(&head_header.hash_slow())
+            .map(|s| s.block_interval)
+            .unwrap_or(3_000); // 3 s default
+        let bid_must_before_ms = self.bid_must_before_ms(head_header.timestamp, block_interval_ms);
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        if now_ms >= bid_must_before_ms {
+            return Err(Self::invalid_bid(format!(
+                "too late: bid must arrive before {}ms, arrived {}ms later, bidHash={bid_hash}",
+                bid_must_before_ms,
+                now_ms.saturating_sub(bid_must_before_ms),
+            )));
+        }
+
         // Decode and hand to the miner via the global intake queue. The simulator-backed tail of
-        // Miner.SendBidBlock — pre-seal verification, execution, selection against the local block,
-        // and revoke-on-invalid — runs miner-side when the block is popped (8d-2b), matching the
-        // legacy SendBid layering where the RPC enqueues and the miner verifies/executes.
+        // Miner.SendBidBlock — Extra overwrite, setBidMevInfo, pre-seal verification, execution,
+        // selection against the local block, and revoke-on-invalid — runs miner-side when the
+        // block is popped, matching the legacy SendBid layering where the RPC enqueues and the
+        // miner verifies/executes.
         let decoded = args
             .to_decoded_bid_block(builder)
             .map_err(|e| Self::invalid_bid(format!("failed to decode bid block: {e}")))?;
+
+        // Register after all checks pass so quota is only consumed by accepted bids.
+        self.add_pending_bid_block(block_number, builder, bid_hash);
+
         crate::shared::push_bid_block_package(decoded);
 
         tracing::info!(
-            "BidBlock queued: block={}, builder={builder}, bidHash={bid_hash:?}",
-            args.bid_block.header.number
+            "BidBlock queued: block={block_number}, builder={builder}, bidHash={bid_hash:?}",
         );
 
         Ok(bid_hash)

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -453,11 +453,24 @@ impl MevApiImpl {
             )));
         }
 
-        // Decode and hand to the miner via the global intake queue. The simulator-backed tail of
-        // Miner.SendBidBlock — Extra overwrite, setBidMevInfo, pre-seal verification, execution,
-        // selection against the local block, and revoke-on-invalid — runs miner-side when the
-        // block is popped, matching the legacy SendBid layering where the RPC enqueues and the
-        // miner verifies/executes.
+        // Decode and hand to the miner via the global intake queue.
+        //
+        // The remaining tail of go-bsc's Miner.SendBidBlock is intentionally deferred to the
+        // miner side (bid_block::simulate_bid_block, called from BidSimulator::commit_bid_block):
+        //
+        //   • Extra overwrite + SetExtraData  →  header.extra_data = vanity + finalize_new_header
+        //   • setBidMevInfo                   →  set_bid_block_mev_info
+        //   • preSealVerifyBidBlock           →  verify_bid_block_payload + verify_bid_block_header
+        //   • execution + state-root check    →  execute_bid_block_payload
+        //
+        // Behavioral difference vs geth: geth runs these synchronously and returns an error to the
+        // builder immediately on failure.  reth-bsc returns bidHash optimistically; if any of the
+        // above steps fail the block is silently dropped miner-side.  The checks still run — the
+        // builder just does not receive per-step error feedback.
+        //
+        // Bringing them forward to admit_bid_block would require injecting
+        // Arc<Parlia<BscChainSpec>> into MevApiImpl (needed by verify_bid_block_header) and is
+        // left as future work.
         let decoded = args
             .to_decoded_bid_block(builder)
             .map_err(|e| Self::invalid_bid(format!("failed to decode bid block: {e}")))?;


### PR DESCRIPTION
## Summary

Adds two admission checks to `MevApiImpl::admit_bid_block` that exist in go-bsc's `Miner.SendBidBlock` but were missing from the reth-bsc equivalent.

### Missing checks (vs go-bsc `Miner.SendBidBlock`)

| Step | go-bsc | reth-bsc before | reth-bsc after |
|------|--------|-----------------|----------------|
| `recordBidBlockBuilder` (metrics) | ✅ | ❌ | ❌ (non-critical, deferred) |
| `CheckPending` duplicate + quota | ✅ | ❌ | ✅ |
| `bidMustBefore` timing | ✅ | ❌ | ✅ |
| `SetExtraData` + Extra overwrite | ✅ | ❌ | ❌ (deferred, miner-side) |
| `setBidMevInfo` | ✅ | ❌ | ❌ (deferred, miner-side) |
| `preSealVerifyBidBlock` | ✅ | ❌ | ❌ (deferred, miner-side) |

### CheckPending (`bidSimulator.CheckPending`)

Adds `pending_bid_blocks: HashMap<block_number → HashMap<builder → HashSet<bid_hash>>>` to `MevApiImpl`. On each `admit_bid_block` call:
- Rejects duplicate `bid_hash` for the same `(block_number, builder)` pair
- Rejects if builder has already submitted `max_bids_per_builder` (default: 3) bids for this block

Quota is only charged **after** all other checks pass, matching the go-bsc ordering where `AddPending` is called in `sendBidBlock` (after `CheckPending` returns `nil`).

### bidMustBefore (`bidSimulator.bidMustBefore`)

Rejects bids arriving after the sealing deadline:
```
bid_must_before_ms = parent_timestamp_ms + block_interval_ms - no_interrupt_left_over_ms
```
`block_interval_ms` comes from the snapshot for the current head (Fermi: 500ms, Maxwell: 1000ms, etc.). `no_interrupt_left_over` is the configured seal deadline margin (default: 500ms). Without this check, late bids enter the miner queue and are silently dropped, wasting simulation budget.

## Test plan

- [ ] Builder sending the same `bid_hash` twice for the same block → second call returns `-38001` "bid already exists"
- [ ] Builder sending `max_bids_per_builder + 1` distinct bids for one block → last call returns `-38001` "too many bids"
- [ ] Bid arriving after `bid_must_before_ms` → returns `-38001` "too late"
- [ ] Valid bid within deadline and quota → accepted, `bidHash` returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)