### PR TITLE
chore: perf traceblock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7534,7 +7534,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7585,7 +7585,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-execution-cache",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7619,7 +7619,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7655,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7758,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7846,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7898,7 +7898,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7974,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8027,7 +8027,7 @@ dependencies = [
  "rand 0.9.4",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -8062,7 +8062,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8078,7 +8078,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8125,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8148,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8173,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8200,7 +8200,7 @@ dependencies = [
  "reth-evm",
  "reth-execution-cache",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8278,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8294,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8316,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8327,7 +8327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8341,7 +8341,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "clap",
  "eyre",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8420,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8436,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8450,7 +8450,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8480,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8494,7 +8494,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8517,7 +8517,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8529,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8549,14 +8549,14 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
  "metrics",
  "parking_lot",
  "reth-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -8567,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8580,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8599,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8616,7 +8616,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8637,7 +8637,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "serde",
  "serde_json",
@@ -8661,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8689,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8709,7 +8709,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8726,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "bindgen",
  "cc",
@@ -8735,7 +8735,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "futures",
  "metrics",
@@ -8761,7 +8761,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8770,7 +8770,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8815,7 +8815,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8905,7 +8905,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8919,7 +8919,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8936,7 +8936,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8960,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9085,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -9123,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9184,7 +9184,7 @@ dependencies = [
  "metrics-util",
  "procfs",
  "reqwest 0.13.4",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9195,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9218,7 +9218,7 @@ dependencies = [
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
  "reth-execution-cache",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9243,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9332,7 +9332,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9369,7 +9369,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9386,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9402,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9460,7 +9460,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9495,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -9525,7 +9525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9540,7 +9540,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-api",
  "reth-node-core",
  "reth-payload-primitives",
@@ -9568,7 +9568,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9589,7 +9589,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9601,7 +9601,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9693,7 +9693,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.1",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9760,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9826,7 +9826,7 @@ dependencies = [
  "reth-codecs",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9916,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9934,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -9944,7 +9944,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rayon",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "thiserror 2.0.18",
  "thread-priority",
  "tokio",
@@ -9955,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9971,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "clap",
  "eyre",
@@ -9996,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "clap",
  "eyre",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10038,7 +10038,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10071,7 +10071,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10114,14 +10114,14 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
@@ -10135,7 +10135,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10148,7 +10148,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
@@ -10163,7 +10163,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f#c13b098660e0a65bd9aac8171eb917c04ed2297f"
+source = "git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8#c46bbdb4639591074679fb7293ba26ab8bb67fe8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10171,7 +10171,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
@@ -10269,7 +10269,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c13b098660e0a65bd9aac8171eb917c04ed2297f)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=c46bbdb4639591074679fb7293ba26ab8bb67fe8)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
 reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
 
 revm = "38.0.0"
 revm-database = "13.0.0"

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -14,30 +14,30 @@ asm-keccak = ["alloy-primitives/asm-keccak"]
 reth_bsc = { path = "../.." }
 
 # reth dependencies aligned with root crate branch to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "mdbx",
     "test-utils",
     "disable-lock",
 ] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "test-utils",
 ] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f", features = [
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8", features = [
     "std",
 ] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c13b098660e0a65bd9aac8171eb917c04ed2297f" }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "c46bbdb4639591074679fb7293ba26ab8bb67fe8" }
 
 # revm
 revm = { version = "38.0.0", features = [


### PR DESCRIPTION
Picks up the storage read breakdown logged by trace_block and debug_traceBlock*, so a slow block trace can be attributed to history index lookups, changeset reads, plain state or the EVM.

The previous pin c13b0986 is the direct parent of c46bbdb4, so this brings in the instrumentation and nothing else. Enable it with --log.stdout.filter "info,storage::timings=debug".

### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
