### PR TITLE
fix(bep675): adopt bsc #3742 BidBlock signing hash + tx-root check

### DIFF
--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -27,7 +27,7 @@ use alloy_consensus::transaction::RlpEcdsaDecodableTx;
 use alloy_consensus::{Header, Transaction, TxLegacy};
 use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::{keccak256, Address, Bytes, Signature, B256, U256};
-use alloy_rlp::{Decodable, Encodable};
+use alloy_rlp::Decodable;
 use reth::primitives::SealedHeader;
 use reth_chainspec::EthChainSpec;
 use reth_ethereum_primitives::{BlockBody, TransactionSigned};
@@ -61,20 +61,21 @@ pub struct BidBlock {
 }
 
 impl BidBlock {
-    /// `rlpHash([header, transactions, sidecars])` — the digest the builder signs.
+    /// The header hash — the digest the builder signs.
     ///
-    /// Matches geth's `BidBlock.Hash()`; see the module note on blob-sidecar parity.
+    /// Matches geth's `BidBlock.Hash()` as of bsc #3742 ("miner: optimize BidBlock signing hash",
+    /// shipped in v1.7.6), which replaced `rlpHash([header, transactions, sidecars])` with
+    /// `b.Header.Hash()`. Re-hashing the body on every call meant re-hashing up to 6 × 128 KiB of
+    /// blob data on the admission hot path; the header is ~600 bytes.
+    ///
+    /// The body is still bound to the signature, indirectly: `header.transactions_root` commits to
+    /// the transactions and is verified in [`verify_bid_block_payload`], and blob sidecars are
+    /// bound through the blob versioned hashes carried inside those transactions. **That tx-root
+    /// check is what makes this digest safe — do not narrow the digest without it.** Recovering a
+    /// signature over the wrong digest does not fail; it silently yields a different address, so a
+    /// mismatch here surfaces as a bogus "builder is not registered" rather than a signature error.
     pub fn hash(&self) -> B256 {
-        let payload_length =
-            self.header.length() + self.transactions.length() + self.sidecars.length();
-
-        let mut out = Vec::with_capacity(payload_length + 8);
-        alloy_rlp::Header { list: true, payload_length }.encode(&mut out);
-        self.header.encode(&mut out);
-        self.transactions.encode(&mut out);
-        self.sidecars.encode(&mut out);
-
-        keccak256(&out)
+        self.header.hash_slow()
     }
 }
 
@@ -166,12 +167,23 @@ impl BidBlockArgs {
             builder,
             header: self.bid_block.header.clone(),
             txs: self.decode_txs()?,
+            submitted_tx_root: submitted_tx_root(&self.bid_block.transactions),
             sidecars: self.bid_block.sidecars.clone(),
             gas_fee: U256::ZERO,
             system_tx_start: 0,
             bid_hash: self.bid_block.hash(),
         })
     }
+}
+
+/// Transactions trie root over raw (EIP-2718) tx bytes — go-bsc `DeriveSha(txs, StackTrie)`.
+///
+/// Hashes the submitted bytes verbatim rather than re-encoding decoded transactions, which would
+/// not round-trip the unsigned system txs (`V=R=S=0`).
+pub fn submitted_tx_root(raw_txs: &[Bytes]) -> B256 {
+    alloy_consensus::proofs::ordered_trie_root_with_encoder(raw_txs, |tx: &Bytes, buf| {
+        buf.extend_from_slice(tx.as_ref())
+    })
 }
 
 /// Validator-side decoded representation of a [`BidBlock`].
@@ -183,6 +195,13 @@ pub struct DecodedBidBlock {
     pub header: Header,
     /// Decoded transactions.
     pub txs: Vec<TransactionSigned>,
+    /// Transactions trie root over the **raw submitted** tx bytes, computed at decode time.
+    ///
+    /// Must be taken from the raw bytes, not by re-encoding [`Self::txs`]: the trailing system txs
+    /// arrive unsigned with `V=R=S=0`, and reth's `Signature` stores only a parity bit, so
+    /// re-encoding a legacy tx emits `v=27` and yields a different root than go-bsc's `DeriveSha`
+    /// over the same input. The raw bytes are also precisely what the builder committed to.
+    pub submitted_tx_root: B256,
     /// Blob sidecars.
     pub sidecars: Vec<BscBlobTransactionSidecar>,
     /// Fees collected from user txs (set during admission).
@@ -602,6 +621,25 @@ pub fn verify_bid_block_payload(
     let header = &decoded.header;
     verify_bid_block_coinbase_and_gas_limit(header, etherbase, expected_gas_limit)?;
 
+    // go-bsc `preSealVerifyBidBlock`: `DeriveSha(decoded.Txs) == header.TxHash`.
+    //
+    // Load-bearing, not a formality. Since bsc #3742 the builder's signature covers only the
+    // header, so `transactions_root` is the *sole* commitment binding the submitted body to that
+    // signature. Without this check anyone could take an honest builder's (header, signature) off
+    // the wire, resubmit it with a substituted transaction list, and have it proposed under that
+    // builder's identity — the validator later overwrites `transactions_root` with the root of
+    // whatever body it was handed (see `simulate_bid_block`), so the forgery would leave no trace.
+    //
+    // Compares the txs exactly as submitted, before `bind_sign_bid_block_system_txs` re-signs the
+    // trailing system txs — that as-submitted set (unsigned system txs, V=R=S=0) is what the
+    // builder committed to. go-bsc likewise checks before blind-signing.
+    if decoded.submitted_tx_root != header.transactions_root {
+        return Err(PreSealVerifyError::TxRootMismatch {
+            got: header.transactions_root,
+            want: decoded.submitted_tx_root,
+        });
+    }
+
     let (system_tx_start, gas_fee) = extract_bid_block_deposit_value(&decoded.txs);
     if gas_fee.is_zero() {
         return Err(PreSealVerifyError::EmptyGasFee);
@@ -651,6 +689,9 @@ pub enum PreSealVerifyError {
     WrongDifficulty { got: U256, want: U256 },
     /// The deposit (gas-fee) value is zero.
     EmptyGasFee,
+    /// Header `transactions_root` does not commit to the submitted transactions. Since bsc #3742
+    /// the signature covers only the header, so this root is what binds the body to it.
+    TxRootMismatch { got: B256, want: B256 },
     /// A user tx exceeds the per-tx gas cap.
     TxGasTooHigh { tx_index: usize, gas: u64, cap: u64 },
     /// Blob-sidecar validation failed.
@@ -679,6 +720,9 @@ impl fmt::Display for PreSealVerifyError {
                 write!(f, "wrong difficulty: got {got}, want {want}")
             }
             Self::EmptyGasFee => write!(f, "empty gasFee"),
+            Self::TxRootMismatch { got, want } => {
+                write!(f, "invalid tx root: got {got}, want {want}")
+            }
             Self::TxGasTooHigh { tx_index, gas, cap } => {
                 write!(f, "tx {tx_index} gas {gas} exceeds cap {cap}")
             }
@@ -894,6 +938,8 @@ pub fn simulate_bid_block(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Needed by the hand-rolled RLP fixtures below; the production path no longer RLP-encodes.
+    use alloy_rlp::Encodable;
     use alloy_primitives::{address, b256, bytes, hex};
 
     /// Repro for the blob-BidBlock admission stack overflow: run the decode+hash path a tokio
@@ -997,7 +1043,7 @@ mod tests {
         // Generated from go-ethereum BidBlock.Hash() (nil sidecars).
         assert_eq!(
             vector_a_block().hash(),
-            b256!("0xdc44b22e7cc5c067a0cc494d39871fa87de72bfd54db5711ccc3cdc31e948491"),
+            b256!("0x45908d0719d520fb290125d2df35591b639a6667a8ca453b807f0577ab3a8eba"),
         );
     }
 
@@ -1021,13 +1067,19 @@ mod tests {
         };
         assert_eq!(
             block.hash(),
-            b256!("0x789bf84e2c1f41f6fe8d05cfc0f4b9ee72380c16f506e0640fcfb4c12d0ea6a5"),
+            b256!("0xad40d96e6b75df67950f6a63e6659936814b5e11407c6cdcf3b5c63675aa59f8"),
         );
+        // Post-#3742 the digest is exactly the header hash; the two transactions above do not
+        // enter it (they are bound via `transactions_root` instead — see `verify_bid_block_payload`).
+        assert_eq!(block.hash(), block.header.hash_slow());
     }
 
     #[test]
     fn ecrecover_matches_geth_vector_c() {
-        // Builder signed vector A's hash with a known key; geth recovered this address.
+        // The same fixed signature reth-bsc has always pinned, recovered over the post-#3742
+        // digest. Regenerated with go-bsc `BidBlockArgs.EcrecoverSender()`: narrowing the digest
+        // changes which address a given signature recovers to, which is exactly why the old
+        // mismatch surfaced as a bogus "builder is not registered".
         let args = BidBlockArgs {
             bid_block: vector_a_block(),
             signature: Bytes::from(hex!(
@@ -1036,7 +1088,7 @@ mod tests {
         };
         assert_eq!(
             args.ecrecover_sender().unwrap(),
-            address!("0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F"),
+            address!("0xd6df9A7DF6A570f65d7BC2B1e1001e0dD8500040"),
         );
     }
 
@@ -1101,11 +1153,16 @@ mod tests {
             transactions: Vec::new(),
             sidecars: vec![sidecar],
         };
-        // Generated from go-bsc BidBlock.Hash() over [header, [], [sidecar]].
+        // Post-#3742 sidecars are NOT part of the signing digest, so attaching one to vector A's
+        // header must leave the hash unchanged. Verified against go-bsc `BidBlock.Hash()` over
+        // [header, [], [sidecar]], which returns vector A's hash. Sidecars are instead bound
+        // through the blob versioned hashes carried inside the (root-committed) transactions.
         assert_eq!(
             block.hash(),
-            b256!("0x020136e0d39a0a27c9597e89c56f77170b1d43e6b391c4852a2138936184d9c5"),
+            b256!("0x45908d0719d520fb290125d2df35591b639a6667a8ca453b807f0577ab3a8eba"),
+            "sidecars must not affect the signing digest"
         );
+        assert_eq!(block.hash(), vector_a_block().hash());
     }
 
     // ---- blob sidecar validation ----
@@ -1422,20 +1479,110 @@ mod tests {
         TransactionSigned::new_unhashed(tx.into(), Signature::new(U256::ZERO, U256::ZERO, false))
     }
 
+    /// Builds a well-formed `DecodedBidBlock`, deriving `transactions_root` from `txs` the way a
+    /// real builder must: since bsc #3742 the signature covers only the header, so that root is the
+    /// commitment binding the body, and `verify_bid_block_payload` rejects a mismatch. Tests that
+    /// want a mismatch should overwrite the root explicitly (see
+    /// `pre_seal_rejects_tx_root_mismatch`).
     fn decoded_block(
         header: Header,
         txs: Vec<TransactionSigned>,
         sidecars: Vec<BscBlobTransactionSidecar>,
     ) -> DecodedBidBlock {
+        let mut header = header;
+        let root = alloy_consensus::proofs::calculate_transaction_root(&txs);
+        header.transactions_root = root;
         DecodedBidBlock {
             builder: Address::ZERO,
             header,
             txs,
+            submitted_tx_root: root,
             sidecars,
             gas_fee: U256::ZERO,
             system_tx_start: 0,
             bid_hash: B256::ZERO,
         }
+    }
+
+    #[test]
+    fn submitted_tx_root_matches_geth_for_unsigned_system_tx() {
+        // Cross-client vector generated with go-bsc `DeriveSha(txs, NewStackTrie(nil))` over one
+        // unsigned parlia system tx (`types.NewTransaction` leaves V=R=S nil, wire-encoded as 0).
+        //
+        // This is the case that forces the root to be taken from the RAW submitted bytes: reth's
+        // `Signature` carries only a parity bit, so decoding this tx and re-encoding it emits
+        // `v=27` instead of `v=0` and produces a different root. Computing the root by
+        // re-encoding would therefore reject every legitimate BidBlock.
+        let raw = bytes!(
+            "0xf8498080887fffffffffffffff94000000000000000000000000000000000000100064a4f340fa01000000000000000000000000bcdd0d2cda5f6423e57b6a4dcd75decbe31aecf0808080"
+        );
+        let geth_root =
+            b256!("0x4527823c77294bc45e8d370fc7c3e95cf779bdbf98f4adacdb57e361050a1ddf");
+
+        assert_eq!(submitted_tx_root(std::slice::from_ref(&raw)), geth_root, "must match go-bsc DeriveSha");
+
+        // And demonstrate why the raw form is required: the re-encoded root differs.
+        // `decode_bid_block_tx` is the production decoder — plain `decode_2718` rejects this
+        // shape outright (`UnexpectedType(0)`), which is itself why reth-bsc needs a bespoke one.
+        let decoded = decode_bid_block_tx(raw.as_ref()).expect("decode system tx");
+        assert_ne!(
+            alloy_consensus::proofs::calculate_transaction_root(&[decoded]),
+            geth_root,
+            "re-encoding a decoded unsigned system tx must NOT reproduce the root — if this ever \
+             starts matching, the raw-bytes path can be simplified"
+        );
+    }
+
+    #[test]
+    fn pre_seal_rejects_tx_root_mismatch() {
+        // The security-critical half of bsc #3742. The signature covers only the header, so
+        // `transactions_root` is the sole binding between the signed header and the submitted body.
+        // Without this rejection, anyone could replay an honest builder's (header, signature) with a
+        // substituted transaction list: recovery would still yield the whitelisted builder, and
+        // `simulate_bid_block` would overwrite the root to match the forged body, leaving no trace.
+        let spec = preseal_spec();
+        let etherbase = Address::repeat_byte(0x11);
+        let parent = Header { number: 0, timestamp: 1, gas_limit: 30_000_000, ..Default::default() };
+        let txs = vec![legacy_tx(0), deposit_system_tx(100)];
+        let mut d = decoded_block(valid_bid_header(etherbase, 30_000_000), txs, vec![]);
+
+        // Sanity: the well-formed fixture passes, so the failure below is attributable to the root.
+        assert!(verify_bid_block_payload(
+            &spec,
+            &d,
+            &parent,
+            etherbase,
+            d.header.gas_limit
+        )
+        .is_ok());
+
+        // Now claim a different body than the one supplied — the replay/substitution shape.
+        let honest_root = d.header.transactions_root;
+        d.header.transactions_root = B256::repeat_byte(0xab);
+        assert_eq!(
+            verify_bid_block_payload(&spec, &d, &parent, etherbase, d.header.gas_limit),
+            Err(PreSealVerifyError::TxRootMismatch {
+                got: B256::repeat_byte(0xab),
+                want: honest_root,
+            }),
+        );
+    }
+
+    #[test]
+    fn signing_digest_ignores_body_and_is_the_header_hash() {
+        // Post-#3742 property, verified against go-bsc: the digest is a pure function of the
+        // header, so neither transactions nor sidecars perturb it. This is the inverse of what the
+        // pre-#3742 vectors asserted, and it is only safe because `verify_bid_block_payload` checks
+        // `transactions_root` — these two tests must be read together.
+        let bare = vector_a_block();
+        let with_txs = BidBlock {
+            header: bare.header.clone(),
+            transactions: vec![bytes!("0x010203"), bytes!("0xdeadbeef")],
+            sidecars: Vec::new(),
+        };
+
+        assert_eq!(bare.hash(), bare.header.hash_slow(), "digest must be the header hash");
+        assert_eq!(with_txs.hash(), bare.hash(), "transactions must not enter the digest");
     }
 
     #[test]

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -1345,6 +1345,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bid_block_engine_err_leaves_double_sign_slot_claimed() {
+        // Characterization test for the `Err(err)` arm of `on_new_bid_block` — the case where
+        // `engine.new_payload()` fails at the transport level instead of returning a verdict.
+        //
+        // This pins CORRECT behavior, not a gap. The BidBlock is broadcast to peers *before*
+        // verification (zero-simulate), so by the time the engine errors the block is already out
+        // on the wire and this validator has signed at this height. The double-sign slot must
+        // therefore STAY claimed: releasing it would let a fallback block be produced for the same
+        // height and turn a missed slot into a slashable double sign. (The slot-rollback helper in
+        // `shared` is scoped to blocks that were "never actually broadcast" — the miner's
+        // channel-send failure — which is not this case.) go-bsc agrees: `handleBidBlockResult`
+        // leaves `recentMinedBlocks` untouched on a verification failure, and has no rollback at
+        // all. The builder is likewise not revoked here — an `Err` is our failure, not provable
+        // dishonesty (a deliberate divergence: go-bsc revokes on any `InsertChain` error, because
+        // its single error return cannot separate "block is invalid" from "our node failed").
+        //
+        // If someone intends to change this, they must first move the broadcast to after
+        // verification; until then, a failing assertion here means a double-sign risk was
+        // introduced.
+        let (responses, mut new_payload_observed) = EngineResponses::unavailable_new_payload();
+        let mut fixture = TestFixture::new(responses).await;
+
+        // High, test-local block number: `RECENT_MINED_BLOCKS` is process-global.
+        let block_number = 900_101_u64;
+        let sealed = create_bid_sealed_block(block_number);
+        let parent_hash = sealed.header().parent_hash;
+
+        let builder = Address::repeat_byte(0x7f);
+        let bid_hash = B256::repeat_byte(0xb2);
+        let pm = crate::shared::get_bid_block_permission_manager();
+        assert!(pm.is_allowed(builder), "builder should start allowed");
+
+        // Stand in for the miner, which claims the slot before handing the block to this service
+        // (`pick_best_payload_and_finalize` → `check_and_record_mined_block`).
+        assert!(
+            crate::shared::check_and_record_mined_block(block_number, parent_hash),
+            "slot must start unclaimed"
+        );
+
+        fixture.bid_tx.send((sealed, builder, bid_hash, U256::ZERO, 0)).unwrap();
+
+        // 1. Broadcast still happens, before (and despite) the failed verification.
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut saw_broadcast = false;
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(2);
+        while !saw_broadcast && tokio::time::Instant::now() < deadline {
+            match fixture.handle.poll_outcome(&mut cx) {
+                Poll::Ready(Some(event)) => {
+                    if matches!(
+                        event,
+                        BlockImportEvent::Announcement(BlockValidation::ValidBlock { .. })
+                    ) {
+                        saw_broadcast = true;
+                    }
+                }
+                Poll::Ready(None) => break,
+                Poll::Pending => tokio::task::yield_now().await,
+            }
+        }
+        assert!(saw_broadcast, "BidBlock must be broadcast before verification");
+
+        // 2. Wait for positive proof the engine call was made and failed, rather than assuming it
+        //    from a bare timeout — otherwise the negative assertions below could pass vacuously.
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), new_payload_observed.recv())
+            .await
+            .expect("engine.new_payload was never called")
+            .expect("engine mock closed without observing new_payload");
+        // The responder was already dropped when the observation fired, so the handle's `Err` is
+        // determined; yield briefly to let the spawned verify task reach its `Err` arm.
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // 3. The slot is still claimed: a second call for the same pair is refused.
+        assert!(
+            !crate::shared::check_and_record_mined_block(block_number, parent_hash),
+            "double-sign slot must remain claimed after an engine error — the block was already \
+             broadcast, so releasing it would permit a second signature at this height"
+        );
+
+        // 4. The builder keeps its permission: `Err` is not provable dishonesty.
+        assert!(
+            pm.is_allowed(builder),
+            "builder must NOT be revoked for an engine-side error (only Invalid revokes)"
+        );
+    }
+
+    #[tokio::test]
     async fn bid_block_low_average_gas_price_revokes() {
         // Post-import average-gas-price floor check (go-bsc `validateBidBlockAverageGasPrice`):
         // a Valid BidBlock whose deposit-derived gas_fee implies an average price below the
@@ -1622,17 +1709,32 @@ mod tests {
     struct EngineResponses {
         new_payload: PayloadStatusEnum,
         fcu: PayloadStatusEnum,
+        /// Make `new_payload` fail at the transport level rather than return a status: the mock
+        /// drops the responder, which `ConsensusEngineHandle::new_payload` maps to
+        /// `Err(BeaconOnNewPayloadError::EngineUnavailable)`. Distinct from
+        /// `PayloadStatusEnum::Invalid` — an `Err` is *our* failure, not a verdict on the block.
+        new_payload_unavailable: bool,
+        /// Fires once per observed `NewPayload`, so a test can await proof that the engine call
+        /// actually happened rather than inferring it from a timeout.
+        new_payload_observed: Option<mpsc::UnboundedSender<()>>,
     }
 
     impl EngineResponses {
         fn both_valid() -> Self {
-            Self { new_payload: PayloadStatusEnum::Valid, fcu: PayloadStatusEnum::Valid }
+            Self {
+                new_payload: PayloadStatusEnum::Valid,
+                fcu: PayloadStatusEnum::Valid,
+                new_payload_unavailable: false,
+                new_payload_observed: None,
+            }
         }
 
         fn invalid_new_payload() -> Self {
             Self {
                 new_payload: PayloadStatusEnum::Invalid { validation_error: "test error".into() },
                 fcu: PayloadStatusEnum::Valid,
+                new_payload_unavailable: false,
+                new_payload_observed: None,
             }
         }
 
@@ -1640,7 +1742,24 @@ mod tests {
             Self {
                 new_payload: PayloadStatusEnum::Valid,
                 fcu: PayloadStatusEnum::Invalid { validation_error: "fcu error".into() },
+                new_payload_unavailable: false,
+                new_payload_observed: None,
             }
+        }
+
+        /// `engine.new_payload()` returns `Err`, exercising the arm that is neither Valid nor
+        /// Invalid. Returns a receiver that fires once the engine call has been made and failed.
+        fn unavailable_new_payload() -> (Self, mpsc::UnboundedReceiver<()>) {
+            let (observed_tx, observed_rx) = mpsc::unbounded_channel();
+            (
+                Self {
+                    new_payload: PayloadStatusEnum::Valid,
+                    fcu: PayloadStatusEnum::Valid,
+                    new_payload_unavailable: true,
+                    new_payload_observed: Some(observed_tx),
+                },
+                observed_rx,
+            )
         }
     }
 
@@ -1773,8 +1892,19 @@ mod tests {
             while let Some(message) = from_engine.recv().await {
                 match message {
                     BeaconEngineMessage::NewPayload { payload: _, tx } => {
-                        tx.send(Ok(PayloadStatus::new(responses.new_payload.clone(), None)))
-                            .unwrap();
+                        if responses.new_payload_unavailable {
+                            // Drop the responder without replying: the handle maps a closed oneshot
+                            // to `Err(BeaconOnNewPayloadError::EngineUnavailable)`, which is the
+                            // real shape of this failure (engine task gone) rather than a synthetic
+                            // error value.
+                            drop(tx);
+                        } else {
+                            tx.send(Ok(PayloadStatus::new(responses.new_payload.clone(), None)))
+                                .unwrap();
+                        }
+                        if let Some(observed) = &responses.new_payload_observed {
+                            let _ = observed.send(());
+                        }
                     }
                     BeaconEngineMessage::ForkchoiceUpdated { state: _, payload_attrs: _, tx } => {
                         tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::new(

--- a/src/rpc/debug_builder.rs
+++ b/src/rpc/debug_builder.rs
@@ -251,6 +251,18 @@ where
         transactions.push(encode_unsigned_legacy(tx).map_err(internal_err)?);
     }
 
+    // Re-root the header over the transactions actually being returned. The built block's root
+    // commits to the *signed* system txs, but the body above re-emits them unsigned, so shipping
+    // the sealed root would produce a candidate whose header does not commit to its own body — a
+    // BidBlock no real builder can produce, and one `verify_bid_block_payload` rejects outright
+    // (`invalid tx root`) now that the signature covers only the header (bsc #3742).
+    //
+    // Safe for the state root this seam exists to exercise: the validator recomputes
+    // `transactions_root` in `simulate_bid_block` after bind-signing, so the sealed header it
+    // proposes is unaffected by what we put here.
+    header.transactions_root =
+        crate::node::miner::bid_block::submitted_tx_root(&transactions);
+
     // The first generated system tx must be the deposit carrying the claimed gas fee.
     let gas_fee = match body_txs.get(user_tx_count) {
         Some(tx) if tx.input().starts_with(&DEPOSIT_SELECTOR) => tx.value(),

--- a/testing/bsc-ef-tests/tests/bid_block_harness.rs
+++ b/testing/bsc-ef-tests/tests/bid_block_harness.rs
@@ -413,7 +413,9 @@ fn execution_gate_round_trip() {
     use alloy_primitives::{Signature, TxKind};
     use reth_bsc::consensus::parlia::util::calculate_difficulty;
     use reth_bsc::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes};
-    use reth_bsc::node::miner::bid_block::{simulate_bid_block, BidBlock, BidBlockArgs};
+    use reth_bsc::node::miner::bid_block::{
+        simulate_bid_block, submitted_tx_root, BidBlock, BidBlockArgs,
+    };
     use reth_bsc::node::miner::signer::sign_system_transaction;
     use reth_bsc::node::miner::util::finalize_new_header;
     use reth_bsc::node::BscNode;
@@ -536,14 +538,20 @@ fn execution_gate_round_trip() {
         ref_txs[1].clone().into_typed_transaction(),
         Signature::new(alloy_primitives::U256::ZERO, alloy_primitives::U256::ZERO, false),
     );
-    let bid = BidBlock {
-        header: block2_ref.header().clone(),
-        transactions: vec![
-            alloy_primitives::Bytes::from(ref_txs[0].encoded_2718()),
-            alloy_primitives::Bytes::from(unsigned_deposit.encoded_2718()),
-        ],
-        sidecars: vec![],
-    };
+    let submitted_txs = vec![
+        alloy_primitives::Bytes::from(ref_txs[0].encoded_2718()),
+        alloy_primitives::Bytes::from(unsigned_deposit.encoded_2718()),
+    ];
+    // The reference header's `transactions_root` commits to the *signed* deposit, but the body
+    // submitted below carries the unsigned placeholder — so the root has to be recomputed over what
+    // is actually sent. That is what a real builder does: since bsc #3742 the signature covers only
+    // the header, so this root is the commitment binding the body, and `verify_bid_block_payload`
+    // rejects a mismatch. Reusing the reference root here built a BidBlock no builder could produce.
+    // `simulate_bid_block` still overwrites the root with the re-signed set, so the sealed header —
+    // and the state root this test compares — is unaffected.
+    let mut bid_header = block2_ref.header().clone();
+    bid_header.transactions_root = submitted_tx_root(&submitted_txs);
+    let bid = BidBlock { header: bid_header, transactions: submitted_txs, sidecars: vec![] };
     let args = BidBlockArgs { bid_block: bid, signature: alloy_primitives::Bytes::from(vec![0u8; 65]) };
     let decoded = args.to_decoded_bid_block(alloy_primitives::Address::repeat_byte(0xbb)).expect("decode bid");
 


### PR DESCRIPTION
## Problem

reth-bsc computes the BidBlock signing digest as `rlpHash([header, transactions, sidecars])`. bsc changed it to `Header.Hash()` in [`22387b2a6`](https://github.com/bnb-chain/bsc/commit/22387b2a6) ("miner: optimize BidBlock signing hash", #3742) — **shipped in v1.7.6 and v1.7.7**, still current on `develop`.

Consequence: every builder on a current bsc release is rejected, closing the BEP-675 route entirely.

The failure is silent rather than loud. ECDSA recovery over the wrong digest doesn't error — it returns a *different* address. So admission reports `-38001 builder is not registered` for a correctly whitelisted builder, pointing at whitelist configuration rather than the digest.

## Evidence

Cross-client, using reth-bsc's own pinned `vector_a` as the reference point (computed from bsc source):

```
reth-bsc pinned vector_a  : 0xdc44b22e…948491
bsc BidBlock.Hash()       : 0x45908d07…3a8eba
bsc Header.Hash()         : 0x45908d07…3a8eba   <- #3742 in effect
bsc pre-3742 rlpHash(b)   : 0xdc44b22e…948491   <- identical to reth's vector
```

Live single-variable A/B on the local devnet — same node, same block, same whitelisted key, only the signed digest differing:

| digest | before | after |
|---|---|---|
| `Header.Hash()` (v1.7.6+ builders) | ❌ `builder is not registered` | ✅ accepted, admitted, imported |
| pre-#3742 `rlpHash` | ✅ accepted | ❌ rejected |

Scope is BEP-675 only: `RawBid.Hash()` (legacy `mev_sendBid`) still uses `rlpHash` upstream and is untouched, so legacy MEV interop was never affected — which is also why this went unnoticed.

## Two coupled halves — do not split these

1. `BidBlock::hash()` → `self.header.hash_slow()`, verified byte-identical to go-bsc `Header.Hash()`.
2. A `transactions_root` check in `verify_bid_block_payload` (go-bsc `preSealVerifyBidBlock`'s `DeriveSha(decoded.Txs) == header.TxHash`), as `PreSealVerifyError::TxRootMismatch` → `-38007`.

**Half 2 is what keeps half 1 safe.** With the digest narrowed to the header, that root is the only thing binding the submitted body to the signature — and `simulate_bid_block` *overwrites* it with the root of whatever body it was handed. Without the check, anyone could replay an honest builder's `(header, signature)` with a substituted transaction list, have it proposed under that builder's identity, and leave no trace — with the honest builder absorbing the revocation.

## The root must come from raw bytes

Not from re-encoding the decoded transactions. Parlia's trailing system txs arrive unsigned with `V=R=S=0`, but reth's `Signature` stores only a parity bit, so re-encoding a legacy tx emits `v=27` and yields a different root than geth's `DeriveSha` over the same input.

An earlier revision of this fix did re-encode, and **rejected every legitimate bid** on the devnet. The unit fixtures could not catch it: both sides used the same function, so they agreed with each other while disagreeing with geth. Now pinned by a cross-client vector that also asserts the re-encoded root differs, so a future simplification is flagged rather than discovered by breaking admission.

## Three latent defects this surfaced in our own tooling

All the same shape — a BidBlock header not committing to its own body, previously invisible because nothing checked:

| where | found by | commit |
|---|---|---|
| `bid_block_harness.rs` reused a reference header whose root covered the *signed* deposit | CI (`cargo test --all`) | ee90d45c2 |
| `debug_buildCandidateBlock` shipped the *sealed* root alongside an unsigned-system-tx body | devnet blob/special/tier2 | 1e03e575b |
| the check itself re-encoding decoded txs instead of hashing submitted bytes | devnet A/B | folded into 1e2adce32 |

## Test vectors

Regenerated from current bsc source, not hand-edited. Three **invert** rather than changing value, because the digest is now a pure function of the header:

- `hash_matches_geth_vector_a` — new constant
- `hash_matches_geth_vector_b` — must equal its own header hash; the transactions no longer enter
- blob-sidecar vector — must equal `vector_a` **exactly**; sidecars no longer affect the digest
- `ecrecover_matches_geth_vector_c` — same fixed signature, new recovered address

All four were green throughout: they pinned the stale formula, which is why nothing caught this.

New: `pre_seal_rejects_tx_root_mismatch` (the substitution attack), `signing_digest_ignores_body_and_is_the_header_hash` (the new property), `submitted_tx_root_matches_geth_for_unsigned_system_tx` (the cross-client root vector).

## Verification

`cargo test --all -- --test-threads=1` (436 lib + 6 ef-tests) and `cargo clippy --workspace --tests --all-features`, both clean. CI green.

Full driver matrix on a fresh devnet chain, cluster geth at v1.7.6 (post-#3742):

| mode | result |
|---|---|
| tier1 (admission matrix) | **15/15** — whole `-38001`…`-38008` range plus the acceptance case |
| quota | **2/2** — dedup + per-builder limit; both require acceptance to work |
| tier2 (state-valid e2e) | **3/3** — bid canonical at block 8416, double-sign guard held at 8417, post-import gas-price revocation fired |
| blob | **functionally 2/2** — see below |
| special | **not run** — needs the target validator in-turn on a height ≡ 0 mod 200, which did not occur within 4m; nothing was submitted, so nothing is verified either way |

## Sidecar binding — verified, and stronger than first assumed

Sidecars are no longer covered by the signature; they are bound through `sidecar.tx_hash == tx.hash()` plus the blob versioned hashes carried inside the (root-committed) transactions. reth-bsc's admission checks are **check-for-check identical** to go-bsc's `validateBidBlockBlobSidecars`, and both defer KZG (`// Only cheap sidecar checks run at admission; KZG is checked for the selected BidBlock`).

Live devnet evidence for both directions:

- **valid sidecar** → admitted, won the block, canonical at 16740, sidecar persisted and served (1 blob of exactly 131072 bytes, 1 commitment, 1 proof, correct txHash)
- **corrupted proof** → `C_KZG_BADARGS`, builder revoked **before broadcast**, blob tx excluded from canonical state

So a substituted sidecar does not reach the wire. `blob-valid` reports FAIL only because the driver queries `eth_getBlobSidecars` immediately after canonicalization and races the index; the same height returns the full sidecar moments later.

## Not in this PR

**bsc #3773** (`consensus/parlia: only blind-sign legacy system txs`, 2026-07-31, develop-only) — reth-bsc's `is_unsigned_system_tx_candidate` lacks the `tx.Type() != LegacyTxType` guard, so a typed-envelope system tx could be blind-signed. Separate change.

## Open question

Confirm reth-bsc is meant to track #3742. It's in shipped releases and the pinned bsc checkout has it, so this is almost certainly right — but it changes a signing digest, and the wrong direction breaks anyone still on the old form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
