### PR TITLE
feat(version): clarify BSC release in `reth --version` and reth_info (#445)

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          # Full history + tags so `git describe --tags` in build.rs can resolve
+          # the release tag into RETH_BSC_VERSION (e.g. 0.1.0-fix).
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/build.rs
+++ b/build.rs
@@ -16,10 +16,27 @@ fn main() {
         .and_then(|o| if o.status.success() { String::from_utf8(o.stdout).ok() } else { None })
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
+    // Emit the BSC release identifier (e.g. `0.1.0-fix`) from the nearest git tag.
+    //
+    // `git describe --tags` resolves the closest ancestor tag, so a binary built
+    // from the `v0.1.0-fix` tag reports `0.1.0-fix` (distinguishing it from
+    // `v0.1.0`), while dev builds report `<tag>-<n>-g<sha>[-dirty]`. Falls back to
+    // the Cargo package version when git metadata is unavailable.
+    let bsc_version = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|o| if o.status.success() { String::from_utf8(o.stdout).ok() } else { None })
+        .map(|s| s.trim().trim_start_matches('v').to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    println!("cargo:rustc-env=RETH_BSC_VERSION={bsc_version}");
     println!("cargo:rustc-env=RETH_BSC_GIT_SHA={git_sha_short}");
     println!("cargo:rustc-env=RETH_BSC_GIT_SHA_LONG={git_sha_long}");
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/heads");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
 
     // Define hardforks that contain system contracts (matching hardfork_to_dir_name function)
     let hardforks = vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,17 +138,45 @@ fn main() -> eyre::Result<()> {
     // this binary as Reth-BSC with its own version + commit.
     {
         use std::borrow::Cow;
-        let pkg_version = env!("CARGO_PKG_VERSION");
+        // The BSC release identifier (e.g. `0.1.0-fix`), derived from the nearest
+        // git tag in build.rs. This is what distinguishes patch/fix releases that
+        // share a Cargo package version.
+        let bsc_version = env!("RETH_BSC_VERSION");
         let git_sha_short = env!("RETH_BSC_GIT_SHA");
         let git_sha_long = env!("RETH_BSC_GIT_SHA_LONG");
+
         let mut md = default_reth_version_metadata();
+        // Capture the upstream Reth identity before we overwrite these fields, so
+        // both the BSC and upstream builds can be reported in `reth --version`.
+        let upstream_reth_version = md.cargo_pkg_version.clone();
+        let upstream_reth_sha = md.vergen_git_sha_long.clone();
+        let build_timestamp = md.vergen_build_timestamp.clone();
+        let cargo_features = md.vergen_cargo_features.clone();
+        let build_profile = md.build_profile_name.clone();
+
         md.name_client = Cow::Borrowed("Reth-BSC");
-        md.cargo_pkg_version = Cow::Borrowed(pkg_version);
+        // Expose the BSC release id as the primary version. This flows into the
+        // `reth_info{version=...}` metric and the DB client version, so `0.1.0-fix`
+        // is distinguishable from `0.1.0` without a commit-to-tag lookup.
+        md.cargo_pkg_version = Cow::Borrowed(bsc_version);
         md.vergen_git_sha = Cow::Borrowed(git_sha_short);
         md.vergen_git_sha_long = Cow::Borrowed(git_sha_long);
-        md.short_version = Cow::Owned(format!("{pkg_version} ({git_sha_short})"));
+        md.short_version = Cow::Owned(format!("{bsc_version} ({git_sha_short})"));
+        // Report both the BSC release/commit and the upstream Reth version/commit
+        // that this binary was built against.
+        // Note: the CLI prepends the client name ("Reth-BSC") to the first line,
+        // so line 0 is just "Version: ..." to render as "Reth-BSC Version: ...".
+        md.long_version = Cow::Owned(format!(
+            "Version: {bsc_version}\n\
+             Commit SHA: {git_sha_long}\n\
+             Upstream Reth Version: {upstream_reth_version}\n\
+             Upstream Reth Commit SHA: {upstream_reth_sha}\n\
+             Build Timestamp: {build_timestamp}\n\
+             Build Features: {cargo_features}\n\
+             Build Profile: {build_profile}",
+        ));
         md.p2p_client_version = Cow::Owned(format!(
-            "reth-bsc/v{pkg_version}-{git_sha_short}/{}",
+            "reth-bsc/v{bsc_version}-{git_sha_short}/{}",
             std::env::consts::OS,
         ));
         let _ = try_init_version_metadata(md);


### PR DESCRIPTION
Closes #445.

## Problem

`reth --version` showed only the **upstream Reth** version/commit, and `reth_info{version=...}` used the Cargo package version (`0.1.0`), which can't distinguish releases that share it — e.g. `v0.1.0` vs `v0.1.0-fix` both report `0.1.0`. Identifying a deployed binary required mapping the commit SHA back to a tag by hand.

## Change

- **`build.rs`** — emit `RETH_BSC_VERSION` from `git describe --tags --always --dirty` (leading `v` stripped). A binary built from the `v0.1.0-fix` tag reports `0.1.0-fix`; dev builds report `<tag>-<n>-g<sha>`. Falls back to the Cargo package version when git metadata is unavailable.
- **`src/main.rs`** — set the BSC release id as `cargo_pkg_version` (flows into `reth_info{version}`, the short version, and the DB client version so releases are distinguishable), and override `long_version` to report **both** the BSC release/commit and the upstream Reth version/commit the binary was built against.
- **`Release.yml`** — checkout with `fetch-depth: 0` so the release tag is always visible to `git describe` (the default shallow clone can hide it).

## Result

`reth --version` (built from a `v0.1.0-fix` tag):

```text
Reth-BSC Version: 0.1.0-fix
Commit SHA: <bsc-commit-sha>
Upstream Reth Version: 2.2.0
Upstream Reth Commit SHA: <upstream-reth-sha>
Build Timestamp: ...
Build Features: ...
Build Profile: ...
```

`reth_info{version="0.1.0-fix", git_sha="<bsc-short-sha>", ...} 1` — the version label now distinguishes patch/fix releases without a commit-to-tag lookup.

## Notes

- Verified locally: `cargo build --bin reth-bsc` + `reth-bsc --version` / `-V` render as above (the `git describe` tag resolution confirmed with a throwaway tag on HEAD).
- A dedicated `bsc_version` metric label (as the issue also suggested) would require changing upstream Reth's `VersionInfo` struct; reusing the existing `version` label keeps the fix entirely within reth-bsc while achieving the same distinguishability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)