### PR TITLE
fix(forkchoice): recover from forks whose base is below the persisted tip

### DIFF
--- a/src/consensus/parlia/forkchoice_rule.rs
+++ b/src/consensus/parlia/forkchoice_rule.rs
@@ -1,7 +1,11 @@
-use crate::{chainspec::BscChainSpec, hardforks::BscHardforks};
+use crate::{chainspec::BscChainSpec, hardforks::BscHardforks, metrics::BscConsensusMetrics};
 use alloy_consensus::Header;
 use alloy_primitives::U256;
+use once_cell::sync::Lazy;
 use std::{sync::Arc, cmp::Ordering};
+
+/// Metrics for fork-choice decisions taken without a resolvable total difficulty.
+static FORKCHOICE_METRICS: Lazy<BscConsensusMetrics> = Lazy::new(BscConsensusMetrics::default);
 
 /// Header with additional fork choice metadata.
 ///
@@ -145,12 +149,35 @@ impl BscForkChoiceRule {
         incoming: &HeaderForForkchoice,
         current: &HeaderForForkchoice,
     ) -> Result<bool, crate::consensus::ParliaConsensusErr> {
-        let current_td = current.td.ok_or(
-            crate::consensus::ParliaConsensusErr::UnknownTotalDifficulty(current.header.hash_slow(), current.header.number)
-        )?;
-        let incoming_td = incoming.td.ok_or(
-            crate::consensus::ParliaConsensusErr::UnknownTotalDifficulty(incoming.header.hash_slow(), incoming.header.number)
-        )?;
+        // An unresolvable TD must never abort the decision. Erroring here returns `Err` all the
+        // way out of `update_forkchoice`, so no forkchoice update is ever sent; the canonical
+        // head then stays pinned to `current`, which is precisely what makes the TD
+        // unresolvable in the first place (the persisted chain keeps the losing branch). That
+        // feedback loop is unrecoverable — see `td_unknown_prefers_higher_descendant` and the
+        // upstream `query_header_with_td` deep-fork gap.
+        //
+        // Fall back to height instead: only a STRICTLY higher block may win. That is
+        // conservative in the direction that matters — we never reorg to a sibling or to a
+        // lower block on the strength of missing information, and every candidate reaching
+        // here has already passed full payload validation (the block-import path only calls
+        // fork choice after `PayloadStatusEnum::Valid`), so it is a real, executed chain.
+        let (Some(current_td), Some(incoming_td)) = (current.td, incoming.td) else {
+            let reorg = incoming.header.number > current.header.number;
+            FORKCHOICE_METRICS.td_unknown_fallbacks_total.increment(1);
+            tracing::warn!(
+                target: "bsc::forkchoice",
+                incoming_number = incoming.header.number,
+                incoming_hash = ?incoming.header.hash_slow(),
+                incoming_td = ?incoming.td,
+                current_number = current.header.number,
+                current_hash = ?current.header.hash_slow(),
+                current_td = ?current.td,
+                reorg,
+                "Total difficulty unresolvable; deciding fork choice by height. Persistent \
+                 occurrences mean this node's persisted tip is on a branch below the fork point"
+            );
+            return Ok(reorg);
+        };
 
         tracing::debug!(
             target: "bsc::forkchoice",
@@ -347,5 +374,113 @@ mod tests {
                 curr_num, curr_tgt, inc_num, inc_tgt, should_reorg, result
             );
         }
+    }
+
+    /// Control case: when the incoming TD is known, fork choice decides normally.
+    ///
+    /// Numbers mirror the 2026-07-28 QA-net incident so this sits directly alongside
+    /// `unknown_incoming_td_must_not_wedge_forkchoice` below: stale local head 63 at
+    /// TD 106, incoming majority-chain block 653. This passes on current code.
+    #[test]
+    fn known_incoming_td_decides_normally() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        let current_header = Header { number: 63, ..Default::default() };
+        let incoming_header = Header { number: 653, ..Default::default() };
+
+        let current = HeaderForForkchoice::new(&current_header, Some(U256::from(106)), 0);
+        let incoming = HeaderForForkchoice::new(&incoming_header, Some(U256::from(1200)), 0);
+
+        assert!(
+            rule.is_need_reorg(&incoming, &current).unwrap(),
+            "higher known TD must win"
+        );
+    }
+
+    /// Reproduces the 2026-07-28 QA-net validator wedge.
+    ///
+    /// Background: four reth-bsc validators lost an equal-TD tie at block 61 and
+    /// persisted their own branch to block 63. Because the fork point (61) sits more
+    /// than one block below the persisted tip (63), upstream `query_header_with_td`
+    /// walks the in-memory fork, fails to reach a canonical ancestor, and returns
+    /// `Ok((header, None))` — "TD unknown" — for every incoming majority-chain block.
+    ///
+    /// `head_choice_with_td` then hard-errors `UnknownTotalDifficulty`, so
+    /// `update_forkchoice` returns `Err` and never issues a forkchoice update. The
+    /// provider's canonical head stays at 63 forever, which means the DB can never
+    /// reorg off the losing branch, which means the TD stays unresolvable. The node
+    /// keeps validating the majority chain in memory and reports itself healthy while
+    /// being permanently unable to rejoin — and its miner idles, because it evaluates
+    /// `sign_recently` against the frozen tip where it had already signed.
+    ///
+    /// The primary assertion is that fork choice must not *abort* on an unresolvable
+    /// TD. The second assertion encodes the proposed policy (a strictly
+    /// higher-numbered block wins when its TD cannot be resolved); reviewers may want
+    /// to debate that policy without weakening the first assertion.
+    ///
+    #[test]
+    fn unknown_incoming_td_must_not_wedge_forkchoice() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        // Local head: the losing branch's persisted tip, TD as observed in the incident.
+        let current_header = Header { number: 63, ..Default::default() };
+        // Incoming: a majority-chain block whose TD the engine could not resolve.
+        let incoming_header = Header { number: 653, ..Default::default() };
+
+        let current = HeaderForForkchoice::new(&current_header, Some(U256::from(106)), 0);
+        let incoming = HeaderForForkchoice::new(&incoming_header, None, 0);
+
+        let decision = rule.is_need_reorg(&incoming, &current);
+
+        assert!(
+            decision.is_ok(),
+            "unresolvable incoming TD must not abort fork choice — aborting pins the \
+             canonical head to the stale tip and the node can never rejoin; got {:?}",
+            decision.err()
+        );
+        assert!(
+            decision.unwrap(),
+            "a strictly higher-numbered block must win when its TD cannot be resolved"
+        );
+    }
+
+    /// The height fallback must stay conservative: unresolvable TD is not a licence to reorg
+    /// onto a sibling or a shorter branch.
+    #[test]
+    fn td_unknown_never_reorgs_to_equal_or_lower_height() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        let current_header = Header { number: 100, ..Default::default() };
+        let current = HeaderForForkchoice::new(&current_header, Some(U256::from(200)), 0);
+
+        for incoming_number in [99u64, 100] {
+            let incoming_header = Header { number: incoming_number, ..Default::default() };
+            let incoming = HeaderForForkchoice::new(&incoming_header, None, 0);
+            assert!(
+                !rule.is_need_reorg(&incoming, &current).unwrap(),
+                "must not reorg to height {incoming_number} against current height 100 with TD unknown"
+            );
+        }
+    }
+
+    /// The fallback applies whichever side is unresolvable — a stale local head whose own TD
+    /// cannot be read must not abort the decision either.
+    #[test]
+    fn td_unknown_on_current_side_also_falls_back() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        let current_header = Header { number: 63, ..Default::default() };
+        let incoming_header = Header { number: 653, ..Default::default() };
+
+        let current = HeaderForForkchoice::new(&current_header, None, 0);
+        let incoming = HeaderForForkchoice::new(&incoming_header, Some(U256::from(1200)), 0);
+
+        let decision = rule.is_need_reorg(&incoming, &current);
+        assert!(decision.is_ok(), "unresolvable current TD must not abort; got {:?}", decision.err());
+        assert!(decision.unwrap(), "higher incoming block must win");
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -59,6 +59,21 @@ pub struct BscConsensusMetrics {
 
     /// Total number of bad blocks detected (equivalent to chain/insert/badBlock)
     pub bad_blocks_total: Counter,
+
+    /// Total number of fork-choice decisions made by height because total difficulty could not
+    /// be resolved.
+    ///
+    /// A sustained nonzero rate means this node's persisted tip sits on a branch below the fork
+    /// point, so the engine cannot derive TD for incoming blocks. Worth alerting on: before the
+    /// height fallback existed, this condition froze the canonical head permanently while the
+    /// node kept reporting itself healthy.
+    pub td_unknown_fallbacks_total: Counter,
+
+    /// Total number of failed forkchoice updates, any cause.
+    ///
+    /// Repeated failures mean the canonical head is not advancing even though blocks are still
+    /// being validated — a state no other metric distinguishes from normal operation.
+    pub forkchoice_update_errors_total: Counter,
 }
 
 /// Metrics for BSC reward distribution

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -1174,6 +1174,8 @@ pub struct BscForkChoiceEngine<P> {
     finality_metrics: BscFinalityMetrics,
     /// Blockchain metrics (including reorg metrics)
     blockchain_metrics: BscBlockchainMetrics,
+    /// Consensus metrics (forkchoice failures)
+    consensus_metrics: crate::metrics::BscConsensusMetrics,
 }
 
 impl<P> BscForkChoiceEngine<P>
@@ -1196,6 +1198,7 @@ where
             ))),
             finality_metrics: BscFinalityMetrics::default(),
             blockchain_metrics: BscBlockchainMetrics::default(),
+            consensus_metrics: crate::metrics::BscConsensusMetrics::default(),
         }
     }
 
@@ -1236,7 +1239,15 @@ where
             .ok_or(ParliaConsensusErr::HeadHashNotFound)?;
 
         // Determine if we need to reorg using fork choice rules
-        let need_reorg = self.is_need_reorg(incoming_header, &current_head).await?;
+        let need_reorg = match self.is_need_reorg(incoming_header, &current_head).await {
+            Ok(need_reorg) => need_reorg,
+            Err(e) => {
+                // Bailing here means no forkchoice update is sent and the canonical head stays
+                // put, so this must be visible in metrics — callers only log it at warn.
+                self.consensus_metrics.forkchoice_update_errors_total.increment(1);
+                return Err(e);
+            }
+        };
 
         // Only count as reorg if:
         // 1. Fork choice says we need to reorg AND
@@ -1453,21 +1464,49 @@ where
     ) -> Result<(Option<alloy_primitives::U256>, Option<alloy_primitives::U256>), ParliaConsensusErr>
     {
         let current_td = self.header_td(engine, current.number, current.hash_slow()).await?;
+
+        // The engine reports "TD unknown" as `Ok(None)`, not `Err` — its walk deliberately
+        // avoids failing the query (see `query_header_with_td`). Falling back only on `Err`
+        // therefore skipped the parent-derived path in exactly the case that needs it: a fork
+        // whose divergence point lies below the persisted tip, where the walk gives up.
         let incoming_td = match self.header_td(engine, incoming.number, incoming.hash_slow()).await
         {
-            Ok(td) => td,
+            Ok(Some(td)) => Some(td),
+            Ok(None) => {
+                tracing::debug!(target: "bsc::forkchoice", "Incoming header TD unknown, try to query parent block TD");
+                self.parent_derived_td(engine, incoming).await?
+            }
             Err(e) => {
                 tracing::debug!(target: "bsc::forkchoice", "Failed to get incoming header TD: {:?}, try to query parent block TD", e);
-                match self.header_td(engine, incoming.number - 1, incoming.parent_hash).await? {
-                    Some(td) => Some(td + incoming.difficulty),
-                    None => {
-                        tracing::debug!(target: "bsc::forkchoice", "Failed to get parent header TD, return None");
-                        None
-                    }
-                }
+                self.parent_derived_td(engine, incoming).await?
             }
         };
         Ok((incoming_td, current_td))
+    }
+
+    /// Derives a header's TD from its parent's, when the header's own TD cannot be resolved.
+    ///
+    /// Returns `None` when the parent's TD is unknown too; callers must treat that as "unknown"
+    /// and degrade, never as a failure.
+    async fn parent_derived_td(
+        &self,
+        engine: &ConsensusEngineHandle<BscPayloadTypes>,
+        incoming: &Header,
+    ) -> Result<Option<alloy_primitives::U256>, ParliaConsensusErr> {
+        if incoming.number == 0 {
+            return Ok(None);
+        }
+        match self.header_td(engine, incoming.number - 1, incoming.parent_hash).await {
+            Ok(Some(td)) => Ok(Some(td + incoming.difficulty)),
+            Ok(None) => {
+                tracing::debug!(target: "bsc::forkchoice", "Failed to get parent header TD, return None");
+                Ok(None)
+            }
+            Err(e) => {
+                tracing::debug!(target: "bsc::forkchoice", "Failed to get parent header TD: {:?}, return None", e);
+                Ok(None)
+            }
+        }
     }
 
     /// Gets the total difficulty for a specific header.
@@ -1483,7 +1522,12 @@ where
             return Ok(*td);
         }
         let td = engine.query_td(number, hash).await.map_err(ParliaConsensusErr::internal)?;
-        self.header_td_cache.write().insert(hash, td);
+        // Only memoize resolved values. Caching a `None` makes a transient failure permanent for
+        // that hash: TD becomes resolvable once the block is persisted or a common ancestor
+        // appears, but a cached `None` means we would never ask again.
+        if td.is_some() {
+            self.header_td_cache.write().insert(hash, td);
+        }
         Ok(td)
     }
 }

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -1858,6 +1858,120 @@ mod tests {
         tokio::time::timeout(timeout, fcu_rx.recv()).await.ok().flatten()
     }
 
+    /// Like [`spawn_service_with_tip`], but the engine answers `QueryTd` with `Ok(None)` —
+    /// "TD unknown" — which is what the real engine-tree returns for a fork whose divergence
+    /// point lies below the persisted tip (its parent walk stops at `last_block_number`).
+    async fn spawn_service_with_td_unknown(
+        local_tip: u64,
+    ) -> (ImportHandle, mpsc::UnboundedReceiver<ForkchoiceState>, mpsc::UnboundedReceiver<()>) {
+        let mut provider = MockProvider::new();
+        let header = Header { number: local_tip, ..Default::default() };
+        provider.insert(header, U256::from(1));
+        let chain_spec =
+            Arc::new(crate::chainspec::BscChainSpec::from(crate::chainspec::bsc::bsc_mainnet()));
+
+        let (to_engine, mut from_engine) = mpsc::unbounded_channel();
+        let engine_handle = ConsensusEngineHandle::new(to_engine);
+
+        let (fcu_tx, fcu_rx) = mpsc::unbounded_channel();
+        let (np_tx, np_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(message) = from_engine.recv().await {
+                match message {
+                    BeaconEngineMessage::NewPayload { payload: _, tx } => {
+                        let _ = np_tx.send(());
+                        let _ = tx.send(Ok(PayloadStatus::new(PayloadStatusEnum::Valid, None)));
+                    }
+                    BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs: _, tx } => {
+                        let _ = fcu_tx.send(state);
+                        let _ = tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::new(
+                            PayloadStatusEnum::Valid,
+                            None,
+                        ))));
+                    }
+                    BeaconEngineMessage::QueryTd { number: _, hash: _, tx } => {
+                        // The distinguishing behavior: query succeeds, answer is "unknown".
+                        let _ = tx.send(Ok(None));
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let (to_import, from_network) = mpsc::unbounded_channel();
+        let (_to_import_mined, from_builder) = mpsc::unbounded_channel();
+        let (_to_import_bid, from_bid_block) = mpsc::unbounded_channel();
+        let (to_hashes, from_hashes) = mpsc::unbounded_channel();
+        let (to_network, import_outcome) = mpsc::unbounded_channel();
+        let handle = ImportHandle::new(to_import, to_hashes, import_outcome);
+
+        let service = ImportService::new(
+            provider,
+            chain_spec,
+            engine_handle,
+            from_network,
+            from_builder,
+            from_bid_block,
+            from_hashes,
+            to_network,
+        );
+        tokio::spawn(Box::pin(async move {
+            service.await.unwrap();
+        }));
+
+        (handle, fcu_rx, np_rx)
+    }
+
+    /// Builds a test block message at `number`.
+    fn create_test_block_at(number: u64) -> NewBlockMessage<BscNewBlock> {
+        let block = BscBlock {
+            header: Header { number, ..Default::default() },
+            body: BscBlockBody {
+                inner: BlockBody {
+                    transactions: Vec::new(),
+                    ommers: Vec::new(),
+                    withdrawals: None,
+                },
+                sidecars: None,
+            },
+        };
+        let new_block = BscNewBlock(NewBlock { block, td: U128::from(1) });
+        let hash = new_block.0.block.header.hash_slow();
+        NewBlockMessage { hash, block: Arc::new(new_block), td: Some(U256::from(1)) }
+    }
+
+    /// Regression test for the unrecoverable-fork wedge (QA net, 2026-07-28).
+    ///
+    /// A node whose persisted tip sits on a branch below the fork point cannot resolve the TD of
+    /// any incoming majority-chain block. Before the fix, `head_choice_with_td` turned that into
+    /// `UnknownTotalDifficulty`, `update_forkchoice` returned `Err`, and **no forkchoice update
+    /// was ever sent** — freezing the canonical head, which kept the DB on the losing branch,
+    /// which kept the TD unresolvable. Four validators stayed dead for an entire run while
+    /// reporting themselves healthy.
+    ///
+    /// This asserts the loop-level property the unit tests cannot: an FCU is actually emitted,
+    /// and it targets the incoming block rather than the stale local tip.
+    #[tokio::test]
+    async fn unresolvable_td_still_emits_forkchoice_update() {
+        // Local tip 63 and incoming 653 mirror the production incident.
+        let (handle, mut fcu_rx, _np_rx) = spawn_service_with_td_unknown(63).await;
+
+        let block = create_test_block_at(653);
+        let expected_head = block.hash;
+        handle.send_block(block, PeerId::random()).unwrap();
+
+        let state = recv_fcu_within(&mut fcu_rx, tokio::time::Duration::from_secs(5))
+            .await
+            .expect(
+                "a forkchoice update must be emitted even when the incoming TD is unresolvable; \
+                 without one the canonical head can never advance and the node is wedged",
+            );
+        assert_eq!(
+            state.head_block_hash, expected_head,
+            "the forkchoice update must target the incoming block, not the stale local tip"
+        );
+    }
+
     #[tokio::test]
     async fn routes_far_behind_announcement_to_pipeline_fcu() {
         // Local tip = 100. Announce a head whose gap exceeds the threshold by


### PR DESCRIPTION
## Problem

A reth-bsc node that ends up on a losing branch can never rejoin the majority chain. It goes **silently dark** — `eth_blockNumber` freezes, block production stops, and every health signal still looks normal.

Observed on the QA net on 2026-07-28: four reth-bsc validators lost an equal-TD tie at block 61 (two off-turn blocks, difficulty 1 each, because the in-turn validator missed its 450 ms slot), persisted their own branch to block 63, and stayed frozen there for the rest of the run while the six geth validators advanced past 1400. The engine tree kept validating the majority chain the whole time, so `Block added to canonical chain` climbed while the canonical head never moved, `eth_syncing` reported `false`, and no metric distinguished the state from healthy operation.

## Why it happens

TD for an in-memory block is derived by walking parents until one has TD on disk. When the persisted tip sits on a **losing** branch, that walk cannot reach a shared ancestor and reports "TD unknown".

From there:

1. `head_choice_with_td` turned unknown TD into `UnknownTotalDifficulty`.
2. `update_forkchoice` returned `Err` and never issued a forkchoice update.
3. The canonical head stayed pinned, so the DB never reorged off the losing branch.
4. Which kept TD unresolvable — a cycle with no exit.

Every would-be escape was blocked: more blocks only deepen the fork, `header_td_cache` memoized the `None`, and `fork_recover`'s Phase-3 FCU re-enters the same comparison (its comment assumes "engine-tree may retry on next import", which cannot help here).

**A graceful restart is sufficient to enter this state**, since shutdown flushes the in-memory branch to disk:

```
Graceful shutdown: engine flush complete persisted_before=Some(23031) persisted_after=Some(23159)
```

Note this is a storage difference from geth rather than a rule difference. geth writes TD per block hash for every block it inserts, including side-chain blocks (`rawdb.WriteTd` in the side-chain path), so `GetTd` is a direct lookup that never fails. Our `is_need_reorg` is a faithful port of geth's `ReorgNeeded` — including its parent fallback and its error-on-missing-TD — but the assumption that TD is always answerable does not hold here.

## Changes

- **`head_choice_with_td`** — fall back to height when either TD is unresolvable, instead of erroring. Only a **strictly** higher block wins, so we never reorg to a sibling or a lower block on missing information. Candidates reaching fork choice have already passed full payload validation.
- **`header_td_fcu`** — route `Ok(None)` through the parent-derived TD path. It previously fell back only on `Err`, skipping the exact case that needed it, because the engine reports "unknown" as `Ok(None)` by design.
- **`header_td`** — stop caching `None`, which made a transient failure permanent for that hash.
- **metrics** — `td_unknown_fallbacks_total` and `forkchoice_update_errors_total`. Worth alerting on: this state previously produced two debug-level warns and nothing else.

## Tests

| Test | Layer |
|---|---|
| `unknown_incoming_td_must_not_wedge_forkchoice` | decision — reproduces the incident (local head 63 @ TD 106, incoming 653 with TD unknown); failed pre-fix with `UnknownTotalDifficulty(.., 653)` |
| `td_unknown_never_reorgs_to_equal_or_lower_height` | guards the conservative direction |
| `td_unknown_on_current_side_also_falls_back` | stale local head whose own TD is unreadable |
| `unresolvable_td_still_emits_forkchoice_update` | **the loop** — asserts an FCU is actually emitted; verified to fail pre-fix by 5s timeout and pass post-fix |

`cargo test --all -- --test-threads=1`: 424 passed. `cargo clippy --workspace --tests --all-features` with `-D warnings`: clean.

## Live verification

On a 10-node cluster (4 reth / 6 geth), same fork, only the binary differing:

| | pre-fix | with this change |
|---|---|---|
| reth heads | 29338, static across 4 polls | 29748 → 29793, advancing |
| majority | 29439 → 29460 | in lockstep |
| wedge warns | 512 / 744 and climbing | none new |

In an earlier run, block 23100 changed from the dead branch's `0x402e65fd…` to the majority's `0x88f02f60…` — a real disk reorg, not a head-pointer move. The height fallback fired **exactly once**, after which TD resolved normally again, which is the intended behaviour for an escape hatch.

## Follow-ups (not in this PR)

- **Upstream `query_header_with_td`** gives up one block below the persisted tip; it should keep descending while parents exist in `tree_state`. Worth landing for TD *accuracy*, but the live test confirms it is **not** required for recovery. A failing test for it exists, along with a fix to `MockEthProvider`, which had no TD store at all — so the pre-existing `query_header_with_td_fork_below_tip_*` tests assert `td == None` as correct for both the resolving and the failing path. That blind spot is why this shipped.
- Operator runbook for nodes already wedged on deployed versions (unwind below the fork point and restart).

## Base branch

Targets `feat/bep675` because the branch is cut from it and `service.rs` differs on `develop`, so the loop-level test would need adapting there. Happy to retarget or backport if you prefer this on `develop` first.


---

## How to reproduce

### A. Deterministic, no cluster (seconds)

Run either test against `feat/bep675`, or against this branch with the source changes reverted:

```bash
cargo test -p reth_bsc unknown_incoming_td_must_not_wedge_forkchoice -- --exact
# pre-fix: FAILED
#   unresolvable incoming TD must not abort fork choice ...
#   got Some(UnknownTotalDifficulty(0x24dda892…, 653))

cargo test -p reth_bsc unresolvable_td_still_emits_forkchoice_update -- --exact
# pre-fix: FAILED after 5.02s
#   a forkchoice update must be emitted even when the incoming TD is unresolvable
```

The second is the meaningful one: it drives the real `ImportService` with an engine mock that answers `QueryTd` with `Ok(None)` — what the engine-tree actually returns for a fork whose base is below the persisted tip — and asserts that a forkchoice update is emitted. Pre-fix, none ever is, so it fails by timeout. The first test only covers the decision function.

### B. Live cluster — node-deploy-bsc, ~10 minutes

**The fork geometry is what matters, and it is easy to get wrong.** The wedged node must be *ahead* of the majority when they reconnect:

1. Healthy 10-node cluster, `RETH_NODE_COUNT=4`.
2. Stop the six geth validators. The four reth nodes keep producing and pull ahead.
   ```bash
   for i in 4 5 6 7 8 9; do ./bsc_cluster.sh stop $i; done
   ```
3. Wait until the reth group is ~70 blocks ahead (they eventually halt on `sign_recently`; that is fine).
4. `./bsc_cluster.sh stop` — a **graceful** stop. The shutdown flush pins each reth node's persisted tip onto that minority branch. This is the actual trigger:
   ```
   Graceful shutdown: engine flush complete persisted_before=Some(23031) persisted_after=Some(23159)
   ```
5. `./bsc_cluster.sh start`. The geth majority resumes from its older tip, builds its own branch, and overtakes on difficulty.
6. Every reth node freezes.

Confirm the wedge:

```bash
curl -s -X POST localhost:8545 -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'      # frozen
grep -c "fork walked below last_block_number" .local/node0/reth.log         # climbing
grep -c "Unknown total difficulty"            .local/node0/reth.log         # climbing
grep "Block added to canonical chain" .local/node0/reth.log | tail -1       # still advancing!
```

The last two together are the signature: the tree keeps validating the majority chain while the canonical head does not move.

To verify recovery, point `RETH_BSC_BINARY_PATH` at a build of this branch, restart only the reth nodes, and watch their heads rejoin the majority.

### Pitfalls that produce false negatives

Each of these cost us a run, and each produced a *wrong verdict* rather than an error:

- **The majority must be BEHIND the reth group at reconnect.** If it is ahead, the first incoming block has an unknown parent, gets routed to backfill/pipeline sync (`routes_far_behind_announcement_to_pipeline_fcu`), and the DB unwinds and recovers — legitimately, even without this fix. A **partition-based reproduction therefore does not work**: six geth validators always outpace four reth ones, leaving reth behind. We confirmed an unfixed binary passes under that geometry.
- **If you do partition, delete `<datadir>/known-peers.json` first.** reth re-dials persisted peers on startup, which defeats both `--trusted-peers` and `--disable-discovery` (`net::peers: Loaded persisted peers count=9`). Verify isolation with `net_peerCount` rather than assuming it.
- **Judge recovery by movement, not proximity.** A wedged node can partially catch up via backfill, stop a few blocks short of the majority, and then freeze. A "within N blocks" check at a single instant scores that as healthy. Require the head to advance across consecutive samples while the majority advances.
- **`bsc_cluster.sh stop` kills every process whose command line matches `reth-bsc`** — including your own shell if the command mentions such a path. Set `RETH_BSC_BINARY_PATH` in `.env` as a separate step instead of passing it inline.
- Check log signatures at the **end** of the observation window; the warns take a minute to accumulate.

Two scripts implementing all of the above live in **node-deploy-bsc** (not this repo): `repro_deep_fork_wedge.sh` (partition/heal diagnostic) and `regress_fork_wedge.sh` (full cycle with a three-valued PASS / FAIL / INCONCLUSIVE verdict — INCONCLUSIVE exists precisely because a run that fails to create the fork must never be reported as a pass).
