### PR TITLE
fix(consensus): stop validating requests hash content post-execution …

### DIFF
--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -859,7 +859,7 @@ where
         }
         // Build a stable sequence based on the index of validators in parent snapshot (although BLS aggregation order is irrelevant, it is convenient for debugging and consistency)
         let mut ordered_unique: Vec<(u64, VoteAddress, VoteSignature)> = Vec::new();
-        for (_, info) in target_header_parent_snap.validators_map.iter() {
+        for info in target_header_parent_snap.validators_map.values() {
             let vote_addr = info.vote_addr;
             if let Some(sig) = unique_by_addr.get(&vote_addr) {
                 ordered_unique.push((info.index, vote_addr, *sig));

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -252,7 +252,6 @@ impl<ChainSpec: EthChainSpec<Header = Header> + BscHardforks + 'static> FullCons
         _receipt_root_bloom: Option<ReceiptRootBloom>,
     ) -> Result<(), ConsensusError> {
         let receipts = &result.receipts;
-        let requests = &result.requests;
         let chain_spec = &self.chain_spec;
 
         // Check if gas used matches the value set in header.
@@ -282,20 +281,18 @@ impl<ChainSpec: EthChainSpec<Header = Header> + BscHardforks + 'static> FullCons
             }
         }
 
-        // Validate that the header requests hash matches the calculated requests hash
+        // BSC repurposes `requestsHash` as an opaque block-source tag rather than an
+        // EIP-7685 commitment: since BEP-675, validators stamp MEV-built blocks with
+        // `(version, builder address)` while locally built blocks keep the empty
+        // requests hash. go-bsc's `Parlia.VerifyRequests` accepts any value and only
+        // enforces presence after Prague, so comparing the content against the hash
+        // of collected requests would reject canonical builder blocks.
         if chain_spec.is_prague_active_at_block_and_timestamp(
             block.header().number,
             block.header().timestamp,
-        ) {
-            let Some(header_requests_hash) = block.header().requests_hash else {
-                return Err(ConsensusError::RequestsHashMissing);
-            };
-            let requests_hash = requests.requests_hash();
-            if requests_hash != header_requests_hash {
-                return Err(ConsensusError::BodyRequestsHashDiff(
-                    GotExpected::new(requests_hash, header_requests_hash).into(),
-                ));
-            }
+        ) && block.header().requests_hash.is_none()
+        {
+            return Err(ConsensusError::RequestsHashMissing);
         }
         Ok(())
     }
@@ -1024,6 +1021,53 @@ mod tests {
         assert_eq!(finalized, (99, parent_hash), "14 votes should reach quorum");
 
         vote_pool::drain();
+    }
+
+    #[test]
+    fn post_execution_requests_hash_is_presence_only() {
+        use alloy_primitives::b256;
+        use reth_chainspec::EthereumHardfork;
+
+        let chain_spec = Arc::new(BscChainSpec::from(
+            ChainSpecBuilder::mainnet()
+                .with_fork(EthereumHardfork::Prague, ForkCondition::Timestamp(0))
+                .build(),
+        ));
+        let consensus = BscConsensus::new(chain_spec);
+        let result = BlockExecutionResult::default();
+
+        let block_with = |requests_hash: Option<B256>| {
+            let header = Header {
+                number: 118_130_133,
+                timestamp: 1_751_900_000,
+                requests_hash,
+                ..Default::default()
+            };
+            RecoveredBlock::new_unhashed(
+                BscBlock { header, body: BscBlockBody::default() },
+                Vec::new(),
+            )
+        };
+
+        // BEP-675 block-source tag as seen at BSC testnet block 118130133: version
+        // byte 0x01 (legacy bid path) followed by the MEV builder address. Not an
+        // EIP-7685 commitment, so it must be accepted without content validation.
+        let tagged = b256!("0000000000000000000000016c98eb21139f6e12db5b78a4aed4d8eba147fb7b");
+        assert!(consensus
+            .validate_block_post_execution(&block_with(Some(tagged)), &result, None)
+            .is_ok());
+
+        // Locally built blocks keep the empty requests hash, sha256("").
+        let empty = b256!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        assert!(consensus
+            .validate_block_post_execution(&block_with(Some(empty)), &result, None)
+            .is_ok());
+
+        // The field itself is still mandatory after Prague.
+        assert!(matches!(
+            consensus.validate_block_post_execution(&block_with(None), &result, None),
+            Err(ConsensusError::RequestsHashMissing)
+        ));
     }
 }
 

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -972,7 +972,7 @@ where
             sender_txs_map.entry(pool_tx.sender()).or_insert_with(Vec::new).push(pool_tx);
         }
 
-        for (_sender, txs) in sender_txs_map.iter_mut() {
+        for txs in sender_txs_map.values_mut() {
             for i in (0..txs.len()).rev() {
                 let tx_hash = txs[i].hash();
                 if bid_tx_hashes.contains(tx_hash) {

--- a/src/system_contracts/abi.rs
+++ b/src/system_contracts/abi.rs
@@ -6093,7 +6093,7 @@ mod tests {
             .unwrap();
 
         let input_str = hex::encode(&input);
-        println!("encoded data: {:?}", &input_str);
+        println!("encoded data: {input_str:?}");
         assert_eq!(input_str, expected);
     }
 


### PR DESCRIPTION
…(#431)

* fix(consensus): stop validating requests hash content post-execution

Since BEP-675, go-bsc repurposes header.requestsHash as an opaque block-source tag: validators stamp MEV-built blocks with (version, builder address) while locally built blocks keep the empty requests hash. go-bsc's Parlia.VerifyRequests accepts any value and only enforces presence after Prague, so comparing the content against the EIP-7685 hash of collected requests rejects canonical builder blocks and stalls sync (first hit at testnet block 118130133).

Keep the presence-only rule and drop the content comparison.



* chore: fix clippy lints flagged by rust 1.97

CI clippy runs on latest stable; 1.97 newly flags for_kv_map in consensus.rs/bid_simulator.rs and useless_borrows_in_formatting in abi.rs, failing the workspace with -D warnings.
