### PR TITLE
fix(hardforks): schedule Pasteur testnet activation

### DIFF
--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -121,8 +121,7 @@ impl BscHardfork {
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1768357800)), /* 2026-01-14 02:30:00 AM UTC */
             (Self::Osaka.boxed(), ForkCondition::Timestamp(1777343400)),
             (Self::Mendel.boxed(), ForkCondition::Timestamp(1777343400)),
-            // TODO: real activation TBD; unscheduled (u64::MAX) until announced.
-            (Self::Pasteur.boxed(), ForkCondition::Timestamp(u64::MAX)),
+            (Self::Pasteur.boxed(), ForkCondition::Timestamp(1784601000)), /* 2026-07-21 02:30:00 AM UTC */
         ])
     }
 
@@ -292,12 +291,20 @@ mod tests {
     }
 
     #[test]
-    fn test_pasteur_present_but_unscheduled_in_schedules() {
-        // No network has an announced Pasteur activation yet, so it must
-        // stay dormant (u64::MAX) until a real timestamp is set.
-        for hardforks in
-            [BscHardfork::bsc_mainnet(), BscHardfork::bsc_testnet(), BscHardfork::bsc_qanet()]
-        {
+    fn test_pasteur_scheduled_on_mainnet() {
+        // Mainnet has an announced Pasteur activation: 2026-07-21 02:30:00 AM UTC.
+        assert_eq!(
+            BscHardfork::bsc_mainnet().fork(BscHardfork::Pasteur),
+            ForkCondition::Timestamp(1784601000),
+            "Pasteur should activate on mainnet at its announced timestamp"
+        );
+    }
+
+    #[test]
+    fn test_pasteur_present_but_unscheduled_in_testnet_and_qanet() {
+        // Testnet and qanet have no announced Pasteur activation yet, so they
+        // must stay dormant (u64::MAX) until a real timestamp is set.
+        for hardforks in [BscHardfork::bsc_testnet(), BscHardfork::bsc_qanet()] {
             let activation = hardforks.fork(BscHardfork::Pasteur);
             assert_eq!(
                 activation,

--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -121,7 +121,8 @@ impl BscHardfork {
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1768357800)), /* 2026-01-14 02:30:00 AM UTC */
             (Self::Osaka.boxed(), ForkCondition::Timestamp(1777343400)),
             (Self::Mendel.boxed(), ForkCondition::Timestamp(1777343400)),
-            (Self::Pasteur.boxed(), ForkCondition::Timestamp(1784601000)), /* 2026-07-21 02:30:00 AM UTC */
+            // TODO: real activation TBD; unscheduled (u64::MAX) until announced.
+            (Self::Pasteur.boxed(), ForkCondition::Timestamp(u64::MAX)),
         ])
     }
 
@@ -169,8 +170,7 @@ impl BscHardfork {
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1762741500)),
             (Self::Osaka.boxed(), ForkCondition::Timestamp(1774319400)),
             (Self::Mendel.boxed(), ForkCondition::Timestamp(1774319400)),
-            // TODO: real activation TBD; unscheduled (u64::MAX) until announced.
-            (Self::Pasteur.boxed(), ForkCondition::Timestamp(u64::MAX)),
+            (Self::Pasteur.boxed(), ForkCondition::Timestamp(1784601000)), /* 2026-07-21 02:30:00 AM UTC */
         ])
     }
 
@@ -291,20 +291,20 @@ mod tests {
     }
 
     #[test]
-    fn test_pasteur_scheduled_on_mainnet() {
-        // Mainnet has an announced Pasteur activation: 2026-07-21 02:30:00 AM UTC.
+    fn test_pasteur_scheduled_on_testnet() {
+        // Testnet has an announced Pasteur activation: 2026-07-21 02:30:00 AM UTC.
         assert_eq!(
-            BscHardfork::bsc_mainnet().fork(BscHardfork::Pasteur),
+            BscHardfork::bsc_testnet().fork(BscHardfork::Pasteur),
             ForkCondition::Timestamp(1784601000),
-            "Pasteur should activate on mainnet at its announced timestamp"
+            "Pasteur should activate on testnet at its announced timestamp"
         );
     }
 
     #[test]
-    fn test_pasteur_present_but_unscheduled_in_testnet_and_qanet() {
-        // Testnet and qanet have no announced Pasteur activation yet, so they
+    fn test_pasteur_present_but_unscheduled_in_mainnet_and_qanet() {
+        // Mainnet and qanet have no announced Pasteur activation yet, so they
         // must stay dormant (u64::MAX) until a real timestamp is set.
-        for hardforks in [BscHardfork::bsc_testnet(), BscHardfork::bsc_qanet()] {
+        for hardforks in [BscHardfork::bsc_mainnet(), BscHardfork::bsc_qanet()] {
             let activation = hardforks.fork(BscHardfork::Pasteur);
             assert_eq!(
                 activation,


### PR DESCRIPTION
## Summary
- Sets the BSC testnet Pasteur hardfork activation timestamp to `1784601000` (2026-07-21 02:30:00 AM UTC), replacing the previous `u64::MAX` (unscheduled) placeholder.
- Mainnet and qanet Pasteur schedules remain unscheduled (`u64::MAX`) pending announcement.
- Splits the old `test_pasteur_present_but_unscheduled_in_schedules` test into `test_pasteur_scheduled_on_testnet` (asserts the new concrete timestamp) and `test_pasteur_present_but_unscheduled_in_mainnet_and_qanet` (keeps the dormant assertion for the still-unscheduled networks).

Supersedes #427, which was accidentally closed by a branch rename (the timestamp was initially, incorrectly, applied to mainnet instead of testnet).

## Test plan
- [x] `cargo test --all -- --test-threads=1` — 303 passed, 0 failed
- [x] `cargo clippy --lib --tests --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` on the touched file — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)