### PR TITLE
perf(miner): adaptive root-reserve + per-attempt sparse-trie sink (ported to develop-hardfork-pasteur)

### DIFF
--- a/src/node/engine.rs
+++ b/src/node/engine.rs
@@ -185,14 +185,26 @@ where
                                     .last()
                                     .map(|b| b.recovered_block().parent_hash())
                                     .unwrap_or(parent_hash);
+                                // Instrumentation: the in-memory overlay depth (= head - on-disk
+                                // tip ≈ persist lag) the proof workers must reconstruct over. We
+                                // suspect a deep overlay (and the per-spawn empty ChangesetCache
+                                // above) is what makes the occasional root slow — NOT tx count.
+                                // Correlate this with bsc_builder_state_root_wait_duration_seconds.
+                                metrics::histogram!("bsc_miner_overlay_depth")
+                                    .record(blocks.len() as f64);
+                                metrics::counter!("bsc_miner_sparse_trie_anchor_inmemory_total")
+                                    .increment(1);
                                 (anchor, Some(LazyOverlay::new(blocks)))
                             }
                             None => {
                                 // Parent already persisted — anchor directly, no overlay.
+                                metrics::counter!("bsc_miner_sparse_trie_anchor_persisted_total")
+                                    .increment(1);
                                 (parent_hash, None)
                             }
                         }
                     } else {
+                        metrics::counter!("bsc_miner_sparse_trie_anchor_nocim_total").increment(1);
                         (parent_hash, None)
                     };
 
@@ -228,12 +240,20 @@ where
                             PrecompileCacheMap::default(),
                         ))
                     });
-                    Some(payload_processor.spawn_state_root(
+                    // Instrumentation: time the spawn itself. spawn_state_root creates the proof
+                    // worker pools and kicks off overlay/proof work per block (3000+ spawns/run);
+                    // a slow spawn points at per-block worker-pool churn / overlay setup rather
+                    // than tx execution.
+                    let spawn_start = std::time::Instant::now();
+                    let handle = payload_processor.spawn_state_root(
                         overlay_factory,
                         parent_state_root,
                         false, // halve_workers
                         tree_config_for_closure.as_ref(),
-                    ))
+                    );
+                    metrics::histogram!("bsc_miner_sparse_trie_spawn_duration_seconds")
+                        .record(spawn_start.elapsed().as_secs_f64());
+                    Some(handle)
                 },
             );
 

--- a/src/node/engine.rs
+++ b/src/node/engine.rs
@@ -155,6 +155,15 @@ where
             let pp_cell: std::sync::OnceLock<
                 std::sync::Arc<PayloadProcessor<crate::node::evm::config::BscEvmConfig>>,
             > = std::sync::OnceLock::new();
+            // Long-lived changeset cache SHARED across all miner sparse-trie spawns. Previously
+            // each spawn built `ChangesetCache::default()` (a fresh, empty cache), so any overlay
+            // that needed trie reverts (anchor below db_tip) missed and recomputed changesets from
+            // the DB on every block — the dominant cause of the occasional 100-280ms "slow root".
+            // A single cache reused across the miner's consecutive blocks warms up: the first block
+            // computes the reverts (from DB) and caches them; later blocks reuse them. Cloning
+            // shares the underlying Arc<RwLock<..>>; `evict` (interior-mutable) bounds growth.
+            const MINER_CHANGESET_RETENTION_BLOCKS: u64 = 256;
+            let miner_changeset_cache = ChangesetCache::new();
             let spawn_fn: crate::shared::SparseTrieSpawnFn = std::sync::Arc::new(
                 move |parent_hash: alloy_primitives::B256,
                       parent_state_root: alloy_primitives::B256| {
@@ -174,6 +183,16 @@ where
                     let (anchor_hash, lazy_overlay) = if let Some(cim) =
                         crate::shared::get_canonical_in_memory_state()
                     {
+                        // Bound the long-lived cache: drop entries well below finalized. The
+                        // overlay only ever needs reverts within [finalized-RETENTION .. head], so
+                        // this keeps the working set hot while preventing unbounded growth over a
+                        // long run. evict() takes &self (RwLock), so it composes with the shared
+                        // clone handed to the OverlayBuilder below.
+                        if let Some(finalized) = cim.get_finalized_num_hash() {
+                            miner_changeset_cache.evict(
+                                finalized.number.saturating_sub(MINER_CHANGESET_RETENTION_BLOCKS),
+                            );
+                        }
                         match cim.state_by_hash(parent_hash) {
                             Some(state) => {
                                 // chain() yields newest-to-oldest including self, exactly
@@ -210,7 +229,9 @@ where
 
                     let overlay_builder = OverlayBuilder::<crate::BscPrimitives>::new(
                         anchor_hash,
-                        ChangesetCache::default(),
+                        // Shared, warm cache (see MINER_CHANGESET_RETENTION_BLOCKS above) instead of
+                        // a fresh empty one per spawn — clone shares the underlying store.
+                        miner_changeset_cache.clone(),
                     )
                     .with_lazy_overlay(lazy_overlay);
 

--- a/src/node/evm/builder.rs
+++ b/src/node/evm/builder.rs
@@ -272,6 +272,37 @@ where
             );
             (root, updates)
         } else {
+            // Fix #1: bound the synchronous state-root fallback by the slot deadline.
+            //
+            // When the sparse-trie precomputed root is unavailable (recv_timeout expired, or no
+            // handle was spawned) we land here on the synchronous full-trie walk
+            // `state_root_with_updates`. Under a deep miner overlay this walk takes ~700ms — far
+            // past the block period. Running it anyway is doubly harmful: it produces a candidate
+            // the miner has already given up waiting for, and it pins a CPU core ~700ms into the
+            // next slot, shrinking the next block's build budget and cascading further
+            // empty/low-gas blocks. If we are already at/over the state-root deadline
+            // (`end_mining_timestamp_ms - STATE_ROOT_WAIT_MARGIN_MS`), abort this candidate so the
+            // miner ships the best already-completed candidate on time instead of over-running.
+            if let Some(deadline_ms) = self.ctx.state_root_deadline_ms {
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
+                if now_ms >= deadline_ms {
+                    metrics::counter!("bsc_builder_sync_root_deadline_abort_total").increment(1);
+                    tracing::warn!(
+                        target: "bsc::builder",
+                        parent_hash = %self.parent.hash(),
+                        block_number = %(self.parent.number + 1),
+                        now_ms,
+                        deadline_ms,
+                        "Synchronous state-root would miss the slot deadline; aborting candidate to avoid slot over-run"
+                    );
+                    return Err(BlockExecutionError::msg(format!(
+                        "synchronous state-root aborted: past slot deadline (now_ms={now_ms} >= deadline_ms={deadline_ms})"
+                    )));
+                }
+            }
             state.state_root_with_updates(hashed_state.clone()).map_err(BlockExecutionError::other)?
         };
         let state_root_duration = state_root_start.elapsed();

--- a/src/node/evm/builder.rs
+++ b/src/node/evm/builder.rs
@@ -229,6 +229,8 @@ where
                         target: "bsc::builder",
                         parent_hash = %self.parent.hash(),
                         block_number = %(self.parent.number + 1),
+                        user_tx_count = self.transactions.len(),
+                        state_root = %outcome.state_root,
                         wait_ms = wait_start.elapsed().as_millis(),
                         "Sparse-trie state-root delivered post-finish()"
                     );
@@ -268,6 +270,7 @@ where
                 user_tx_count = self.transactions.len(),
                 hashed_accounts = hashed_state.accounts.len(),
                 hashed_storages = hashed_state.storages.len(),
+                state_root = %root,
                 "Using precomputed state root from sparse-trie task"
             );
             (root, updates)

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -428,11 +428,21 @@ where
         let validator_cache_sink: ValidatorCacheSink = Arc::new(Mutex::new(None));
         let turn_length_sink: Arc<Mutex<Option<u8>>> = Arc::new(Mutex::new(None));
 
-        // Sink for the sparse-trie precomputed state root. The same Arc<Mutex<>> from
-        // `state_root_precomputed` is threaded into ctx so builder.rs can read it during
-        // `finish`. When the sparse-trie path is not active (flag off), this Mutex stays
-        // `None` and the builder falls through to `state_root_with_updates`.
-        let state_root_precomputed_sink = state_root_precomputed.clone();
+        // Sink for the sparse-trie precomputed state root. This MUST be a fresh per-attempt
+        // Arc<Mutex<>> — NOT a clone of the job-level `state_root_precomputed`. The job-level Arc
+        // is shared by every build attempt (including the deadline-spawned empty-fallback build),
+        // and inside `finish` the write (after the sparse-trie wait) and the read-back
+        // (`sink.take()`) are separated by `merge_transitions` + `hashed_post_state` over all txs
+        // (~hundreds of ms for a full block). With a shared sink, a concurrent second finish (e.g.
+        // the empty build, which has no trie_handle so it jumps straight to the take()) steals the
+        // root this attempt deposited, forcing this attempt onto the slow synchronous
+        // `state_root_with_updates`. A per-attempt sink makes write→read strictly intra-attempt, so
+        // the full build reads back its OWN precomputed root. When the sparse-trie path is not active
+        // (flag off), this Mutex stays `None` and the builder falls through to
+        // `state_root_with_updates`.
+        let state_root_precomputed_sink: Arc<
+            Mutex<Option<(alloy_primitives::B256, reth_trie_common::updates::TrieUpdates)>>,
+        > = Arc::new(Mutex::new(None));
 
         let next_env_attributes = BscNextBlockEnvAttributes {
             inner: NextBlockEnvAttributes {
@@ -827,7 +837,10 @@ where
         // it after executor.finish() and calls `state_root()` once the hook is
         // naturally dropped (executor consumption triggers `StateHookSender::drop`
         // which sends `FinishedStateUpdates`).
-        let _ = &state_root_precomputed; // sink referenced for trace; written by builder
+        // The job-level `state_root_precomputed` Arc is vestigial: this attempt uses its own
+        // per-attempt sink (see `state_root_precomputed_sink` above). Kept bound to avoid an
+        // unused-variable warning until the field is removed from BscBuildArguments.
+        let _ = &state_root_precomputed;
         let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } =
             builder.finish(&state_provider, None)?;
 
@@ -982,7 +995,13 @@ where
                     },
                     validator_cache_sink: Some(validator_cache_sink.clone()),
                     turn_length_sink: Some(turn_length_sink.clone()),
-                    state_root_precomputed_sink: Some(state_root_precomputed.clone()),
+                    // Empty-fallback build never installs a sparse-trie hook (trie_handle: None
+                    // below), so it must NOT read from any sparse-trie sink. Passing None makes the
+                    // builder compute this empty block's own (cheap) state root via
+                    // `state_root_with_updates` instead of stealing a full build's precomputed root
+                    // out of a shared sink (which both starved the full build and risked sealing a
+                    // foreign root onto the empty block).
+                    state_root_precomputed_sink: None,
                     // Empty-payload path: don't engage sparse-trie (would still be
                     // correct but the setup overhead isn't worth it for ~0-tx blocks).
                     trie_handle: None,

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -56,7 +56,7 @@ use tracing::{debug, info, trace, warn};
 /// 120ms to avoid missing the block deadline or eating into the next block's time budget.
 pub const DELAY_LEFT_OVER: u64 = 120;
 
-/// Maximum end-of-slot reserve (ms) used when the in-memory overlay is deep.
+/// Adaptive end-of-slot reserve, tuned at runtime via env (no recompile needed for testing).
 ///
 /// Empty blocks under load cluster at the *peaks* of the overlay depth (head − finalized): there
 /// the background sparse-trie root can't finalize within the default 120ms reserve, so `finish`
@@ -66,25 +66,61 @@ pub const DELAY_LEFT_OVER: u64 = 120;
 /// → the finalize tail gets a larger window, and fewer txs are filled → the finalize tail is
 /// smaller), turning a would-be empty block into an on-time smaller block.
 /// See docs/design-adaptive-overlay-depth.md.
+///
+/// Env knobs (read once at startup, cached):
+/// - `BSC_MINING_ADAPTIVE_RESERVE` = on/off (default on); off → fixed `DELAY_LEFT_OVER` (A/B base).
+/// - `BSC_MINING_ROOT_RESERVE_DEPTH_LOW`  (default 15) — at/below this, default reserve.
+/// - `BSC_MINING_ROOT_RESERVE_DEPTH_HIGH` (default 40) — at/above this, max reserve.
+/// - `BSC_MINING_ROOT_RESERVE_MAX_MS`     (default 280) — reserve used at/above DEPTH_HIGH.
+#[derive(Debug, Clone, Copy)]
+struct AdaptiveReserveConfig {
+    enabled: bool,
+    depth_low: u64,
+    depth_high: u64,
+    reserve_max_ms: u64,
+}
+
+/// Default knob values (also the fallback when the corresponding env var is unset/unparseable).
 const ROOT_RESERVE_MAX_MS: u64 = 280;
-/// Overlay depth (head − finalized) at/below which the default reserve is used (normal blocks).
 const ROOT_RESERVE_DEPTH_LOW: u64 = 15;
-/// Overlay depth at/above which the maximum reserve is used.
 const ROOT_RESERVE_DEPTH_HIGH: u64 = 40;
+
+fn adaptive_reserve_config() -> &'static AdaptiveReserveConfig {
+    static CFG: std::sync::OnceLock<AdaptiveReserveConfig> = std::sync::OnceLock::new();
+    CFG.get_or_init(|| {
+        let env_u64 = |k: &str, default: u64| {
+            std::env::var(k).ok().and_then(|v| v.trim().parse::<u64>().ok()).unwrap_or(default)
+        };
+        let enabled = std::env::var("BSC_MINING_ADAPTIVE_RESERVE")
+            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"))
+            .unwrap_or(true);
+        let cfg = AdaptiveReserveConfig {
+            enabled,
+            depth_low: env_u64("BSC_MINING_ROOT_RESERVE_DEPTH_LOW", ROOT_RESERVE_DEPTH_LOW),
+            depth_high: env_u64("BSC_MINING_ROOT_RESERVE_DEPTH_HIGH", ROOT_RESERVE_DEPTH_HIGH),
+            reserve_max_ms: env_u64("BSC_MINING_ROOT_RESERVE_MAX_MS", ROOT_RESERVE_MAX_MS),
+        };
+        tracing::info!(target: "bsc::miner", ?cfg, "Adaptive root-reserve config");
+        cfg
+    })
+}
 
 /// Effective end-of-slot reserve (ms) given the current in-memory overlay depth.
 ///
-/// Linearly interpolates `DELAY_LEFT_OVER..=ROOT_RESERVE_MAX_MS` between the LOW and HIGH depths.
-/// At/below LOW it returns the unchanged default, so normal blocks are unaffected.
+/// Linearly interpolates `DELAY_LEFT_OVER..=reserve_max_ms` between `depth_low` and `depth_high`.
+/// At/below `depth_low` (or when disabled) returns the unchanged default, so normal blocks are
+/// unaffected. The branch ordering also makes a misconfigured `depth_high <= depth_low` behave as a
+/// step at `depth_low` (no divide-by-zero).
 pub fn effective_delay_left_over(overlay_depth: u64) -> u64 {
-    if overlay_depth <= ROOT_RESERVE_DEPTH_LOW {
+    let cfg = adaptive_reserve_config();
+    if !cfg.enabled || overlay_depth <= cfg.depth_low {
         DELAY_LEFT_OVER
-    } else if overlay_depth >= ROOT_RESERVE_DEPTH_HIGH {
-        ROOT_RESERVE_MAX_MS
+    } else if overlay_depth >= cfg.depth_high {
+        cfg.reserve_max_ms
     } else {
-        let span = (ROOT_RESERVE_DEPTH_HIGH - ROOT_RESERVE_DEPTH_LOW) as f64;
-        let t = (overlay_depth - ROOT_RESERVE_DEPTH_LOW) as f64 / span;
-        DELAY_LEFT_OVER + (t * (ROOT_RESERVE_MAX_MS - DELAY_LEFT_OVER) as f64) as u64
+        let span = (cfg.depth_high - cfg.depth_low) as f64;
+        let t = (overlay_depth - cfg.depth_low) as f64 / span;
+        DELAY_LEFT_OVER + (t * cfg.reserve_max_ms.saturating_sub(DELAY_LEFT_OVER) as f64) as u64
     }
 }
 

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -56,6 +56,38 @@ use tracing::{debug, info, trace, warn};
 /// 120ms to avoid missing the block deadline or eating into the next block's time budget.
 pub const DELAY_LEFT_OVER: u64 = 120;
 
+/// Maximum end-of-slot reserve (ms) used when the in-memory overlay is deep.
+///
+/// Empty blocks under load cluster at the *peaks* of the overlay depth (head − finalized): there
+/// the background sparse-trie root can't finalize within the default 120ms reserve, so `finish`
+/// waits past the slot deadline and the block degrades to empty-fallback. For the ~97% of blocks
+/// at normal depth the root is ready in ~20ms, so the default reserve is left untouched. When the
+/// overlay is deep we reserve more of the slot for the root (fill stops earlier → exec ends earlier
+/// → the finalize tail gets a larger window, and fewer txs are filled → the finalize tail is
+/// smaller), turning a would-be empty block into an on-time smaller block.
+/// See docs/design-adaptive-overlay-depth.md.
+const ROOT_RESERVE_MAX_MS: u64 = 280;
+/// Overlay depth (head − finalized) at/below which the default reserve is used (normal blocks).
+const ROOT_RESERVE_DEPTH_LOW: u64 = 15;
+/// Overlay depth at/above which the maximum reserve is used.
+const ROOT_RESERVE_DEPTH_HIGH: u64 = 40;
+
+/// Effective end-of-slot reserve (ms) given the current in-memory overlay depth.
+///
+/// Linearly interpolates `DELAY_LEFT_OVER..=ROOT_RESERVE_MAX_MS` between the LOW and HIGH depths.
+/// At/below LOW it returns the unchanged default, so normal blocks are unaffected.
+pub fn effective_delay_left_over(overlay_depth: u64) -> u64 {
+    if overlay_depth <= ROOT_RESERVE_DEPTH_LOW {
+        DELAY_LEFT_OVER
+    } else if overlay_depth >= ROOT_RESERVE_DEPTH_HIGH {
+        ROOT_RESERVE_MAX_MS
+    } else {
+        let span = (ROOT_RESERVE_DEPTH_HIGH - ROOT_RESERVE_DEPTH_LOW) as f64;
+        let t = (overlay_depth - ROOT_RESERVE_DEPTH_LOW) as f64 / span;
+        DELAY_LEFT_OVER + (t * (ROOT_RESERVE_MAX_MS - DELAY_LEFT_OVER) as f64) as u64
+    }
+}
+
 /// Minimum estimated fee uplift required for a normal rebuild, expressed in basis points.
 const NORMAL_REBUILD_UPLIFT_BPS: u64 = 1_500;
 
@@ -1193,10 +1225,22 @@ where
 
         let trace_id = build_args.trace_id;
 
+        // Adaptive root reserve: when the in-memory overlay (head − finalized) is deep, reserve
+        // more of the slot for the background state root so it finalizes before the deadline
+        // instead of degrading the block to empty-fallback. Normal-depth blocks keep the default
+        // reserve (overlay_depth ≤ ROOT_RESERVE_DEPTH_LOW). Falls back to depth 0 (default reserve)
+        // when finalized is not yet available. See docs/design-adaptive-overlay-depth.md.
+        let block_number = mining_ctx.parent_header.number() + 1;
+        let overlay_depth = crate::shared::get_canonical_in_memory_state()
+            .and_then(|cim| cim.get_finalized_num_hash())
+            .map(|f| block_number.saturating_sub(f.number))
+            .unwrap_or(0);
+        let effective_reserve = effective_delay_left_over(overlay_depth);
+        metrics::histogram!("bsc_miner_effective_reserve_ms").record(effective_reserve as f64);
         let mining_delay = parlia.clone().delay_for_mining(
             &mining_ctx.parent_snapshot,
             mining_ctx.header.as_ref().unwrap(),
-            DELAY_LEFT_OVER,
+            effective_reserve,
         );
         let pending_basefee = builder.pool.block_info().pending_basefee;
 


### PR DESCRIPTION
## What

Ports the miner adaptive root-reserve work from `fix/miner-adaptive-root-reserve` onto `develop-hardfork-pasteur`.

A straight rebase was not viable: the original branch diverged long ago (most lower commits are already squash-merged into develop) and, critically, develop **removed the triedb/pathdb state backend (#371)** while the original branch was written against it. So this is a clean **port** of the 6 genuinely-new miner commits, with the triedb coupling stripped.

## Commits

- `fix(miner): bound synchronous state-root fallback by slot deadline` — abort the sync full-trie fallback when already past the slot deadline (avoids ~700ms over-run cascading empty blocks). Adapted to develop's 2-tuple state-root return.
- `fix(miner): per-attempt sparse-trie root sink to stop cross-build theft` — fresh per-attempt `Arc<Mutex<>>` sink so a concurrent empty-fallback build can't steal this attempt's precomputed root. **triedb-decoupled**: dropped `finish_with_difflayer`/`difflayer`, uses develop's `finish(state, None)`.
- `feat(miner): instrument sparse-trie overlay depth + spawn duration`
- `perf(miner): share one long-lived changeset cache across sparse-trie spawns`
- `perf(miner): adaptive end-of-slot reserve by overlay depth`
- `perf(miner): make adaptive root-reserve knobs env-configurable`

The last 4 cherry-picked with zero conflicts.

## Notes

- Touches only `src/node/{engine.rs, evm/builder.rs, miner/payload.rs}` (+185/-11). No triedb/difflayer references remain.
- `cargo check` is clean (0 errors, 0 warnings) against develop's pinned reth rev `0dea17d2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)