### PR TITLE
Merge from develop to main 

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          # Full history + tags so `git describe --tags` in build.rs can resolve
+          # the release tag into RETH_BSC_VERSION (e.g. 0.1.0-fix).
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 6.2.1",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -1852,7 +1852,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cow-utils",
- "dashmap",
+ "dashmap 6.2.1",
  "dynify",
  "fast-float2",
  "float16",
@@ -2089,6 +2089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2172,15 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
@@ -2176,12 +2191,25 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.9",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.3",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -2966,6 +2994,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -3513,6 +3554,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -5787,6 +5837,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.3",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6909,6 +6974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7458,7 +7534,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7499,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7509,7 +7585,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-execution-cache",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7526,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7543,12 +7619,13 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
  "revm-database",
  "revm-state",
+ "rust-eth-triedb-common",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7558,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7578,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7591,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7665,6 +7742,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -7680,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7690,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7739,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7755,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7768,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7781,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7807,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7820,7 +7898,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7836,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7862,11 +7940,12 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
+ "alloy-trie",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -7883,6 +7962,9 @@ dependencies = [
  "reth-static-file-types",
  "reth-trie",
  "reth-trie-db",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7892,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7907,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7932,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7945,7 +8027,7 @@ dependencies = [
  "rand 0.9.4",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -7956,10 +8038,10 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
- "dashmap",
+ "dashmap 6.2.1",
  "data-encoding",
  "enr",
  "hickory-resolver",
@@ -7980,7 +8062,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7996,7 +8078,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -8015,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8043,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8066,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8091,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8118,7 +8200,7 @@ dependencies = [
  "reth-evm",
  "reth-execution-cache",
  "reth-execution-types",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8139,6 +8221,10 @@ dependencies = [
  "reth-trie-sparse",
  "revm",
  "revm-primitives",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "rust-eth-triedb-state-trie",
  "schnellru",
  "thiserror 2.0.18",
  "tokio",
@@ -8148,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8176,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8192,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8208,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8230,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8241,7 +8327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8255,7 +8341,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8270,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8295,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "clap",
  "eyre",
@@ -8318,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8334,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8350,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8364,7 +8450,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8394,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8408,7 +8494,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8418,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8431,18 +8517,19 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
+ "rust-eth-triedb-common",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8462,14 +8549,14 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
  "metrics",
  "parking_lot",
  "reth-errors",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -8480,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8493,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8512,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8529,7 +8616,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8550,7 +8637,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8564,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "serde",
  "serde_json",
@@ -8574,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8602,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8622,12 +8709,12 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
  "crossbeam-queue",
- "dashmap",
+ "dashmap 6.2.1",
  "derive_more 2.1.1",
  "parking_lot",
  "reth-mdbx-sys",
@@ -8639,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "bindgen",
  "cc",
@@ -8648,7 +8735,20 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+dependencies = [
+ "futures",
+ "metrics",
+ "metrics-derive",
+ "reth-primitives-traits",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "reth-metrics"
+version = "2.2.0"
+source = "git+https://github.com/bnb-chain/reth.git#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "futures",
  "metrics",
@@ -8661,7 +8761,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8670,7 +8770,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8684,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8715,7 +8815,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
  "reth-fs-util",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8742,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8767,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8790,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8805,7 +8905,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8819,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8836,7 +8936,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8860,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8873,6 +8973,7 @@ dependencies = [
  "fdlimit",
  "futures",
  "jsonrpsee",
+ "metrics",
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
@@ -8918,6 +9019,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
+ "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -8928,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8983,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -9021,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9045,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9069,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9082,7 +9184,7 @@ dependencies = [
  "metrics-util",
  "procfs",
  "reqwest 0.13.4",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9093,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9105,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9116,7 +9218,7 @@ dependencies = [
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
  "reth-execution-cache",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9129,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9141,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9165,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9187,7 +9289,7 @@ dependencies = [
  "arbitrary",
  "byteorder",
  "bytes 1.11.1",
- "dashmap",
+ "dashmap 6.2.1",
  "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
@@ -9207,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9230,7 +9332,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9245,6 +9347,8 @@ dependencies = [
  "revm-database",
  "revm-state",
  "rocksdb",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
  "strum",
  "tokio",
  "tracing",
@@ -9253,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9265,7 +9369,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9282,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9298,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9313,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9356,7 +9460,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9377,6 +9481,7 @@ dependencies = [
  "revm",
  "revm-inspectors",
  "revm-primitives",
+ "rust-eth-triedb",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -9390,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -9420,7 +9525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9435,7 +9540,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-api",
  "reth-node-core",
  "reth-payload-primitives",
@@ -9463,7 +9568,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9484,7 +9589,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9496,7 +9601,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9515,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9554,6 +9659,7 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
+ "rust-eth-triedb",
  "serde_json",
  "tokio",
  "tracing",
@@ -9562,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9587,7 +9693,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9610,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.1",
@@ -9624,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9654,12 +9760,13 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
@@ -9698,6 +9805,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "rust-eth-triedb",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -9707,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9718,7 +9826,7 @@ dependencies = [
  "reth-codecs",
  "reth-consensus",
  "reth-errors",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9735,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9749,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9769,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9784,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9808,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9826,17 +9934,17 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "crossbeam-utils",
- "dashmap",
+ "dashmap 6.2.1",
  "futures-util",
  "libc",
  "metrics",
  "parking_lot",
  "pin-project",
  "rayon",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "thiserror 2.0.18",
  "thread-priority",
  "tokio",
@@ -9847,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9863,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9873,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "clap",
  "eyre",
@@ -9888,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "clap",
  "eyre",
@@ -9906,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9930,7 +10038,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -9951,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9963,7 +10071,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -9977,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9997,6 +10105,8 @@ dependencies = [
  "reth-codecs",
  "reth-primitives-traits",
  "revm-database",
+ "rust-eth-triedb",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_with",
 ]
@@ -10004,27 +10114,28 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
+ "rust-eth-triedb",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10037,7 +10148,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
@@ -10052,7 +10163,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=0dea17d20f358768ac2d458bef170d8f0ab1df59#0dea17d20f358768ac2d458bef170d8f0ab1df59"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10060,7 +10171,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
@@ -10158,7 +10269,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",
@@ -10587,6 +10698,77 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rust-eth-triedb"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "metrics",
+ "once_cell",
+ "rayon",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git)",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "rust-eth-triedb-state-trie",
+ "schnellru",
+ "serde",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+ "tracing",
+]
+
+[[package]]
+name = "rust-eth-triedb-common"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
+dependencies = [
+ "alloy-primitives",
+ "auto_impl",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+]
+
+[[package]]
+name = "rust-eth-triedb-pathdb"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "metrics",
+ "mini-moka",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git)",
+ "rocksdb",
+ "rust-eth-triedb-common",
+ "schnellru",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+ "tracing",
+]
+
+[[package]]
+name = "rust-eth-triedb-state-trie"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#e235d46535c316c22ce6ee7b54a16597b92098ee"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "arbitrary",
+ "auto_impl",
+ "hex 0.4.3",
+ "rand 0.8.6",
+ "rayon",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+ "tracing",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -11422,6 +11604,21 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata 0.14.2",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
 
 [[package]]
 name = "sketches-ddsketch"
@@ -12429,6 +12626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12647,7 +12850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
 reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
 
 revm = "38.0.0"
 revm-database = "13.0.0"

--- a/MIGRATE_V2.md
+++ b/MIGRATE_V2.md
@@ -1,0 +1,169 @@
+# Migrating storage layout v1 → v2 (`db migrate-v2`)
+
+`reth-bsc db migrate-v2` upgrades an existing node's on-disk storage from the
+legacy **v1** layout (everything in MDBX) to the **v2** layout (cold,
+append-only data lives in static files, hot state lives in MDBX/RocksDB). v2 is
+the layout the node uses going forward; running on v1 keeps you on a code path
+that is being phased out and that is slower and larger on disk.
+
+You only need to do this **once per datadir**. New datadirs created by a recent
+build are already v2 — `migrate-v2` will detect that and exit immediately.
+
+---
+
+## TL;DR
+
+```bash
+# 1. Stop the node (the migration needs exclusive access to the database).
+
+# 2. Back up — or at least make sure you can re-sync — before migrating.
+
+# 3. Run the migration (point it at the SAME chain + datadir the node uses).
+./target/release/reth-bsc db migrate-v2 \
+    --chain bsc \
+    --datadir /path/to/your/datadir
+
+# 4. Restart the node normally. It rebuilds the recomputable data via the
+#    pipeline on first run; the first start after migration takes longer.
+./target/release/reth-bsc node --chain bsc --datadir /path/to/your/datadir
+```
+
+> The migration is **idempotent against an already-migrated datadir**: if the
+> storage is already v2, the command logs `Storage is already v2, nothing to do`
+> and returns without touching anything.
+
+---
+
+## What it actually does
+
+The command runs in phases. Understanding them helps you read the logs and know
+what is safe to interrupt.
+
+| Phase | Action | Notes |
+| ----- | ------ | ----- |
+| 0 — Preflight | Reads current `StorageSettings`, finds the chain tip, and verifies the target static-file segments are empty. | Bails out if storage is already v2, or if the `AccountChangeSets` / `StorageChangeSets` static-file segments already contain data. |
+| 1 — Changesets | Moves `AccountChangeSets` and `StorageChangeSets` from MDBX into static files. | These cannot be recomputed, so they are *migrated*, not cleared. Respects existing prune checkpoints. |
+| 2 — Receipts | Moves `Receipts` into static files. | **Skipped** (receipts kept in MDBX) if you run with a receipt-log-filter prune config. Skipped if receipts are already in static files. |
+| 3 — Flip metadata | Writes `StorageSettings::v2()`. | After this point the datadir is marked v2. |
+| 4 — Clear recomputable tables | Clears senders, tx-hash/history indices, plain state, and trie tables, then resets the relevant stage checkpoints to 0. | This data is rebuilt by the pipeline on next node start. |
+| 5 — Compact MDBX | Copies MDBX to a compacted `db_compact`, then atomically swaps it in (keeping a temporary `db_pre_compact` backup that is removed on success). | This is where most of the disk-space reduction comes from. |
+| 6 — Pipeline rebuild | **Done by the node, not the command.** | On the next `node` start, stages with reset checkpoints (sender recovery, tx lookup, history indices, merkle) re-run to rebuild what was cleared. |
+
+So the data that *cannot* be recomputed (changesets + receipts) is preserved by
+moving it to static files; everything that *can* be recomputed is dropped and
+rebuilt, which is what lets the database compact down significantly.
+
+---
+
+## Datadir layout: which stores are involved
+
+A v2 datadir uses **three** stores, but the `migrate-v2` command itself only
+touches two of them. The third (RocksDB) is created by the node on the next
+restart.
+
+```
+<datadir>/<chain>/
+├── db/             # MDBX  — touched by migrate-v2 (read, cleared, compacted)
+├── static_files/   # static files — written by migrate-v2 (changesets, receipts)
+└── rocksdb/        # RocksDB — NOT created by migrate-v2; appears on first node restart
+```
+
+What ends up where under v2:
+
+| Store | Holds (v2) | Created/populated by |
+| ----- | ---------- | -------------------- |
+| `static_files/` | changesets, receipts, transaction senders | `migrate-v2` (changesets, receipts) + pipeline |
+| `rocksdb/` | history indices — `AccountsHistory`, `StoragesHistory`, `TransactionHashNumbers` | the **node**, on the first restart after migration |
+| `db/` (MDBX) | hashed state + remaining hot tables | the node |
+
+So during the migration, **only `db/` and `static_files/` are required and
+touched** (plus the transient `db_compact` / `db_pre_compact` directories created
+next to `db/` during compaction). The migration *clears* the history-index
+tables from MDBX but does **not** write RocksDB — those indices are rebuilt into
+a freshly created `rocksdb/` directory by the pipeline when you next start the
+node (the stages whose checkpoints were reset to 0 in phase 4). This is why the
+first restart after migration does extra work and takes longer.
+
+> You do not need to pre-create `rocksdb/`. If you keep your RocksDB on a
+> separate path via `--datadir.rocksdb <PATH>`, pass the same flag to the `node`
+> command after migrating so the node builds it where you expect.
+
+---
+
+## Requirements & precautions
+
+- **Stop the node first.** The migration opens the database read-write and needs
+  exclusive access. Running it against a live node will fail or contend on the
+  lock.
+- **Use the same `--chain` and `--datadir` your node uses.** Otherwise the
+  command operates on the wrong (or a non-existent) database. It errors out if
+  the datadir or database directory does not exist.
+- **Have enough free disk.** Phase 5 writes a *second*, compacted copy of MDBX
+  (`db_compact`) alongside the original before swapping. Make sure you have free
+  space roughly equal to your current MDBX size before starting. The compacted
+  copy plus the temporary `db_pre_compact` backup exist briefly at the same
+  time.
+- **Back up / be ready to re-sync.** The migration mutates the database in place.
+  It is designed to be safe and keeps a temporary backup during the swap, but a
+  snapshot of the datadir (or confidence that you can re-sync) is the cheapest
+  insurance.
+- **First restart is slower.** Because cleared tables are rebuilt by the
+  pipeline, the first `node` run after migration does extra work before it
+  reaches the tip. This is expected.
+
+---
+
+## Verifying the result
+
+Check the storage version with the `db settings` subcommand (or look for
+`Storage settings updated to v2` in the migration logs):
+
+```bash
+./target/release/reth-bsc db settings --chain bsc --datadir /path/to/your/datadir
+```
+
+Re-running `migrate-v2` on a migrated datadir is a safe no-op and is a quick way
+to confirm migration completed:
+
+```bash
+./target/release/reth-bsc db migrate-v2 --chain bsc --datadir /path/to/your/datadir
+# -> "Storage is already v2, nothing to do"
+```
+
+---
+
+## Troubleshooting
+
+- **`Static file segment ... already contains data. Cannot migrate — target
+  must be empty.`** — The changeset static-file segments already hold data,
+  meaning a previous (possibly partial) migration ran, or the datadir is in an
+  unexpected state. Do not force it; restore from backup or re-sync into a fresh
+  datadir.
+- **`Datadir does not exist` / `Database does not exist`** — You pointed the
+  command at the wrong path or chain. Match exactly what your `node` command
+  uses.
+- **Migration interrupted before the metadata flip (phase 3).** The original
+  data is still intact in MDBX. Re-running the command starts over; the preflight
+  empty-segment check protects against double-writing changesets.
+- **Disk filled up during compaction (phase 5).** Free up space and re-run.
+  The swap is atomic — on failure it restores the original database from the
+  `db_pre_compact` backup.
+
+---
+
+## FAQ
+
+**Do I have to migrate?** Not immediately, but v2 is the supported forward path.
+v1 is being phased out, runs slower, and uses more disk. Migrate when convenient.
+
+**Will it lose data?** No data that matters is discarded. Non-recomputable data
+(changesets, receipts) is moved to static files; recomputable data is rebuilt by
+the pipeline on next start.
+
+**How long does it take?** Proportional to database size — the changeset/receipt
+copy and the MDBX compaction dominate. Plan for a maintenance window on a
+mainnet-sized node, and expect the first node restart afterward to also take
+extra time for the pipeline rebuild.
+
+**Can I run it on a fresh/new node?** You don't need to. Recent builds create v2
+datadirs directly; `migrate-v2` will just report it's already v2.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ This client implements the BSC upgrade-status handshake extension. When EVN is e
 
 Note: This currently affects the outgoing handshake signaling. Further EVN behaviors (e.g., peer whitelists, conditional broadcast policies) can be added incrementally.
 
+## Storage migration (v1 → v2)
+
+Existing nodes on the legacy v1 storage layout can upgrade to the v2 layout
+(static files + RocksDB) with a one-time migration:
+
+```bash
+./target/release/reth-bsc db migrate-v2 --chain bsc --datadir ./data_dir
+```
+
+See [MIGRATE_V2.md](MIGRATE_V2.md) for the full guide — what it does, requirements, verification, and troubleshooting.
+
 ## Contributing
 
 We welcome community contributions! Please feel free to open issues or submit pull requests.

--- a/build.rs
+++ b/build.rs
@@ -16,10 +16,27 @@ fn main() {
         .and_then(|o| if o.status.success() { String::from_utf8(o.stdout).ok() } else { None })
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
+    // Emit the BSC release identifier (e.g. `0.1.0-fix`) from the nearest git tag.
+    //
+    // `git describe --tags` resolves the closest ancestor tag, so a binary built
+    // from the `v0.1.0-fix` tag reports `0.1.0-fix` (distinguishing it from
+    // `v0.1.0`), while dev builds report `<tag>-<n>-g<sha>[-dirty]`. Falls back to
+    // the Cargo package version when git metadata is unavailable.
+    let bsc_version = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|o| if o.status.success() { String::from_utf8(o.stdout).ok() } else { None })
+        .map(|s| s.trim().trim_start_matches('v').to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    println!("cargo:rustc-env=RETH_BSC_VERSION={bsc_version}");
     println!("cargo:rustc-env=RETH_BSC_GIT_SHA={git_sha_short}");
     println!("cargo:rustc-env=RETH_BSC_GIT_SHA_LONG={git_sha_long}");
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/heads");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
 
     // Define hardforks that contain system contracts (matching hardfork_to_dir_name function)
     let hardforks = vec![

--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -121,8 +121,7 @@ impl BscHardfork {
             (Self::Fermi.boxed(), ForkCondition::Timestamp(1768357800)), /* 2026-01-14 02:30:00 AM UTC */
             (Self::Osaka.boxed(), ForkCondition::Timestamp(1777343400)),
             (Self::Mendel.boxed(), ForkCondition::Timestamp(1777343400)),
-            // TODO: real activation TBD; unscheduled (u64::MAX) until announced.
-            (Self::Pasteur.boxed(), ForkCondition::Timestamp(u64::MAX)),
+            (Self::Pasteur.boxed(), ForkCondition::Timestamp(1787625000)), /* 2026-08-25 02:30:00 AM UTC */
         ])
     }
 
@@ -301,17 +300,24 @@ mod tests {
     }
 
     #[test]
-    fn test_pasteur_present_but_unscheduled_in_mainnet_and_qanet() {
-        // Mainnet and qanet have no announced Pasteur activation yet, so they
-        // must stay dormant (u64::MAX) until a real timestamp is set.
-        for hardforks in [BscHardfork::bsc_mainnet(), BscHardfork::bsc_qanet()] {
-            let activation = hardforks.fork(BscHardfork::Pasteur);
-            assert_eq!(
-                activation,
-                ForkCondition::Timestamp(u64::MAX),
-                "Pasteur should be defined but dormant until a real activation is set"
-            );
-        }
+    fn test_pasteur_scheduled_on_mainnet() {
+        // Mainnet has an announced Pasteur activation: 2026-08-25 02:30:00 AM UTC.
+        assert_eq!(
+            BscHardfork::bsc_mainnet().fork(BscHardfork::Pasteur),
+            ForkCondition::Timestamp(1787625000),
+            "Pasteur should activate on mainnet at its announced timestamp"
+        );
+    }
+
+    #[test]
+    fn test_pasteur_present_but_unscheduled_in_qanet() {
+        // Qanet has no announced Pasteur activation yet, so it must stay
+        // dormant (u64::MAX) until a real timestamp is set.
+        assert_eq!(
+            BscHardfork::bsc_qanet().fork(BscHardfork::Pasteur),
+            ForkCondition::Timestamp(u64::MAX),
+            "Pasteur should be defined but dormant until a real activation is set"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,17 +138,45 @@ fn main() -> eyre::Result<()> {
     // this binary as Reth-BSC with its own version + commit.
     {
         use std::borrow::Cow;
-        let pkg_version = env!("CARGO_PKG_VERSION");
+        // The BSC release identifier (e.g. `0.1.0-fix`), derived from the nearest
+        // git tag in build.rs. This is what distinguishes patch/fix releases that
+        // share a Cargo package version.
+        let bsc_version = env!("RETH_BSC_VERSION");
         let git_sha_short = env!("RETH_BSC_GIT_SHA");
         let git_sha_long = env!("RETH_BSC_GIT_SHA_LONG");
+
         let mut md = default_reth_version_metadata();
+        // Capture the upstream Reth identity before we overwrite these fields, so
+        // both the BSC and upstream builds can be reported in `reth --version`.
+        let upstream_reth_version = md.cargo_pkg_version.clone();
+        let upstream_reth_sha = md.vergen_git_sha_long.clone();
+        let build_timestamp = md.vergen_build_timestamp.clone();
+        let cargo_features = md.vergen_cargo_features.clone();
+        let build_profile = md.build_profile_name.clone();
+
         md.name_client = Cow::Borrowed("Reth-BSC");
-        md.cargo_pkg_version = Cow::Borrowed(pkg_version);
+        // Expose the BSC release id as the primary version. This flows into the
+        // `reth_info{version=...}` metric and the DB client version, so `0.1.0-fix`
+        // is distinguishable from `0.1.0` without a commit-to-tag lookup.
+        md.cargo_pkg_version = Cow::Borrowed(bsc_version);
         md.vergen_git_sha = Cow::Borrowed(git_sha_short);
         md.vergen_git_sha_long = Cow::Borrowed(git_sha_long);
-        md.short_version = Cow::Owned(format!("{pkg_version} ({git_sha_short})"));
+        md.short_version = Cow::Owned(format!("{bsc_version} ({git_sha_short})"));
+        // Report both the BSC release/commit and the upstream Reth version/commit
+        // that this binary was built against.
+        // Note: the CLI prepends the client name ("Reth-BSC") to the first line,
+        // so line 0 is just "Version: ..." to render as "Reth-BSC Version: ...".
+        md.long_version = Cow::Owned(format!(
+            "Version: {bsc_version}\n\
+             Commit SHA: {git_sha_long}\n\
+             Upstream Reth Version: {upstream_reth_version}\n\
+             Upstream Reth Commit SHA: {upstream_reth_sha}\n\
+             Build Timestamp: {build_timestamp}\n\
+             Build Features: {cargo_features}\n\
+             Build Profile: {build_profile}",
+        ));
         md.p2p_client_version = Cow::Owned(format!(
-            "reth-bsc/v{pkg_version}-{git_sha_short}/{}",
+            "reth-bsc/v{bsc_version}-{git_sha_short}/{}",
             std::env::consts::OS,
         ));
         let _ = try_init_version_metadata(md);

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,19 @@ pub struct BscCliArgs {
     pub evn_disable_tx_broadcast_forbidden: bool,
 }
 
+/// BSC default for `--gpo.ignoreprice` (wei), matching geth and pre-v2.2 reth-bsc.
+///
+/// BSC blocks carry many legitimate zero-gas-price transactions, most of them not sent
+/// by the block's coinbase, so with upstream's default threshold of 0 they dominate the
+/// gas-price-oracle sample and `eth_gasPrice` / `eth_maxPriorityFeePerGas` return 0.
+const BSC_DEFAULT_GPO_IGNORE_PRICE: u64 = 2;
+
+/// Returns true if `--gpo.ignoreprice` was passed explicitly, either as
+/// `--gpo.ignoreprice <value>` or `--gpo.ignoreprice=<value>`.
+fn user_set_gpo_ignore_price(mut args: impl Iterator<Item = String>) -> bool {
+    args.any(|arg| arg == "--gpo.ignoreprice" || arg.starts_with("--gpo.ignoreprice="))
+}
+
 fn main() -> eyre::Result<()> {
     // Override reth's global version metadata so startup/P2P logs identify
     // this binary as Reth-BSC with its own version + commit.
@@ -159,7 +172,7 @@ fn main() -> eyre::Result<()> {
                     as Arc<dyn FullConsensus<BscPrimitives>>,
             )
         },
-        async move |builder, args| {
+        async move |mut builder, args| {
             // Set genesis hash override if provided
             if let Err(e) = genesis_override::set_genesis_hash_override(args.genesis_hash) {
                 tracing::error!("Failed to set genesis hash override: {}", e);
@@ -170,7 +183,13 @@ fn main() -> eyre::Result<()> {
                 panic!("IPC is disabled, please enable it by setting --ipc.enable to true");
             }
             let ipc_path = builder.config().rpc.ipcpath.clone();
-            
+
+            // Apply the BSC gas-price-oracle default unless the user set the flag.
+            if !user_set_gpo_ignore_price(std::env::args()) {
+                builder.config_mut().rpc.gas_price_oracle.ignore_price =
+                    BSC_DEFAULT_GPO_IGNORE_PRICE;
+            }
+
             // Map CLI args into a global MiningConfig override before launching services
             {
                 use reth_bsc::node::miner::{config as mining_config, MiningConfig};
@@ -470,4 +489,21 @@ fn main() -> eyre::Result<()> {
         },
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::user_set_gpo_ignore_price;
+
+    fn args(v: &[&str]) -> std::vec::IntoIter<String> {
+        v.iter().map(|s| s.to_string()).collect::<Vec<_>>().into_iter()
+    }
+
+    #[test]
+    fn detects_explicit_gpo_ignore_price() {
+        assert!(user_set_gpo_ignore_price(args(&["reth-bsc", "node", "--gpo.ignoreprice", "0"])));
+        assert!(user_set_gpo_ignore_price(args(&["reth-bsc", "node", "--gpo.ignoreprice=7"])));
+        assert!(!user_set_gpo_ignore_price(args(&["reth-bsc", "node", "--chain", "bsc"])));
+        assert!(!user_set_gpo_ignore_price(args(&["reth-bsc", "node", "--gpo.blocks", "20"])));
+    }
 }

--- a/src/node/network/blocks_by_range.rs
+++ b/src/node/network/blocks_by_range.rs
@@ -4,7 +4,9 @@ use alloy_rpc_types::Withdrawals;
 use bytes::BufMut;
 
 use crate::node::network::bsc_protocol::protocol::proto::BscProtoMessageId;
-use crate::node::primitives::BscBlock;
+use crate::node::primitives::{BscBlock, BscBlobTransactionSidecar};
+use crate::BscBlockBody;
+use reth_ethereum_primitives::{BlockBody, TransactionSigned};
 
 /// Max range allowed in a single request, mirroring geth's constant.
 pub const MAX_REQUEST_RANGE_BLOCKS_COUNT: u64 = 64;
@@ -57,17 +59,142 @@ impl Encodable for BlocksByRangePacket {
 
 impl Decodable for BlocksByRangePacket {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        if buf.is_empty() {
-            return Err(alloy_rlp::Error::InputTooShort);
-        }
-        let msg = buf[0];
-        *buf = &buf[1..];
-        if msg != (BscProtoMessageId::BlocksByRange as u8) {
-            return Err(alloy_rlp::Error::Custom("Invalid message ID for BlocksByRangePacket"));
-        }
-        let inner = BlocksByRangePacketInner::decode(buf)?;
-        Ok(inner.into())
+        decode_blocks_by_range(buf).map_err(|e| e.error)
     }
+}
+
+/// Failure from [`decode_blocks_by_range`], carrying the `request_id` when it
+/// was readable before the failure point. The id is the first field of the
+/// packet, so it survives almost any malformation of the block payload —
+/// letting the stream fail the matching pending request immediately instead
+/// of letting it burn the full fetch timeout.
+#[derive(Debug)]
+pub struct BlocksByRangeDecodeError {
+    pub request_id: Option<u64>,
+    pub error: alloy_rlp::Error,
+}
+
+/// Decode a BlocksByRange frame (msg-id byte + packet). Same semantics as
+/// [`BlocksByRangePacket`]'s [`Decodable`] impl, but errors keep the
+/// already-decoded `request_id` (see [`BlocksByRangeDecodeError`]).
+pub fn decode_blocks_by_range(
+    buf: &mut &[u8],
+) -> Result<BlocksByRangePacket, BlocksByRangeDecodeError> {
+    let no_id = |error| BlocksByRangeDecodeError { request_id: None, error };
+
+    if buf.is_empty() {
+        return Err(no_id(alloy_rlp::Error::InputTooShort));
+    }
+    let msg = buf[0];
+    *buf = &buf[1..];
+    if msg != (BscProtoMessageId::BlocksByRange as u8) {
+        return Err(no_id(alloy_rlp::Error::Custom("Invalid message ID for BlocksByRangePacket")));
+    }
+    let head = alloy_rlp::Header::decode(buf).map_err(no_id)?;
+    if !head.list {
+        return Err(no_id(alloy_rlp::Error::UnexpectedString));
+    }
+    if buf.len() < head.payload_length {
+        return Err(no_id(alloy_rlp::Error::InputTooShort));
+    }
+    let started = buf.len();
+
+    let request_id = u64::decode(buf).map_err(no_id)?;
+    let with_id = |error| BlocksByRangeDecodeError { request_id: Some(request_id), error };
+
+    let blocks_head = alloy_rlp::Header::decode(buf).map_err(with_id)?;
+    if !blocks_head.list {
+        return Err(with_id(alloy_rlp::Error::UnexpectedString));
+    }
+    let blocks_started = buf.len();
+    let mut blocks = Vec::new();
+    while blocks_started - buf.len() < blocks_head.payload_length {
+        blocks.push(decode_wire_block_data(buf).map_err(with_id)?);
+    }
+    if blocks_started - buf.len() != blocks_head.payload_length {
+        return Err(with_id(alloy_rlp::Error::ListLengthMismatch {
+            expected: blocks_head.payload_length,
+            got: blocks_started - buf.len(),
+        }));
+    }
+
+    // Packet-level tolerance is pure future-proofing: BAL-era geth only
+    // extended the per-block encoding (see `decode_wire_block_data`), not the
+    // packet itself, so this skip is a no-op against every known sender.
+    skip_unknown_trailing(buf, head.payload_length, started, "BlocksByRangePacket")
+        .map_err(with_id)?;
+    Ok(BlocksByRangePacket { request_id, blocks })
+}
+
+/// Decode one wire `BlockData`
+/// (`[header, txs, ommers, withdrawals?, sidecars?, <unknown trailing>*]`).
+///
+/// Known fields are decoded strictly; unknown trailing list elements are
+/// skipped instead of failing the whole packet. geth-bsc releases between
+/// bnb-chain/bsc#3374 (2025-09-30) and #3690 (2026-05-19) append a BEP-592
+/// block access list here, which a strict 5-field decode rejects with
+/// `unexpected list length` — starving fork recovery on any node whose only
+/// live bsc/2 peers run those releases (issue #374). Tolerating trailing
+/// data is confined to this wire path; `BscBlock`'s own RLP stays strict.
+fn decode_wire_block_data(buf: &mut &[u8]) -> alloy_rlp::Result<BscBlock> {
+    let head = alloy_rlp::Header::decode(buf)?;
+    if !head.list {
+        return Err(alloy_rlp::Error::UnexpectedString);
+    }
+    if buf.len() < head.payload_length {
+        return Err(alloy_rlp::Error::InputTooShort);
+    }
+    let started = buf.len();
+
+    let header = alloy_consensus::Header::decode(buf)?;
+    let transactions = Vec::<TransactionSigned>::decode(buf)?;
+    let ommers = Vec::<alloy_consensus::Header>::decode(buf)?;
+    let mut withdrawals = None;
+    let mut sidecars = None;
+    if started - buf.len() < head.payload_length {
+        withdrawals = Some(Withdrawals::decode(buf)?);
+    }
+    if started - buf.len() < head.payload_length {
+        sidecars = Some(Vec::<BscBlobTransactionSidecar>::decode(buf)?);
+    }
+
+    // BAL-era BlockData (geth v1.6.2–v1.7.5) is handled HERE: those releases
+    // append a 6th element — the BEP-592 block access list — after
+    // `sidecars`. It reaches this point as unconsumed trailing bytes of the
+    // block's list and is skipped, so the five known fields above decode the
+    // block exactly as if the BAL were absent. Any future trailing extension
+    // takes the same path.
+    skip_unknown_trailing(buf, head.payload_length, started, "BlockData")?;
+    Ok(BscBlock {
+        header,
+        body: BscBlockBody { inner: BlockBody { transactions, ommers, withdrawals }, sidecars },
+    })
+}
+
+/// Advance `buf` past any bytes left in the enclosing list after the known
+/// fields were decoded. Errors only if the fields overran the declared
+/// payload (a genuinely malformed message).
+fn skip_unknown_trailing(
+    buf: &mut &[u8],
+    payload_length: usize,
+    started: usize,
+    what: &'static str,
+) -> alloy_rlp::Result<()> {
+    let consumed = started - buf.len();
+    if consumed > payload_length {
+        return Err(alloy_rlp::Error::ListLengthMismatch { expected: payload_length, got: consumed });
+    }
+    let extra = payload_length - consumed;
+    if extra > 0 {
+        tracing::trace!(
+            target: "bsc_protocol",
+            what,
+            extra_bytes = extra,
+            "ignoring unknown trailing wire fields"
+        );
+        *buf = &buf[extra..];
+    }
+    Ok(())
 }
 
 /// Pure variant of [`build_blocks_by_range_response`] parameterised by a block
@@ -166,7 +293,12 @@ impl From<GetBlocksByRangePacketInner> for GetBlocksByRangePacket {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+/// Encode-only shape of the response packet. Decoding deliberately does NOT
+/// go through a derived `RlpDecodable` here — the derive's strict
+/// consumed-equals-declared check is exactly what rejected BAL-era peers
+/// (issue #374); the tolerant [`decode_blocks_by_range`] is the only decode
+/// path.
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable)]
 struct BlocksByRangePacketInner {
     request_id: u64,
     blocks: Vec<BscBlock>,
@@ -189,12 +321,6 @@ impl From<&BlocksByRangePacket> for BlocksByRangePacketInner {
             })
             .collect();
         Self { request_id: v.request_id, blocks }
-    }
-}
-
-impl From<BlocksByRangePacketInner> for BlocksByRangePacket {
-    fn from(v: BlocksByRangePacketInner) -> Self {
-        Self { request_id: v.request_id, blocks: v.blocks }
     }
 }
 
@@ -483,5 +609,232 @@ mod tests {
             resp.blocks.is_empty(),
             "no cache entry + no FullBlockProvider installed must yield empty response"
         );
+    }
+
+    // ---- BEP-592 BAL-era interop (issue #374) ----
+    //
+    // geth-bsc between bnb-chain/bsc#3374 (2025-09-30) and #3690 (2026-05-19)
+    // encoded `BlockData` with a 6th trailing element:
+    //   [header, txs, uncles, withdrawals, sidecars, BAL]
+    // where BAL is `BlockAccessListEncode { version, number, hash, sign_data,
+    // accounts }`. `NewBlockData` attached it unconditionally (no bsc/3
+    // gating), so bsc/2 peers receive it too whenever the serving geth holds
+    // a BAL for the block.
+
+    #[derive(Debug, RlpEncodable)]
+    struct BalStorageItem {
+        tx_index: u32,
+        dirty: bool,
+        key: B256,
+    }
+
+    #[derive(Debug, RlpEncodable)]
+    struct BalAccount {
+        tx_index: u32,
+        address: alloy_primitives::Address,
+        storage_items: Vec<BalStorageItem>,
+    }
+
+    /// Mirrors go-bsc `types.BlockAccessListEncode` (BEP-592 era).
+    #[derive(Debug, RlpEncodable)]
+    struct BalEncode {
+        version: u32,
+        number: u64,
+        hash: B256,
+        sign_data: alloy_primitives::Bytes,
+        accounts: Vec<BalAccount>,
+    }
+
+    /// Mirrors go-bsc BAL-era `bsc.BlockData` (6 elements). Go's
+    /// `rlp:"optional"` semantics force the earlier optionals (withdrawals,
+    /// sidecars) to be present (as empty lists) whenever BAL is attached.
+    #[derive(Debug, RlpEncodable)]
+    struct BalEraBlockData {
+        header: Header,
+        transactions: Vec<TransactionSigned>,
+        ommers: Vec<Header>,
+        withdrawals: Withdrawals,
+        sidecars: Vec<BscBlobTransactionSidecar>,
+        bal: BalEncode,
+    }
+
+    #[derive(Debug, RlpEncodable)]
+    struct BalEraPacketInner {
+        request_id: u64,
+        blocks: Vec<BalEraBlockData>,
+    }
+
+    fn dummy_bal(number: u64) -> BalEncode {
+        BalEncode {
+            version: 1,
+            number,
+            hash: B256::repeat_byte(0xbb),
+            sign_data: alloy_primitives::Bytes::from(vec![0u8; 65]),
+            accounts: vec![BalAccount {
+                tx_index: 0,
+                address: alloy_primitives::Address::repeat_byte(0xaa),
+                storage_items: vec![
+                    BalStorageItem { tx_index: 0, dirty: true, key: B256::repeat_byte(0x01) },
+                    BalStorageItem { tx_index: 0, dirty: false, key: B256::repeat_byte(0x02) },
+                ],
+            }],
+        }
+    }
+
+    #[test]
+    fn blocks_by_range_ignores_bal_era_blockdata_trailing_field() {
+        // Regression for issue #374: before the tolerant wire decode this
+        // exact packet failed with `unexpected list length (got …, expected …)`
+        // and starved fork recovery. It must now decode, with the BAL ignored.
+        let packet = BalEraPacketInner {
+            request_id: 374,
+            blocks: vec![BalEraBlockData {
+                header: Header::default(),
+                transactions: Vec::new(),
+                ommers: Vec::new(),
+                withdrawals: Withdrawals::default(),
+                sidecars: Vec::new(),
+                bal: dummy_bal(1),
+            }],
+        };
+        let mut bytes = BytesMut::new();
+        bytes.put_u8(BscProtoMessageId::BlocksByRange as u8);
+        packet.encode(&mut bytes);
+
+        let mut slice = bytes.as_ref();
+        let decoded = BlocksByRangePacket::decode(&mut slice)
+            .expect("BAL-era 6-element BlockData must decode with the BAL ignored");
+        assert_eq!(decoded.request_id, 374);
+        assert_eq!(decoded.blocks.len(), 1);
+        assert_eq!(
+            decoded.blocks[0].header.hash_slow(),
+            Header::default().hash_slow(),
+            "header must survive the tolerant decode intact"
+        );
+        assert_eq!(decoded.blocks[0].body.inner.withdrawals, Some(Withdrawals::default()));
+        assert_eq!(decoded.blocks[0].body.sidecars, Some(Vec::new()));
+    }
+
+    #[test]
+    fn blocks_by_range_ignores_packet_level_trailing_fields() {
+        // Same tolerance one level up: unknown elements after `blocks` in the
+        // packet list must not fail the decode either.
+        #[derive(Debug, RlpEncodable)]
+        struct PacketWithTrailing {
+            request_id: u64,
+            blocks: Vec<BalEraBlockData>,
+            future_field: alloy_primitives::Bytes,
+        }
+        let packet = PacketWithTrailing {
+            request_id: 99,
+            blocks: vec![BalEraBlockData {
+                header: Header::default(),
+                transactions: Vec::new(),
+                ommers: Vec::new(),
+                withdrawals: Withdrawals::default(),
+                sidecars: Vec::new(),
+                bal: dummy_bal(2),
+            }],
+            future_field: alloy_primitives::Bytes::from(vec![0x42u8; 33]),
+        };
+        let mut bytes = BytesMut::new();
+        bytes.put_u8(BscProtoMessageId::BlocksByRange as u8);
+        packet.encode(&mut bytes);
+
+        let mut slice = bytes.as_ref();
+        let decoded = BlocksByRangePacket::decode(&mut slice)
+            .expect("packet-level trailing fields must be ignored");
+        assert_eq!(decoded.request_id, 99);
+        assert_eq!(decoded.blocks.len(), 1);
+    }
+
+    #[test]
+    fn blocks_by_range_still_rejects_truncated_packet() {
+        // Tolerance must not become acceptance of garbage: a packet whose
+        // fields overrun the declared list payload still fails.
+        let packet = BalEraPacketInner {
+            request_id: 7,
+            blocks: vec![BalEraBlockData {
+                header: Header::default(),
+                transactions: Vec::new(),
+                ommers: Vec::new(),
+                withdrawals: Withdrawals::default(),
+                sidecars: Vec::new(),
+                bal: dummy_bal(3),
+            }],
+        };
+        let mut bytes = BytesMut::new();
+        bytes.put_u8(BscProtoMessageId::BlocksByRange as u8);
+        packet.encode(&mut bytes);
+        let truncated = &bytes[..bytes.len() - 10];
+        let mut slice = truncated;
+        BlocksByRangePacket::decode(&mut slice)
+            .expect_err("truncated packet must still fail to decode");
+    }
+
+    #[test]
+    fn decode_error_carries_request_id_for_fail_fast() {
+        // A frame whose body is garbage after the request id fails to decode,
+        // but the error still yields the id — so the stream can fail the
+        // pending waiter immediately instead of waiting out the fetch timeout.
+        #[derive(Debug, RlpEncodable)]
+        struct GarbagePacket {
+            request_id: u64,
+            junk: alloy_primitives::Bytes,
+        }
+        let mut bytes = BytesMut::new();
+        bytes.put_u8(BscProtoMessageId::BlocksByRange as u8);
+        GarbagePacket { request_id: 4242, junk: alloy_primitives::Bytes::from(vec![7u8; 16]) }
+            .encode(&mut bytes);
+        let err = decode_blocks_by_range(&mut bytes.as_ref())
+            .expect_err("garbage block payload must fail to decode");
+        assert_eq!(err.request_id, Some(4242));
+
+        // Failures before the request id is reachable carry no id.
+        let err = decode_blocks_by_range(&mut &[0xffu8, 0xc0][..])
+            .expect_err("wrong message id must fail");
+        assert_eq!(err.request_id, None);
+        let err = decode_blocks_by_range(&mut &[][..]).expect_err("empty frame must fail");
+        assert_eq!(err.request_id, None);
+    }
+
+    #[test]
+    fn blocks_by_range_accepts_five_element_blockdata_control() {
+        // Control: identical shape minus the BAL element (what post-#3690 geth
+        // sends, withdrawals/sidecars present-but-empty) decodes fine, proving
+        // the rejection above is caused by the trailing BAL specifically.
+        #[derive(Debug, RlpEncodable)]
+        struct FiveElementBlockData {
+            header: Header,
+            transactions: Vec<TransactionSigned>,
+            ommers: Vec<Header>,
+            withdrawals: Withdrawals,
+            sidecars: Vec<BscBlobTransactionSidecar>,
+        }
+        #[derive(Debug, RlpEncodable)]
+        struct FiveElementPacketInner {
+            request_id: u64,
+            blocks: Vec<FiveElementBlockData>,
+        }
+
+        let packet = FiveElementPacketInner {
+            request_id: 375,
+            blocks: vec![FiveElementBlockData {
+                header: Header::default(),
+                transactions: Vec::new(),
+                ommers: Vec::new(),
+                withdrawals: Withdrawals::default(),
+                sidecars: Vec::new(),
+            }],
+        };
+        let mut bytes = BytesMut::new();
+        bytes.put_u8(BscProtoMessageId::BlocksByRange as u8);
+        packet.encode(&mut bytes);
+
+        let mut slice = bytes.as_ref();
+        let decoded = BlocksByRangePacket::decode(&mut slice)
+            .expect("5-element BlockData must decode");
+        assert_eq!(decoded.request_id, 375);
+        assert_eq!(decoded.blocks.len(), 1);
     }
 }

--- a/src/node/network/bsc_protocol/stream.rs
+++ b/src/node/network/bsc_protocol/stream.rs
@@ -325,7 +325,9 @@ impl BscProtocolConnection {
             }
             x if x == BscProtoMessageId::BlocksByRange as u8 => {
                 tracing::debug!(target: "bsc_protocol", "Processing BlocksByRange response");
-                match BlocksByRangePacket::decode(&mut &slice[..]) {
+                match crate::node::network::blocks_by_range::decode_blocks_by_range(
+                    &mut &slice[..],
+                ) {
                     Ok(res) => {
                         tracing::debug!(
                             target: "bsc_protocol",
@@ -340,8 +342,28 @@ impl BscProtocolConnection {
                         }
                         None
                     }
-                    Err(e) => {
-                        tracing::warn!(target: "bsc_protocol", error = %e, "Failed to decode BlocksByRangePacket");
+                    Err(err) => {
+                        // The decode error carries the request id when it was
+                        // readable, so the pending waiter fails now instead of
+                        // burning the full fetch timeout; the extra fields make
+                        // the sender diagnosable in the field (issue #374).
+                        tracing::warn!(
+                            target: "bsc_protocol",
+                            error = %err.error,
+                            peer = ?self._peer_id,
+                            proto_version = self.proto_version,
+                            frame_len = slice.len(),
+                            request_id = ?err.request_id,
+                            "Failed to decode BlocksByRangePacket"
+                        );
+                        if let Some(req_id) = err.request_id {
+                            if let Some((waiter, _)) = self.pending_range_reqs.remove(&req_id) {
+                                let _ = waiter.send(Err(format!(
+                                    "failed to decode BlocksByRangePacket: {}",
+                                    err.error
+                                )));
+                            }
+                        }
                         None
                     }
                 }

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -192,6 +192,7 @@ fn apply_bsc_discv4_overrides<I>(
 fn apply_bsc_peer_stability_overrides(
     peers_config: &mut PeersConfig,
     sessions_config: &mut SessionsConfig,
+    user_max_outbound: Option<usize>,
 ) {
     // BANNED_REPUTATION = -51200. Weights below picked so a single event
     // does not cross it: ~4 bad_protocol, ~13 failed_to_connect, or ~50
@@ -207,8 +208,12 @@ fn apply_bsc_peer_stability_overrides(
     sessions_config.protocol_breach_request_timeout = Duration::from_secs(600);
 
     // Tentative: widen outbound pipeline against BSC mainnet's ~5-10% dial success rate.
+    // The raised outbound cap is a default only; an explicit --max-outbound-peers or
+    // --max-peers (already baked into peers_config by the CLI) wins.
     peers_config.connection_info.max_concurrent_outbound_dials = 64;
-    peers_config.connection_info.max_outbound = 256;
+    if user_max_outbound.is_none() {
+        peers_config.connection_info.max_outbound = 256;
+    }
 
     // Tentative: 30s covers cross-region bootnode handshakes that clip at the 20s default.
     sessions_config.pending_session_timeout = Duration::from_secs(30);
@@ -371,6 +376,7 @@ impl BscNetworkBuilder {
         apply_bsc_peer_stability_overrides(
             &mut network_config.peers_config,
             &mut network_config.sessions_config,
+            ctx.config().network.resolved_max_outbound_peers(),
         );
         network_config.status.forkid = network_config.fork_filter.current();
 
@@ -627,8 +633,9 @@ async fn register_nodeids_actions<P: StateProviderFactory>(
 
 #[cfg(test)]
 mod tests {
-    use super::apply_bsc_discv4_overrides;
+    use super::{apply_bsc_discv4_overrides, apply_bsc_peer_stability_overrides};
     use reth_discv4::{Discv4Config, NatResolver};
+    use reth_network::{PeersConfig, SessionsConfig};
     use reth_network_peers::NodeRecord;
     use std::{
         net::{IpAddr, Ipv4Addr},
@@ -648,5 +655,29 @@ mod tests {
         let discv4 = discv4.expect("discv4 config should remain enabled");
         assert_eq!(discv4.external_ip_resolver, Some(NatResolver::ExternalIp(external_ip)));
         assert_eq!(discv4.lookup_interval, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn peer_stability_overrides_raise_outbound_by_default() {
+        let mut peers = PeersConfig::default();
+        let mut sessions = SessionsConfig::default();
+
+        apply_bsc_peer_stability_overrides(&mut peers, &mut sessions, None);
+
+        assert_eq!(peers.connection_info.max_outbound, 256);
+        assert_eq!(peers.connection_info.max_concurrent_outbound_dials, 64);
+    }
+
+    #[test]
+    fn peer_stability_overrides_respect_user_max_outbound() {
+        // Mirror the CLI flow: the user's --max-outbound-peers is already applied
+        // to the config before the BSC overrides run.
+        let mut peers = PeersConfig::default().with_max_outbound(50);
+        let mut sessions = SessionsConfig::default();
+
+        apply_bsc_peer_stability_overrides(&mut peers, &mut sessions, Some(50));
+
+        assert_eq!(peers.connection_info.max_outbound, 50);
+        assert_eq!(peers.connection_info.max_concurrent_outbound_dials, 64);
     }
 }

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,30 +14,30 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate branch to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "mdbx",
     "test-utils",
     "disable-lock",
 ] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "test-utils",
 ] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59", features = [
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
     "std",
 ] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "0dea17d20f358768ac2d458bef170d8f0ab1df59" }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
 
 # revm
 revm = { version = "38.0.0", features = [


### PR DESCRIPTION
### Description

Release merge from `develop` into `main`, bundling the changes accumulated since the last release. Headline items:

- **reth dependency bump** to `main` @ `c13b0986`, which pulls in the upstream receipt-streaming fix (bnb-chain/reth #206) and the nightly-toolchain build fixes (#208). All `reth-*` pins in both the root crate and `testing/bsc-ef-tests` moved together.
- **Pasteur hardfork scheduled on BSC mainnet** — `2026-08-25 02:30:00 AM UTC` (#443).
- **Clear version identity** in `reth --version` and the `reth_info` metric (#446).
- Several **network-layer** fixes (BlocksByRange decode tolerance, outbound-peer cap, EVN) and the **gas-price-oracle** default restore.

### Rationale

- The reth bump was needed to consume the finalization-appended receipt-root fix and to keep the pinned fork building on the current nightly (the previous pin failed clippy/docs/tests under the latest nightly).
- Pasteur needs a concrete mainnet activation timestamp ahead of the fork.
- A deployed binary previously reported only the upstream Reth version/commit, and `reth_info{version="0.1.0"}` could not distinguish releases sharing a Cargo version (e.g. `v0.1.0` vs `v0.1.0-fix`) — making fleet inventory and incident triage rely on manual commit-to-tag lookups.

### Example

`reth --version` now reports both identities:

```text
Reth-BSC Version: 0.1.0-fix
Commit SHA: <bsc-commit>
Upstream Reth Version: 2.2.0
Upstream Reth Commit SHA: <upstream-reth-commit>
Build Timestamp: ...
Build Features: ...
Build Profile: ...
```

and `reth_info{version="0.1.0-fix", git_sha="<bsc-short-sha>", ...} 1`.

### Changes

Notable changes:
* **deps:** bump every `bnb-chain/reth` pin (root + `bsc-ef-tests`) `0dea17d` → `c13b0986`; `Cargo.lock` re-resolved to a single reth rev.
* **hardforks:** schedule Pasteur on BSC mainnet at `1787625000` (2026-08-25 02:30:00 UTC) (#443).
* **version:** `build.rs` emits `RETH_BSC_VERSION` from `git describe --tags`; `main.rs` sets it as the primary version (flows into `reth_info` + DB client version) and reports upstream Reth version/commit in `--version`; `Release.yml` checks out with `fetch-depth: 0` so the release tag resolves (#446, closes #445).
* **network:** tolerate unknown trailing fields in the `BlocksByRange` wire decode (#374/#441); respect `--max-outbound-peers` over the BSC stability override (#434).
* **rpc/gpo:** restore the BSC `--gpo.ignoreprice` default so `eth_gasPrice` is not skewed to `0` by zero-gas-price txs (#438).
* **docs:** add `MIGRATE_V2.md` and README notes (#421).

### Potential Impacts

* **reth bump** is the widest-reaching change; the pin is content-equivalent to reth `develop` at merge time. Verified `cargo check --workspace` clean and reth-bsc CI green on #443.
* **Pasteur mainnet timestamp** is now committed — confirm the date matches the coordinated network schedule before release/deploy.
* **version string / `reth_info{version}` format change** — dashboards or alerts that match the exact `version` label value (previously `0.1.0`) should be updated to the new release-id format.
* **gas-price-oracle default** changes `eth_gasPrice` / `eth_maxPriorityFeePerGas` behavior relative to upstream defaults.
* **BlocksByRange decode** now ignores unknown trailing wire fields (forward-compatible with geth BAL); no change for well-formed peers.
