### PR TITLE
fix(evm): don't run Parlia finalization for eth_simulateV1 (#451)

### DIFF
--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -50,6 +50,44 @@ pub type ValidatorCacheSink = Arc<Mutex<Option<(Vec<Address>, Vec<VoteAddress>)>
 pub type StateRootPrecomputedSink =
     Arc<Mutex<Option<(alloy_primitives::B256, reth_trie_common::updates::TrieUpdates)>>>;
 
+/// What the executor is doing with the block it is running.
+///
+/// Replaces the former `is_miner: bool`, which fused two independent questions: whether a
+/// header already exists, and whether Parlia finalization should run. Those two always
+/// moved together for the import and mining paths, so a bool sufficed — until
+/// `eth_simulateV1` needed the third combination (author a block, but do *not* finalize
+/// it) and was silently rounded to [`Self::Mining`], making a read-only RPC try to sign
+/// Parlia system transactions. See <https://github.com/bnb-chain/reth-bsc/issues/451>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BscExecutionMode {
+    /// Verifying a block received from the network or the engine API. The header already
+    /// exists and system transactions are consumed from the block rather than generated.
+    Import,
+    /// Producing a block this validator will sign and broadcast. System transactions are
+    /// generated and signed with the validator key.
+    Mining,
+    /// Answering a hypothetical — `eth_simulateV1` or the local pending block. Authors a
+    /// header like [`Self::Mining`], but runs no Parlia finalization and signs nothing,
+    /// matching BSC geth's simulation path.
+    Simulation,
+}
+
+impl BscExecutionMode {
+    /// Whether no header exists yet and one is being authored.
+    ///
+    /// True for both [`Self::Mining`] and [`Self::Simulation`]; the block-verification
+    /// checks that dereference `ctx.header` must be skipped in both.
+    pub const fn authors_block(self) -> bool {
+        matches!(self, Self::Mining | Self::Simulation)
+    }
+
+    /// Whether Parlia post-block finalization (reward distribution, slashing, validator-set
+    /// updates) must run — which implies signing system transactions.
+    pub const fn finalizes(self) -> bool {
+        matches!(self, Self::Mining)
+    }
+}
+
 /// BSC wrapper around [`NextBlockEnvAttributes`].
 ///
 /// Extends the upstream attributes with sparse-trie sinks and validator/turn-length
@@ -59,6 +97,13 @@ pub type StateRootPrecomputedSink =
 #[derive(Debug, Clone)]
 pub struct BscNextBlockEnvAttributes {
     pub inner: NextBlockEnvAttributes,
+    /// Execution mode for the block built from these attributes.
+    ///
+    /// Defaults to [`BscExecutionMode::Simulation`] via [`BuildPendingEnv`], which is the
+    /// entry point reth uses for `eth_simulateV1` and the local pending block. The miner and
+    /// bid simulator construct this struct literally and must set
+    /// [`BscExecutionMode::Mining`] explicitly.
+    pub mode: BscExecutionMode,
     /// Sink for transporting `current_validators` from builder to payload layer without writing
     /// to VALIDATOR_CACHE prematurely (hash not yet final at build time).
     pub validator_cache_sink: Option<ValidatorCacheSink>,
@@ -94,6 +139,9 @@ impl<H: BlockHeader> BuildPendingEnv<H> for BscNextBlockEnvAttributes {
     fn build_pending_env(parent: &SealedHeader<H>) -> Self {
         Self {
             inner: NextBlockEnvAttributes::build_pending_env(parent),
+            // This is the RPC-side entry point (`eth_simulateV1`, local pending block), not
+            // the miner. Simulation must not run Parlia finalization or sign system txs.
+            mode: BscExecutionMode::Simulation,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -143,8 +191,8 @@ pub struct BscBlockExecutionCtx<'a> {
     pub header: Option<Header>,
     /// Block hash when known (sealed block), to avoid re-hashing.
     pub header_hash: Option<BlockHash>,
-    /// Whether the block is being mined.
-    pub is_miner: bool,
+    /// What this execution is for: verifying, mining, or simulating.
+    pub mode: BscExecutionMode,
     /// Sink for `current_validators` — written by builder in `finish()` and read by the
     /// payload layer after the builder is consumed. `None` for non-miner paths.
     pub validator_cache_sink: Option<ValidatorCacheSink>,
@@ -474,7 +522,7 @@ where
             },
             header: Some(block.header().clone()),
             header_hash: Some(block.hash()),
-            is_miner: false,
+            mode: BscExecutionMode::Import,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -488,7 +536,12 @@ where
         parent: &SealedHeader<HeaderTy<Self::Primitives>>,
         attributes: Self::NextBlockEnvCtx,
     ) -> Result<ExecutionCtxFor<'_, Self>, Self::Error> {
-        tracing::trace!("Try to create next block ctx for miner, next_block_numer={}, parent_hash={}", parent.number+1, parent.hash());
+        tracing::trace!(
+            "Try to create next block ctx, next_block_numer={}, parent_hash={}, mode={:?}",
+            parent.number + 1,
+            parent.hash(),
+            attributes.mode
+        );
         Ok(BscBlockExecutionCtx {
             base: EthBlockExecutionCtx {
                 tx_count_hint: None,
@@ -501,7 +554,9 @@ where
             },
             header: None, // No header available for next block context
             header_hash: None,
-            is_miner: true,
+            // Carried from the attributes rather than hard-coded: this hook is shared by
+            // the miner, `eth_simulateV1` and the local pending-block path.
+            mode: attributes.mode,
             validator_cache_sink: attributes.validator_cache_sink,
             turn_length_sink: attributes.turn_length_sink,
             state_root_precomputed_sink: attributes.state_root_precomputed_sink,
@@ -570,7 +625,7 @@ where
             },
             header: Some(block.header.clone()),
             header_hash: Some(payload.block_hash_cached()),
-            is_miner: false,
+            mode: BscExecutionMode::Import,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -669,5 +724,42 @@ pub fn revm_spec_by_timestamp_and_block_number(
         } else {
             BscHardfork::Frontier
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use reth_primitives_traits::SealedHeader;
+
+    /// Regression guard for <https://github.com/bnb-chain/reth-bsc/issues/451>.
+    ///
+    /// `build_pending_env` is the entry point reth uses for `eth_simulateV1` and the local
+    /// pending block. It must not select a mode that runs Parlia finalization, or those
+    /// read-only RPCs try to sign system transactions and fail on any node without a
+    /// validator key (and silently inject a signed reward tx on nodes that have one).
+    #[test]
+    fn rpc_pending_env_does_not_select_a_finalizing_mode() {
+        let parent = SealedHeader::seal_slow(Header::default());
+        let attrs = <BscNextBlockEnvAttributes as BuildPendingEnv<Header>>::build_pending_env(
+            &parent,
+        );
+
+        assert_eq!(attrs.mode, BscExecutionMode::Simulation);
+        assert!(!attrs.mode.finalizes(), "simulation must not run Parlia finalization");
+    }
+
+    /// The two predicates encode the axes the old `is_miner: bool` fused together.
+    /// Mining and simulation both author a header; only mining finalizes.
+    #[test]
+    fn execution_mode_predicates_split_authoring_from_finalizing() {
+        assert!(!BscExecutionMode::Import.authors_block());
+        assert!(BscExecutionMode::Mining.authors_block());
+        assert!(BscExecutionMode::Simulation.authors_block());
+
+        assert!(!BscExecutionMode::Import.finalizes());
+        assert!(BscExecutionMode::Mining.finalizes());
+        assert!(!BscExecutionMode::Simulation.finalizes());
     }
 }

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -1,4 +1,6 @@
-use super::config::{revm_spec_by_timestamp_and_block_number, BscBlockExecutionCtx};
+use super::config::{
+    revm_spec_by_timestamp_and_block_number, BscBlockExecutionCtx, BscExecutionMode,
+};
 use super::patch::HertzPatchManager;
 use crate::consensus::parlia::SnapshotProvider;
 use crate::{
@@ -162,8 +164,8 @@ where
                 .lock()
                 .unwrap()
                 .insert_header_to_cache_with_hash(header.clone(), ctx.header_hash);
-        } else if !ctx.is_miner {
-            // miner has no current header.
+        } else if !ctx.mode.authors_block() {
+            // Block-authoring modes (mining, simulation) have no current header.
             warn!(
                 "No header found in the context, block_number: {:?}",
                 evm.block().number().to::<u64>()
@@ -411,7 +413,7 @@ where
         trace!(
             target: "bsc::executor",
             block_id = %block_env.number(),
-            is_miner = self.ctx.is_miner,
+            mode = ?self.ctx.mode,
             "Start to apply_pre_execution_changes"
         );
 
@@ -420,7 +422,8 @@ where
         self.consensus_metrics.current_block_height.set(block_number as f64);
 
         // pre check and prepare some intermediate data for commit parlia snapshot in finish function.
-        if self.ctx.is_miner {
+        // `check_new_block` dereferences `ctx.header`, which only exists when importing.
+        if self.ctx.mode.authors_block() {
             self.prepare_new_block(&block_env)?;
         } else {
             self.check_new_block(&block_env)?;
@@ -485,8 +488,9 @@ where
             });
         }
 
-        // Apply hertz patch before tx (validation only, not mining).
-        if !self.ctx.is_miner {
+        // Apply hertz patch before tx (import only — it replays a historical state fix and
+        // is meaningless for a block being authored).
+        if !self.ctx.mode.authors_block() {
             self.hertz_patch_manager.patch_before_tx(&tx_signed, self.evm.db_mut())?;
         }
 
@@ -578,9 +582,9 @@ where
 
         self.evm.db_mut().commit(state);
 
-        // Apply hertz patch after tx (validation only, not mining).
+        // Apply hertz patch after tx (import only — see `patch_before_tx` above).
         // commit_transaction cannot return errors in the new API, so defer any error to finish().
-        if !self.ctx.is_miner {
+        if !self.ctx.mode.authors_block() {
             if let Err(e) = self.hertz_patch_manager.patch_after_tx(&output.tx, self.evm.db_mut()) {
                 self.deferred_error = Some(e);
             }
@@ -599,7 +603,7 @@ where
         debug!(
             target: "bsc::executor",
             block_id = %block_env.number(),
-            is_miner = self.ctx.is_miner,
+            mode = ?self.ctx.mode,
             "Start to finish"
         );
 
@@ -611,33 +615,49 @@ where
             false,
         )?;
 
-        // Initialize Feynman contracts on transition block
-        if self.spec.is_feynman_transition_at_timestamp(
-            self.evm.block().number().to::<u64>(),
-            self.evm.block().timestamp().to::<u64>(),
-            parent_timestamp,
-        ) {
-            info!(
-                target: "bsc::executor::feynman",
-                block_number = self.evm.block().number().to::<u64>(),
-                "Initializing Feynman contracts"
-            );
-            self.initialize_feynman_contracts(self.evm.block().beneficiary())?;
+        // Both contract-initialization steps below issue Parlia system transactions via
+        // `transact_system_tx`, so they require either a block to consume them from (import)
+        // or a validator key to sign them with (mining). A simulation has neither, and its
+        // caller asked a hypothetical rather than for a sealed block — so skip them, along
+        // with the finalization below.
+        if self.ctx.mode != BscExecutionMode::Simulation {
+            // Initialize Feynman contracts on transition block
+            if self.spec.is_feynman_transition_at_timestamp(
+                self.evm.block().number().to::<u64>(),
+                self.evm.block().timestamp().to::<u64>(),
+                parent_timestamp,
+            ) {
+                info!(
+                    target: "bsc::executor::feynman",
+                    block_number = self.evm.block().number().to::<u64>(),
+                    "Initializing Feynman contracts"
+                );
+                self.initialize_feynman_contracts(self.evm.block().beneficiary())?;
+            }
+
+            // Deploy genesis contracts on Block 1
+            if self.evm.block().number() == uint!(1U256) {
+                info!(
+                    target: "bsc::executor::genesis",
+                    "Deploying genesis contracts on Block 1"
+                );
+                self.deploy_genesis_contracts(self.evm.block().beneficiary())?;
+            }
         }
 
-        // Deploy genesis contracts on Block 1
-        if self.evm.block().number() == uint!(1U256) {
-            info!(
-                target: "bsc::executor::genesis",
-                "Deploying genesis contracts on Block 1"
-            );
-            self.deploy_genesis_contracts(self.evm.block().beneficiary())?;
-        }
-
-        if self.ctx.is_miner {
-            self.finalize_new_block(&self.evm.block().clone())?;
-        } else {
-            self.post_check_new_block(&self.evm.block().clone())?;
+        match self.ctx.mode {
+            // Generates and signs system txs (rewards, slashing, validator-set updates).
+            BscExecutionMode::Mining => self.finalize_new_block(&self.evm.block().clone())?,
+            // Verifies the system txs already present in the received block.
+            BscExecutionMode::Import => self.post_check_new_block(&self.evm.block().clone())?,
+            // Neither: return the executed block as-is, matching BSC geth's simulation path.
+            BscExecutionMode::Simulation => {
+                trace!(
+                    target: "bsc::executor",
+                    block_id = %block_env.number(),
+                    "Skipping Parlia finalization for simulated block"
+                );
+            }
         }
 
         // Update receipt height metric

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -1,7 +1,7 @@
 use super::executor::BscBlockExecutor;
 use super::error::{BscBlockExecutionError, BscBlockValidationError};
 use super::util::set_nonce;
-use super::config::revm_spec_by_timestamp_and_block_number;
+use super::config::{revm_spec_by_timestamp_and_block_number, BscExecutionMode};
 use crate::consensus::parlia::{FF_REWARD_DISTRIBUTION_INTERVAL};
 use crate::node::evm::pre_execution::TURN_LENGTH_CACHE;
 use crate::node::evm::util::get_header_by_hash_from_cache;
@@ -60,7 +60,7 @@ where
         &mut self, 
         block: &BlockEnv
     ) -> Result<(), BlockExecutionError> {
-        tracing::debug!("Start to post check new block, block_number: {}, is_miner: {}", block.number(), self.ctx.is_miner); 
+        tracing::debug!("Start to post check new block, block_number: {}, mode: {:?}", block.number(), self.ctx.mode);
         self.verify_validators(self.inner_ctx.current_validators.clone(), self.inner_ctx.header.clone())?;
         self.verify_turn_length(self.inner_ctx.header.clone())?;
 
@@ -298,7 +298,20 @@ where
 
         let transaction = set_nonce(transaction, account.nonce);
 
-        let signed_tx = if !self.ctx.is_miner {
+        // Simulation never generates system transactions: `finish` skips finalization and
+        // the contract-init steps that would reach here. Guard defensively so a future
+        // caller cannot reintroduce issue #451 by routing a simulation into signing.
+        if self.ctx.mode == BscExecutionMode::Simulation {
+            debug_assert!(false, "system tx attempted during simulation: {transaction:?}");
+            tracing::warn!(
+                target: "bsc::evm",
+                "Skipping system transaction in simulation mode: {:?}",
+                transaction.to()
+            );
+            return Ok(());
+        }
+
+        let signed_tx = if !self.ctx.mode.finalizes() {
             let hash = transaction.signature_hash();
             if self.system_txs.is_empty() || hash != self.system_txs[0].signature_hash() {
                 // slash tx could fail and not in the block
@@ -337,7 +350,7 @@ where
             return Err(BscBlockExecutionError::GlobalSignerNotInitializedForMiningMode.into());
         };
 
-        if self.ctx.is_miner {
+        if self.ctx.mode.finalizes() {
             if let Some(signed) = signed_tx.clone() {
                 let recovered = signed.clone().try_into_recovered_unchecked().unwrap_or_else(|_| {
                     panic!("Failed to recover system transaction signature")
@@ -643,7 +656,7 @@ where
         &mut self, 
         block: &BlockEnv
     ) -> Result<(), BlockExecutionError> {
-        tracing::debug!("Start to finalize new block, block_number: {}, is_miner: {}", block.number(), self.ctx.is_miner);
+        tracing::debug!("Start to finalize new block, block_number: {}, mode: {:?}", block.number(), self.ctx.mode);
         let snap = self.inner_ctx.snap.as_ref().unwrap();
         let epoch_length = snap.epoch_num;
         let expected_validator = snap.inturn_validator();

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -550,17 +550,27 @@ where
             .get_header_by_hash(&self.ctx.base.parent_hash)
             .ok_or(BlockExecutionError::msg("Failed to get parent header from global header reader"))?;
         self.inner_ctx.parent_header = Some(parent_header.clone());
-        let snap = self
-            .snapshot_provider
-            .as_ref()
-            .unwrap()
-            .snapshot_by_hash(&self.ctx.base.parent_hash)
-            .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
-        self.inner_ctx.snap = Some(snap.clone());
+
+        // Only the Parlia finalization in `finish` reads the snapshot, and simulation skips
+        // that entirely. Requiring one here would make `eth_simulateV1` fail — or panic on
+        // the `unwrap` below — whenever the snapshot provider is unavailable, e.g. during
+        // early startup before consensus has published it.
+        if self.ctx.mode.finalizes() {
+            let snap = self
+                .snapshot_provider
+                .as_ref()
+                .ok_or(BlockExecutionError::msg("Snapshot provider is not available"))?
+                .snapshot_by_hash(&self.ctx.base.parent_hash)
+                .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
+            self.inner_ctx.snap = Some(snap.clone());
+        }
 
         let header_number = block.number().to::<u64>();
         let header_timestamp = block.timestamp().to::<u64>();
-        if self.spec.is_feynman_active_at_timestamp(header_number, header_timestamp) &&
+        // The election data below feeds `update_validator_set_v2`, which only runs during
+        // finalization; skip the system-contract calls in simulation.
+        if self.ctx.mode.finalizes() &&
+            self.spec.is_feynman_active_at_timestamp(header_number, header_timestamp) &&
             !self.spec.is_feynman_transition_at_timestamp(header_number, header_timestamp, parent_header.timestamp) &&
             is_breathe_block(parent_header.timestamp, header_timestamp)
         {

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -4,7 +4,9 @@ use crate::consensus::parlia::provider::SnapshotProvider;
 use crate::consensus::parlia::Snapshot;
 use crate::hardforks::BscHardforks;
 use crate::node::engine::BscBuiltPayload;
-use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes, ValidatorCacheSink};
+use crate::node::evm::config::{
+    BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes, ValidatorCacheSink,
+};
 use crate::node::miner::bsc_miner::MiningContext;
 use crate::node::miner::payload::DELAY_LEFT_OVER;
 use crate::node::miner::util::prepare_new_attributes;
@@ -414,6 +416,10 @@ where
                         extra_data: builder_config.extra_data.clone(),
                         slot_number: None,
                     },
+                    // MEV bid simulation reproduces the block this validator would seal, so
+                    // it must run the full Parlia finalization the miner runs — unlike
+                    // `eth_simulateV1`, which is a caller-facing hypothetical.
+                    mode: BscExecutionMode::Mining,
                     validator_cache_sink: Some(bid_validator_cache_sink.clone()),
                     turn_length_sink: Some(bid_turn_length_sink.clone()),
                     // Bid simulation does not run alongside a sparse-trie task —

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -6,7 +6,9 @@ use crate::evm::blacklist;
 use crate::hardforks::BscHardforks;
 use crate::metrics::{BscConsensusMetrics, BscMinerMetrics};
 use crate::node::engine::{BscBuiltPayload, BuildKind};
-use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes, ValidatorCacheSink};
+use crate::node::evm::config::{
+    BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes, ValidatorCacheSink,
+};
 use crate::node::evm::pre_execution::{TURN_LENGTH_CACHE, VALIDATOR_CACHE};
 use crate::node::miner::bid_simulator::BidSimulator;
 use crate::node::miner::bsc_miner::{MiningContext, SubmitContext};
@@ -525,6 +527,7 @@ where
                     .unwrap_or_else(|| self.builder_config.extra_data.clone()),
                 slot_number: None,
             },
+            mode: BscExecutionMode::Mining,
             validator_cache_sink: Some(validator_cache_sink.clone()),
             turn_length_sink: Some(turn_length_sink.clone()),
             state_root_precomputed_sink: Some(state_root_precomputed_sink),
@@ -1061,6 +1064,7 @@ where
                             .unwrap_or_else(|| self.builder_config.extra_data.clone()),
                         slot_number: None,
                     },
+                    mode: BscExecutionMode::Mining,
                     validator_cache_sink: Some(validator_cache_sink.clone()),
                     turn_length_sink: Some(turn_length_sink.clone()),
                     // Empty-fallback build never installs a sparse-trie hook (trie_handle: None


### PR DESCRIPTION
Fixes #451.

## Problem

`eth_simulateV1` fails on any node without a validator key:

```
{"code":-32603,"message":"global signer not initialized for mining mode"}
```

`BscBlockExecutionCtx.is_miner` is a two-state bool that fuses two independent questions: **does a header already exist**, and **should Parlia finalization run**. Those two always move together for the import and mining paths, so a bool was enough — until simulation needed the third combination: *author a block, but do not finalize it*.

There is no way to express that, so `context_for_next_block` hard-codes `is_miner: true`. Upstream reth shares that one hook between the miner, `eth_simulateV1`, and the local pending block, so a read-only RPC ends up running block production — reward distribution, slashing, and system-transaction signing.

### The more serious half

On a node that *does* hold a signing key, the call does not fail. It succeeds and returns a corrupted answer:

```
calls: 1     block txs: 2     gasUsed: 0x1afd1
phantom tx -> to=0x…1000 (ValidatorContract) selector=0xf340fa01 (deposit) value=0x1319718a5000
```

The node signs itself a Parlia reward transaction with the validator key and injects it into the caller's simulation result. Gas is over-reported by more than 5x on a plain transfer. Nothing errors, so a caller has no way to detect it.

## Fix

Replace the bool with a three-state mode that separates the two axes:

```rust
pub enum BscExecutionMode { Import, Mining, Simulation }

impl BscExecutionMode {
    pub const fn authors_block(self) -> bool { matches!(self, Self::Mining | Self::Simulation) }
    pub const fn finalizes(self) -> bool { matches!(self, Self::Mining) }
}
```

- `BuildPendingEnv` — reth's RPC-side entry point — selects `Simulation`. This is the line that fixes the bug, and it covers the local pending-block path too.
- The miner and bid simulator build the attributes as struct literals, so the new field makes each an explicit compile-time decision rather than an inherited default.
- `finish()` additionally skips the Feynman/genesis contract initialization under `Simulation`; those issue system transactions of their own and sit above the mode branch. Missing them would leave the bug alive at fork boundaries.
- `prepare_new_block` skips the snapshot lookup under `Simulation` (only finalization reads it), which also removes an `unwrap` that could panic an RPC call before the snapshot provider is published.

Import and mining map one-to-one onto the old `false`/`true` at every site, so block validation and production are unchanged. The only new behavior is `Simulation`, which no consensus path can reach.

## Prior art

BSC geth hit this and fixed it the same way in bnb-chain/bsc#3433 (*"internal/ethapi: fix eth_simulateV1"*), replacing the consensus-engine call with a simulation-local assembler.

Worth flagging: **that fix has since regressed upstream.** Current BSC geth routes simulation back through Parlia via `core.AssembleBlock(engine, …)`, and geth v1.7.6 reproduces the same failure. Their now-unused bypass function still sits in `simulate.go`. So the claim in #451 that geth works is no longer true for current builds — the reporter likely tested during the window when their fix was live. That deserves its own report to bnb-chain/bsc.

## Testing

`cargo clippy --workspace --tests --all-features` with `-D warnings`: clean. `cargo test --all -- --test-threads=1`: 314 passed, including 2 new regression tests asserting `build_pending_env` never selects a finalizing mode.

A/B on a local 4-reth + 6-geth devnet, using two release builds from this commit differing only by this patch:

| | before | after |
|---|---|---|
| keyless node | `-32603` | OK, 1 tx |
| mining node | 2 txs for 1 call, gas `0x1afd1` | 1 tx, gas `0x5208` |

Regression checks on the patched build: block production continued throughout, all reth and geth nodes stayed in lockstep, no new errors in any node log, and a patched reth node sealed 7 of 20 blocks which the geth validators accepted — confirming Parlia finalization still works on the mining path.

### Reproducing

No sync required — a keyless node at genesis is enough:

```bash
reth-bsc node --chain <devnet>/genesis_reth.json --datadir /tmp/repro451 \
  --genesis-hash 0x10a06aa7… --disable-discovery \
  --http --http.port 8571 --http.api eth,net,web3,debug

curl -s -X POST -H 'Content-Type: application/json' --data-raw '{"jsonrpc":"2.0","id":1,
 "method":"eth_simulateV1","params":[{"blockStateCalls":[{"calls":[{
 "from":"<funded>","to":"0x…dEaD","value":"0x1","gas":"0x5208","gasPrice":"0x3b9aca00"}]}],
 "validation":true},"latest"]}' http://127.0.0.1:8571
```

`eth_call` with the same transfer succeeds throughout, before and after — it never builds a block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
