### PR TITLE
fix(rpc/eth_config): return null blobSchedule to match go-bsc

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -438,8 +438,7 @@ fn main() -> eyre::Result<()> {
 
                         tracing::info!("Start to register eth_config (EIP-7910) API...");
                         use reth::api::FullNodeComponents;
-                        use reth_bsc::rpc::BscEthConfigHandler;
-                        use reth_rpc_eth_api::helpers::config::EthConfigApiServer;
+                        use reth_bsc::rpc::{BscEthConfigApiServer, BscEthConfigHandler};
                         use reth_rpc_server_types::RethRpcModule;
 
                         let eth_config = BscEthConfigHandler::new(

--- a/src/rpc/eth_config.rs
+++ b/src/rpc/eth_config.rs
@@ -1,5 +1,6 @@
-use alloy_eips::eip7910::{EthConfig, EthForkConfig, SystemContract};
+use alloy_eips::eip7910::{EthForkConfig, SystemContract};
 use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks, Hardforks};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
@@ -7,39 +8,63 @@ use reth_primitives_traits::header::HeaderMut;
 use reth_provider::BlockReaderIdExt;
 use reth_rpc_eth_api::helpers::config::{EthConfigApiServer, EthConfigHandler};
 
+use std::sync::Arc;
+
+use crate::hardforks::BscHardforks;
+use crate::hardforks::bsc::BscHardfork;
+use crate::node::evm::config::revm_spec_by_timestamp_and_block_number;
+
+/// BSC-specific `eth_config` (EIP-7910) RPC.
+///
+/// Returns a raw JSON value rather than alloy's [`EthConfig`](alloy_eips::eip7910::EthConfig)
+/// because BSC must be able to emit `blobSchedule: null` to match go-bsc, and alloy's
+/// `EthForkConfig::blob_schedule` is a required (non-optional) `BlobParams` that always serializes.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
+pub trait BscEthConfigApi {
+    /// Returns an object with data about recent and upcoming fork configurations.
+    #[method(name = "config")]
+    fn config(&self) -> RpcResult<serde_json::Value>;
+}
+
 /// BSC-specific wrapper around reth's [`EthConfigHandler`].
 ///
-/// Adjusts `systemContracts` to match geth-bsc behavior:
-/// - BSC has no Beacon Chain, so `BEACON_ROOTS_ADDRESS` is not included.
-/// - BSC only includes `HISTORY_STORAGE_ADDRESS` when Prague is active.
-/// - Other Ethereum-specific system contracts (ConsolidationRequest, Deposit,
-///   WithdrawalRequest) are not used on BSC.
+/// Adjusts the EIP-7910 output to match geth-bsc behavior:
+/// - `systemContracts`: BSC only exposes `HISTORY_STORAGE_ADDRESS` (from Prague); Ethereum-specific
+///   contracts (BeaconRoots, Deposit, Consolidation, Withdrawal) are dropped.
+/// - `blobSchedule`: mirrors go-bsc's `ChainConfig.BlobConfig(LatestFork(t))` — only the forks that
+///   go-bsc reports a blob config for keep a value; all others (incl. Mendel/Pasteur) become `null`.
 #[derive(Debug, Clone)]
 pub struct BscEthConfigHandler<Provider, Evm> {
     inner: EthConfigHandler<Provider, Evm>,
+    provider: Provider,
 }
 
 impl<Provider, Evm> BscEthConfigHandler<Provider, Evm>
 where
-    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>
+    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks + BscHardforks>
         + BlockReaderIdExt<Header: HeaderMut>
+        + Clone
         + 'static,
     Evm: ConfigureEvm<Primitives: NodePrimitives<BlockHeader = Provider::Header>> + 'static,
 {
     /// Creates a new [`BscEthConfigHandler`].
     pub fn new(provider: Provider, evm_config: Evm) -> Self {
-        Self { inner: EthConfigHandler::new(provider, evm_config) }
+        Self { inner: EthConfigHandler::new(provider.clone(), evm_config), provider }
     }
 }
 
-impl<Provider, Evm> EthConfigApiServer for BscEthConfigHandler<Provider, Evm>
+impl<Provider, Evm> BscEthConfigApiServer for BscEthConfigHandler<Provider, Evm>
 where
-    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>
+    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks + BscHardforks>
         + BlockReaderIdExt<Header: HeaderMut>
+        + Clone
         + 'static,
+    Arc<<Provider as ChainSpecProvider>::ChainSpec>: BscHardforks,
     Evm: ConfigureEvm<Primitives: NodePrimitives<BlockHeader = Provider::Header>> + 'static,
 {
-    fn config(&self) -> RpcResult<EthConfig> {
+    fn config(&self) -> RpcResult<serde_json::Value> {
+        // Build the standard EIP-7910 config via reth's handler, then apply BSC adjustments.
         let mut config = EthConfigApiServer::config(&self.inner)?;
         fix_bsc_system_contracts(&mut config.current);
         if let Some(ref mut next) = config.next {
@@ -48,8 +73,59 @@ where
         if let Some(ref mut last) = config.last {
             fix_bsc_system_contracts(last);
         }
-        Ok(config)
+
+        // Serialize to a raw value so `blobSchedule` can be nulled per go-bsc parity.
+        let mut value = serde_json::to_value(&config).map_err(|e| {
+            jsonrpsee::types::ErrorObjectOwned::owned(
+                jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+                e.to_string(),
+                None::<()>,
+            )
+        })?;
+
+        let chain_spec = self.provider.chain_spec();
+        let mut null_if_needed = |key: &str, activation_time: u64| {
+            // block_number is irrelevant for the post-merge (timestamp-gated) forks that carry
+            // blob params; u64::MAX keeps all block-based forks active so the timestamp decides.
+            let fork = revm_spec_by_timestamp_and_block_number(
+                chain_spec.clone(),
+                activation_time,
+                u64::MAX,
+            );
+            if !go_bsc_reports_blob_schedule(fork) {
+                if let Some(fork_obj) = value.get_mut(key).and_then(|v| v.as_object_mut()) {
+                    fork_obj.insert("blobSchedule".to_string(), serde_json::Value::Null);
+                }
+            }
+        };
+
+        null_if_needed("current", config.current.activation_time);
+        if let Some(ref next) = config.next {
+            null_if_needed("next", next.activation_time);
+        }
+        if let Some(ref last) = config.last {
+            null_if_needed("last", last.activation_time);
+        }
+
+        Ok(value)
     }
+}
+
+/// Mirrors go-bsc `params.ChainConfig.BlobConfig`: only these forks return a blob config; every
+/// other fork (including Mendel and Pasteur) yields `nil`, which serializes as `blobSchedule: null`.
+///
+/// go-bsc keeps: `Cancun`, `Prague`, `Fermi`, `Maxwell`, `Lorentz`, `Osaka`. The reth-bsc spec
+/// resolver never emits a standalone `Prague` (it is always superseded by a later BSC fork), so the
+/// observable set here is the same.
+const fn go_bsc_reports_blob_schedule(fork: BscHardfork) -> bool {
+    matches!(
+        fork,
+        BscHardfork::Cancun
+            | BscHardfork::Fermi
+            | BscHardfork::Maxwell
+            | BscHardfork::Lorentz
+            | BscHardfork::Osaka
+    )
 }
 
 /// Replaces the Ethereum system-contracts map with BSC's.


### PR DESCRIPTION
## Summary
Aligns reth-bsc's `eth_config` (EIP-7910) `blobSchedule` with go-bsc. reth now returns `blobSchedule: null` for the forks where go-bsc's `ChainConfig.BlobConfig(LatestFork(t))` returns `nil` (Mendel, Pasteur, …), instead of a populated object.

## Background
Reported divergence (chainId=714, Pasteur active):
- reth `eth_config().current.blobSchedule` → `{"target":3,"max":6,"baseFeeUpdateFraction":3338477}`
- go-bsc → `null`

Root cause: go-bsc's `BlobConfig` switch (`params/config.go`) returns a value only for `Cancun / Prague / Fermi / Maxwell / Lorentz / Osaka`; Mendel/Pasteur fall through to `default: nil` → `null`. reth carried the last-defined params forward. This PR replicates go-bsc's behavior for cross-client parity.

## Mechanism
- alloy's `EthForkConfig.blob_schedule` is a required (non-`Option`) `BlobParams` and always serializes, so reth structurally can't emit `null`.
- Added a BSC-specific `BscEthConfigApi` RPC returning a raw `serde_json::Value`. `config()` builds the normal EIP-7910 result via reth's inner `EthConfigHandler`, applies the existing `systemContracts` fix, then nulls `blobSchedule` on `current`/`next`/`last` for forks not in go-bsc's keep-set. Each snapshot's fork is resolved from its `activationTime` via `revm_spec_by_timestamp_and_block_number`.

## Testing
- `cargo build --bin reth-bsc` clean.
- Local 4×reth + 6×geth cluster, Pasteur active: reth `eth_config().current.blobSchedule` == `null`, matching all geth nodes.

## Notes
- **RPC introspection only — no consensus impact.** Both clients enforce the same blob params in block validation.
- Mirrors go-bsc's current behavior. If go-bsc later adds Mendel/Pasteur to `BlobConfig`, the keep-set in `go_bsc_reports_blob_schedule` should be updated in lockstep.
- Draft: no regression test added yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
