### PR TITLE
fix(rpc): don't run Parlia finalization for the pending block or eth_simulateV1

### DIFF
--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -50,6 +50,44 @@ pub type ValidatorCacheSink = Arc<Mutex<Option<(Vec<Address>, Vec<VoteAddress>)>
 pub type StateRootPrecomputedSink =
     Arc<Mutex<Option<(alloy_primitives::B256, reth_trie_common::updates::TrieUpdates)>>>;
 
+/// What the executor is doing with the block it is running.
+///
+/// Replaces the former `is_miner: bool`, which fused two independent questions: whether a
+/// header already exists, and whether Parlia finalization should run. Those two always
+/// moved together for the import and mining paths, so a bool sufficed — until
+/// `eth_simulateV1` needed the third combination (author a block, but do *not* finalize
+/// it) and was silently rounded to [`Self::Mining`], making a read-only RPC try to sign
+/// Parlia system transactions. See <https://github.com/bnb-chain/reth-bsc/issues/451>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BscExecutionMode {
+    /// Verifying a block received from the network or the engine API. The header already
+    /// exists and system transactions are consumed from the block rather than generated.
+    Import,
+    /// Producing a block this validator will sign and broadcast. System transactions are
+    /// generated and signed with the validator key.
+    Mining,
+    /// Answering a hypothetical — `eth_simulateV1` or the local pending block. Authors a
+    /// header like [`Self::Mining`], but runs no Parlia finalization and signs nothing,
+    /// matching BSC geth's simulation path.
+    Simulation,
+}
+
+impl BscExecutionMode {
+    /// Whether no header exists yet and one is being authored.
+    ///
+    /// True for both [`Self::Mining`] and [`Self::Simulation`]; the block-verification
+    /// checks that dereference `ctx.header` must be skipped in both.
+    pub const fn authors_block(self) -> bool {
+        matches!(self, Self::Mining | Self::Simulation)
+    }
+
+    /// Whether Parlia post-block finalization (reward distribution, slashing, validator-set
+    /// updates) must run — which implies signing system transactions.
+    pub const fn finalizes(self) -> bool {
+        matches!(self, Self::Mining)
+    }
+}
+
 /// BSC wrapper around [`NextBlockEnvAttributes`].
 ///
 /// Extends the upstream attributes with sparse-trie sinks and validator/turn-length
@@ -59,6 +97,13 @@ pub type StateRootPrecomputedSink =
 #[derive(Debug, Clone)]
 pub struct BscNextBlockEnvAttributes {
     pub inner: NextBlockEnvAttributes,
+    /// Execution mode for the block built from these attributes.
+    ///
+    /// Defaults to [`BscExecutionMode::Simulation`] via [`BuildPendingEnv`], which is the
+    /// entry point reth uses for `eth_simulateV1` and the local pending block. The miner and
+    /// bid simulator construct this struct literally and must set
+    /// [`BscExecutionMode::Mining`] explicitly.
+    pub mode: BscExecutionMode,
     /// Sink for transporting `current_validators` from builder to payload layer without writing
     /// to VALIDATOR_CACHE prematurely (hash not yet final at build time).
     pub validator_cache_sink: Option<ValidatorCacheSink>,
@@ -94,6 +139,9 @@ impl<H: BlockHeader> BuildPendingEnv<H> for BscNextBlockEnvAttributes {
     fn build_pending_env(parent: &SealedHeader<H>) -> Self {
         Self {
             inner: NextBlockEnvAttributes::build_pending_env(parent),
+            // This is the RPC-side entry point (`eth_simulateV1`, local pending block), not
+            // the miner. Simulation must not run Parlia finalization or sign system txs.
+            mode: BscExecutionMode::Simulation,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -143,8 +191,8 @@ pub struct BscBlockExecutionCtx<'a> {
     pub header: Option<Header>,
     /// Block hash when known (sealed block), to avoid re-hashing.
     pub header_hash: Option<BlockHash>,
-    /// Whether the block is being mined.
-    pub is_miner: bool,
+    /// What this execution is for: verifying, mining, or simulating.
+    pub mode: BscExecutionMode,
     /// Sink for `current_validators` — written by builder in `finish()` and read by the
     /// payload layer after the builder is consumed. `None` for non-miner paths.
     pub validator_cache_sink: Option<ValidatorCacheSink>,
@@ -469,7 +517,7 @@ where
             },
             header: Some(block.header().clone()),
             header_hash: Some(block.hash()),
-            is_miner: false,
+            mode: BscExecutionMode::Import,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -483,7 +531,12 @@ where
         parent: &SealedHeader<HeaderTy<Self::Primitives>>,
         attributes: Self::NextBlockEnvCtx,
     ) -> Result<ExecutionCtxFor<'_, Self>, Self::Error> {
-        tracing::trace!("Try to create next block ctx for miner, next_block_numer={}, parent_hash={}", parent.number+1, parent.hash());
+        tracing::trace!(
+            "Try to create next block ctx, next_block_numer={}, parent_hash={}, mode={:?}",
+            parent.number + 1,
+            parent.hash(),
+            attributes.mode
+        );
         Ok(BscBlockExecutionCtx {
             base: EthBlockExecutionCtx {
                 tx_count_hint: None,
@@ -496,7 +549,9 @@ where
             },
             header: None, // No header available for next block context
             header_hash: None,
-            is_miner: true,
+            // Carried from the attributes rather than hard-coded: this hook is shared by
+            // the miner, `eth_simulateV1` and the local pending-block path.
+            mode: attributes.mode,
             validator_cache_sink: attributes.validator_cache_sink,
             turn_length_sink: attributes.turn_length_sink,
             state_root_precomputed_sink: attributes.state_root_precomputed_sink,
@@ -565,7 +620,7 @@ where
             },
             header: Some(block.header.clone()),
             header_hash: Some(payload.block_hash_cached()),
-            is_miner: false,
+            mode: BscExecutionMode::Import,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,
@@ -664,5 +719,42 @@ pub fn revm_spec_by_timestamp_and_block_number(
         } else {
             BscHardfork::Frontier
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use reth_primitives_traits::SealedHeader;
+
+    /// Regression guard for <https://github.com/bnb-chain/reth-bsc/issues/451>.
+    ///
+    /// `build_pending_env` is the entry point reth uses for `eth_simulateV1` and the local
+    /// pending block. It must not select a mode that runs Parlia finalization, or those
+    /// read-only RPCs try to sign system transactions and fail on any node without a
+    /// validator key (and silently inject a signed reward tx on nodes that have one).
+    #[test]
+    fn rpc_pending_env_does_not_select_a_finalizing_mode() {
+        let parent = SealedHeader::seal_slow(Header::default());
+        let attrs = <BscNextBlockEnvAttributes as BuildPendingEnv<Header>>::build_pending_env(
+            &parent,
+        );
+
+        assert_eq!(attrs.mode, BscExecutionMode::Simulation);
+        assert!(!attrs.mode.finalizes(), "simulation must not run Parlia finalization");
+    }
+
+    /// The two predicates encode the axes the old `is_miner: bool` fused together.
+    /// Mining and simulation both author a header; only mining finalizes.
+    #[test]
+    fn execution_mode_predicates_split_authoring_from_finalizing() {
+        assert!(!BscExecutionMode::Import.authors_block());
+        assert!(BscExecutionMode::Mining.authors_block());
+        assert!(BscExecutionMode::Simulation.authors_block());
+
+        assert!(!BscExecutionMode::Import.finalizes());
+        assert!(BscExecutionMode::Mining.finalizes());
+        assert!(!BscExecutionMode::Simulation.finalizes());
     }
 }

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -757,4 +757,37 @@ mod tests {
         assert!(BscExecutionMode::Mining.finalizes());
         assert!(!BscExecutionMode::Simulation.finalizes());
     }
+
+    /// Regression guard for <https://github.com/bnb-chain/reth-bsc/issues/464>.
+    ///
+    /// `context_for_next_block` used to hard-code `is_miner: true`, so the execution context
+    /// reth builds for the local pending block demanded Parlia finalization regardless of the
+    /// attributes it was handed. On a node without a validator key that made
+    /// `eth_getBlockByNumber("pending")` fail to build and return `null`. The mode must be
+    /// carried from the attributes, not re-decided here.
+    #[test]
+    fn next_block_ctx_carries_the_mode_from_the_attributes() {
+        let chain_spec = Arc::new(BscChainSpec::from(crate::chainspec::bsc::bsc_mainnet()));
+        let evm_config = BscEvmConfig::new(chain_spec);
+        let parent = SealedHeader::seal_slow(Header::default());
+
+        // The RPC pending-block / `eth_simulateV1` entry point.
+        let pending_attrs =
+            <BscNextBlockEnvAttributes as BuildPendingEnv<Header>>::build_pending_env(&parent);
+        let ctx = evm_config.context_for_next_block(&parent, pending_attrs).unwrap();
+        assert_eq!(ctx.mode, BscExecutionMode::Simulation);
+        assert!(
+            !ctx.mode.finalizes(),
+            "pending-block ctx must not require a validator key to finalize"
+        );
+        assert!(ctx.mode.authors_block(), "pending block still authors a header");
+
+        // The miner passes its attributes through the same hook and must keep finalizing.
+        let mut mining_attrs =
+            <BscNextBlockEnvAttributes as BuildPendingEnv<Header>>::build_pending_env(&parent);
+        mining_attrs.mode = BscExecutionMode::Mining;
+        let ctx = evm_config.context_for_next_block(&parent, mining_attrs).unwrap();
+        assert_eq!(ctx.mode, BscExecutionMode::Mining);
+        assert!(ctx.mode.finalizes(), "mining must still run Parlia finalization");
+    }
 }

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -1,4 +1,6 @@
-use super::config::{revm_spec_by_timestamp_and_block_number, BscBlockExecutionCtx};
+use super::config::{
+    revm_spec_by_timestamp_and_block_number, BscBlockExecutionCtx, BscExecutionMode,
+};
 use super::patch::HertzPatchManager;
 use crate::consensus::parlia::SnapshotProvider;
 use crate::{
@@ -165,8 +167,8 @@ where
                 .lock()
                 .unwrap()
                 .insert_header_to_cache_with_hash(header.clone(), ctx.header_hash);
-        } else if !ctx.is_miner {
-            // miner has no current header.
+        } else if !ctx.mode.authors_block() {
+            // Block-authoring modes (mining, simulation) have no current header.
             warn!(
                 "No header found in the context, block_number: {:?}",
                 evm.block().number().to::<u64>()
@@ -455,7 +457,7 @@ where
         trace!(
             target: "bsc::executor",
             block_id = %block_env.number(),
-            is_miner = self.ctx.is_miner,
+            mode = ?self.ctx.mode,
             "Start to apply_pre_execution_changes"
         );
 
@@ -464,7 +466,8 @@ where
         self.consensus_metrics.current_block_height.set(block_number as f64);
 
         // pre check and prepare some intermediate data for commit parlia snapshot in finish function.
-        if self.ctx.is_miner {
+        // `check_new_block` dereferences `ctx.header`, which only exists when importing.
+        if self.ctx.mode.authors_block() {
             self.prepare_new_block(&block_env)?;
         } else {
             self.check_new_block(&block_env)?;
@@ -529,8 +532,9 @@ where
             });
         }
 
-        // Apply hertz patch before tx (validation only, not mining).
-        if !self.ctx.is_miner {
+        // Apply hertz patch before tx (import only — it replays a historical state fix and
+        // is meaningless for a block being authored).
+        if !self.ctx.mode.authors_block() {
             self.hertz_patch_manager.patch_before_tx(&tx_signed, self.evm.db_mut())?;
         }
 
@@ -622,9 +626,9 @@ where
 
         self.evm.db_mut().commit(state);
 
-        // Apply hertz patch after tx (validation only, not mining).
+        // Apply hertz patch after tx (import only — see `patch_before_tx` above).
         // commit_transaction cannot return errors in the new API, so defer any error to finish().
-        if !self.ctx.is_miner {
+        if !self.ctx.mode.authors_block() {
             if let Err(e) = self.hertz_patch_manager.patch_after_tx(&output.tx, self.evm.db_mut()) {
                 self.deferred_error = Some(e);
             }
@@ -643,7 +647,7 @@ where
         debug!(
             target: "bsc::executor",
             block_id = %block_env.number(),
-            is_miner = self.ctx.is_miner,
+            mode = ?self.ctx.mode,
             "Start to finish"
         );
 
@@ -655,33 +659,49 @@ where
             false,
         )?;
 
-        // Initialize Feynman contracts on transition block
-        if self.spec.is_feynman_transition_at_timestamp(
-            self.evm.block().number().to::<u64>(),
-            self.evm.block().timestamp().to::<u64>(),
-            parent_timestamp,
-        ) {
-            info!(
-                target: "bsc::executor::feynman",
-                block_number = self.evm.block().number().to::<u64>(),
-                "Initializing Feynman contracts"
-            );
-            self.initialize_feynman_contracts(self.evm.block().beneficiary())?;
+        // Both contract-initialization steps below issue Parlia system transactions via
+        // `transact_system_tx`, so they require either a block to consume them from (import)
+        // or a validator key to sign them with (mining). A simulation has neither, and its
+        // caller asked a hypothetical rather than for a sealed block — so skip them, along
+        // with the finalization below.
+        if self.ctx.mode != BscExecutionMode::Simulation {
+            // Initialize Feynman contracts on transition block
+            if self.spec.is_feynman_transition_at_timestamp(
+                self.evm.block().number().to::<u64>(),
+                self.evm.block().timestamp().to::<u64>(),
+                parent_timestamp,
+            ) {
+                info!(
+                    target: "bsc::executor::feynman",
+                    block_number = self.evm.block().number().to::<u64>(),
+                    "Initializing Feynman contracts"
+                );
+                self.initialize_feynman_contracts(self.evm.block().beneficiary())?;
+            }
+
+            // Deploy genesis contracts on Block 1
+            if self.evm.block().number() == uint!(1U256) {
+                info!(
+                    target: "bsc::executor::genesis",
+                    "Deploying genesis contracts on Block 1"
+                );
+                self.deploy_genesis_contracts(self.evm.block().beneficiary())?;
+            }
         }
 
-        // Deploy genesis contracts on Block 1
-        if self.evm.block().number() == uint!(1U256) {
-            info!(
-                target: "bsc::executor::genesis",
-                "Deploying genesis contracts on Block 1"
-            );
-            self.deploy_genesis_contracts(self.evm.block().beneficiary())?;
-        }
-
-        if self.ctx.is_miner {
-            self.finalize_new_block(&self.evm.block().clone())?;
-        } else {
-            self.post_check_new_block(&self.evm.block().clone())?;
+        match self.ctx.mode {
+            // Generates and signs system txs (rewards, slashing, validator-set updates).
+            BscExecutionMode::Mining => self.finalize_new_block(&self.evm.block().clone())?,
+            // Verifies the system txs already present in the received block.
+            BscExecutionMode::Import => self.post_check_new_block(&self.evm.block().clone())?,
+            // Neither: return the executed block as-is, matching BSC geth's simulation path.
+            BscExecutionMode::Simulation => {
+                trace!(
+                    target: "bsc::executor",
+                    block_id = %block_env.number(),
+                    "Skipping Parlia finalization for simulated block"
+                );
+            }
         }
 
         // Update receipt height metric

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -1,7 +1,7 @@
 use super::executor::BscBlockExecutor;
 use super::error::{BscBlockExecutionError, BscBlockValidationError};
 use super::util::set_nonce;
-use super::config::revm_spec_by_timestamp_and_block_number;
+use super::config::{revm_spec_by_timestamp_and_block_number, BscExecutionMode};
 use crate::consensus::parlia::{FF_REWARD_DISTRIBUTION_INTERVAL};
 use crate::node::evm::pre_execution::{CallBlockEnv, TURN_LENGTH_CACHE};
 use crate::node::evm::util::get_header_by_hash_from_cache;
@@ -61,7 +61,7 @@ where
         &mut self, 
         block: &BlockEnv
     ) -> Result<(), BlockExecutionError> {
-        tracing::debug!("Start to post check new block, block_number: {}, is_miner: {}", block.number(), self.ctx.is_miner); 
+        tracing::debug!("Start to post check new block, block_number: {}, mode: {:?}", block.number(), self.ctx.mode);
         self.verify_validators(self.inner_ctx.current_validators.clone(), self.inner_ctx.header.clone())?;
         self.verify_turn_length(self.inner_ctx.header.clone())?;
 
@@ -303,7 +303,20 @@ where
 
         let transaction = set_nonce(transaction, account.nonce);
 
-        let signed_tx = if !self.ctx.is_miner {
+        // Simulation never generates system transactions: `finish` skips finalization and
+        // the contract-init steps that would reach here. Guard defensively so a future
+        // caller cannot reintroduce issue #451 by routing a simulation into signing.
+        if self.ctx.mode == BscExecutionMode::Simulation {
+            debug_assert!(false, "system tx attempted during simulation: {transaction:?}");
+            tracing::warn!(
+                target: "bsc::evm",
+                "Skipping system transaction in simulation mode: {:?}",
+                transaction.to()
+            );
+            return Ok(());
+        }
+
+        let signed_tx = if !self.ctx.mode.finalizes() {
             let hash = transaction.signature_hash();
             if self.system_txs.is_empty() || hash != self.system_txs[0].signature_hash() {
                 // slash tx could fail and not in the block
@@ -342,7 +355,7 @@ where
             return Err(BscBlockExecutionError::GlobalSignerNotInitializedForMiningMode.into());
         };
 
-        if self.ctx.is_miner {
+        if self.ctx.mode.finalizes() {
             if let Some(signed) = signed_tx.clone() {
                 let recovered = signed.clone().try_into_recovered_unchecked().unwrap_or_else(|_| {
                     panic!("Failed to recover system transaction signature")
@@ -661,7 +674,7 @@ where
         &mut self, 
         block: &BlockEnv
     ) -> Result<(), BlockExecutionError> {
-        tracing::debug!("Start to finalize new block, block_number: {}, is_miner: {}", block.number(), self.ctx.is_miner);
+        tracing::debug!("Start to finalize new block, block_number: {}, mode: {:?}", block.number(), self.ctx.mode);
         let snap = self.inner_ctx.snap.as_ref().unwrap();
         let epoch_length = snap.epoch_num;
         let expected_validator = snap.inturn_validator();

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -650,17 +650,27 @@ where
             .get_header_by_hash(&self.ctx.base.parent_hash)
             .ok_or(BlockExecutionError::msg("Failed to get parent header from global header reader"))?;
         self.inner_ctx.parent_header = Some(parent_header.clone());
-        let snap = self
-            .snapshot_provider
-            .as_ref()
-            .unwrap()
-            .snapshot_by_hash(&self.ctx.base.parent_hash)
-            .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
-        self.inner_ctx.snap = Some(snap.clone());
+
+        // Only the Parlia finalization in `finish` reads the snapshot, and simulation skips
+        // that entirely. Requiring one here would make `eth_simulateV1` fail — or panic on
+        // the `unwrap` below — whenever the snapshot provider is unavailable, e.g. during
+        // early startup before consensus has published it.
+        if self.ctx.mode.finalizes() {
+            let snap = self
+                .snapshot_provider
+                .as_ref()
+                .ok_or(BlockExecutionError::msg("Snapshot provider is not available"))?
+                .snapshot_by_hash(&self.ctx.base.parent_hash)
+                .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
+            self.inner_ctx.snap = Some(snap.clone());
+        }
 
         let header_number = block.number().to::<u64>();
         let header_timestamp = block.timestamp().to::<u64>();
-        if self.spec.is_feynman_active_at_timestamp(header_number, header_timestamp) &&
+        // The election data below feeds `update_validator_set_v2`, which only runs during
+        // finalization; skip the system-contract calls in simulation.
+        if self.ctx.mode.finalizes() &&
+            self.spec.is_feynman_active_at_timestamp(header_number, header_timestamp) &&
             !self.spec.is_feynman_transition_at_timestamp(header_number, header_timestamp, parent_header.timestamp) &&
             is_breathe_block(parent_header.timestamp, header_timestamp)
         {

--- a/src/node/evm/pre_execution_tests.rs
+++ b/src/node/evm/pre_execution_tests.rs
@@ -428,7 +428,7 @@ mod parent_block_env {
     use crate::consensus::parlia::snapshot::MAXWELL_EPOCH_LENGTH;
     use crate::evm::api::BscEvm;
     use crate::node::evm::config::{
-        evm_env_for_header, BscBlockExecutionCtx, BscExecutionSharedCtx,
+        evm_env_for_header, BscBlockExecutionCtx, BscExecutionMode, BscExecutionSharedCtx,
     };
     use crate::node::evm::executor::BscBlockExecutor;
     use crate::node::evm::pre_execution::{CallBlockEnv, VALIDATOR_CACHE};
@@ -608,7 +608,7 @@ mod parent_block_env {
             },
             header: Some(header),
             header_hash: None,
-            is_miner: false,
+            mode: BscExecutionMode::Import,
             validator_cache_sink: None,
             turn_length_sink: None,
             state_root_precomputed_sink: None,

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -4,7 +4,9 @@ use crate::consensus::parlia::provider::SnapshotProvider;
 use crate::consensus::parlia::Snapshot;
 use crate::hardforks::BscHardforks;
 use crate::node::engine::BscBuiltPayload;
-use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes, ValidatorCacheSink};
+use crate::node::evm::config::{
+    BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes, ValidatorCacheSink,
+};
 use crate::node::miner::bsc_miner::MiningContext;
 use crate::node::miner::payload::DELAY_LEFT_OVER;
 use crate::node::miner::util::{epoch_validators_for_next_block, prepare_new_attributes};
@@ -650,6 +652,10 @@ where
                         extra_data: builder_config.extra_data.clone(),
                         slot_number: None,
                     },
+                    // MEV bid simulation reproduces the block this validator would seal, so
+                    // it must run the full Parlia finalization the miner runs — unlike
+                    // `eth_simulateV1`, which is a caller-facing hypothetical.
+                    mode: BscExecutionMode::Mining,
                     validator_cache_sink: Some(bid_validator_cache_sink.clone()),
                     turn_length_sink: Some(bid_turn_length_sink.clone()),
                     // Bid simulation does not run alongside a sparse-trie task —

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -6,7 +6,9 @@ use crate::evm::blacklist;
 use crate::hardforks::BscHardforks;
 use crate::metrics::{BscConsensusMetrics, BscMinerMetrics};
 use crate::node::engine::{BscBuiltPayload, BuildKind};
-use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes, ValidatorCacheSink};
+use crate::node::evm::config::{
+    BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes, ValidatorCacheSink,
+};
 use crate::node::evm::pre_execution::{EpochValidators, TURN_LENGTH_CACHE, VALIDATOR_CACHE};
 use crate::node::miner::bid_block::{validate_bid_block_blob_kzg, BidBlockTask};
 use crate::node::miner::bid_simulator::BidSimulator;
@@ -527,6 +529,7 @@ where
                     .unwrap_or_else(|| self.builder_config.extra_data.clone()),
                 slot_number: None,
             },
+            mode: BscExecutionMode::Mining,
             validator_cache_sink: Some(validator_cache_sink.clone()),
             turn_length_sink: Some(turn_length_sink.clone()),
             state_root_precomputed_sink: Some(state_root_precomputed_sink),
@@ -1064,6 +1067,7 @@ where
                             .unwrap_or_else(|| self.builder_config.extra_data.clone()),
                         slot_number: None,
                     },
+                    mode: BscExecutionMode::Mining,
                     validator_cache_sink: Some(validator_cache_sink.clone()),
                     turn_length_sink: Some(turn_length_sink.clone()),
                     // Empty-fallback build never installs a sparse-trie hook (trie_handle: None

--- a/src/rpc/debug_builder.rs
+++ b/src/rpc/debug_builder.rs
@@ -18,7 +18,7 @@ use crate::consensus::parlia::util::{
     calculate_difficulty, calculate_millisecond_timestamp, set_millisecond_part_of_timestamp,
 };
 use crate::hardforks::BscHardforks;
-use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes};
+use crate::node::evm::config::{BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes};
 use crate::node::miner::bid_block::BidBlock;
 use alloy_consensus::transaction::SignerRecoverable;
 use alloy_consensus::Transaction;
@@ -201,6 +201,9 @@ where
                     extra_data: Default::default(),
                     slot_number: None,
                 },
+                // `debug_buildCandidateBlock` runs the real block-building pipeline and
+                // signs Parlia system txs, so it is Mining despite passing no sinks.
+                mode: BscExecutionMode::Mining,
                 validator_cache_sink: None,
                 turn_length_sink: None,
                 state_root_precomputed_sink: None,

--- a/testing/bsc-ef-tests/tests/bid_block_harness.rs
+++ b/testing/bsc-ef-tests/tests/bid_block_harness.rs
@@ -258,7 +258,9 @@ fn publish_env(chain_spec: Arc<BscChainSpec>) {
 /// This is the reference the round-trip will compare `simulate_bid_block` against.
 #[test]
 fn trusted_local_build_produces_block() {
-    use reth_bsc::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes};
+    use reth_bsc::node::evm::config::{
+        BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes,
+    };
     use reth_evm::execute::{BlockBuilder, BlockBuilderOutcome};
     use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
     use reth_provider::DatabaseProviderFactory;
@@ -292,6 +294,7 @@ fn trusted_local_build_produces_block() {
                     extra_data: Default::default(),
                     slot_number: None,
                 },
+                mode: BscExecutionMode::Mining,
                 validator_cache_sink: None,
                 turn_length_sink: None,
                 state_root_precomputed_sink: None,
@@ -320,7 +323,9 @@ fn trusted_local_build_produces_block() {
 #[test]
 fn round_trip_build_finalize_reexecute_agree() {
     use reth_bsc::consensus::parlia::util::calculate_difficulty;
-    use reth_bsc::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes};
+    use reth_bsc::node::evm::config::{
+        BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes,
+    };
     use reth_bsc::node::miner::util::finalize_new_header;
     use reth_evm::execute::{BlockBuilder, BlockBuilderOutcome, Executor};
     use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
@@ -365,6 +370,7 @@ fn round_trip_build_finalize_reexecute_agree() {
                         extra_data: alloy_primitives::Bytes::from(vec![0u8; 32]),
                         slot_number: None,
                     },
+                    mode: BscExecutionMode::Mining,
                     validator_cache_sink: None,
                     turn_length_sink: None,
                     state_root_precomputed_sink: None,
@@ -435,7 +441,9 @@ fn execution_gate_round_trip() {
     use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::{Signature, TxKind};
     use reth_bsc::consensus::parlia::util::calculate_difficulty;
-    use reth_bsc::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes};
+    use reth_bsc::node::evm::config::{
+        BscEvmConfig, BscExecutionMode, BscNextBlockEnvAttributes,
+    };
     use reth_bsc::node::miner::bid_block::{
         simulate_bid_block, submitted_tx_root, BidBlock, BidBlockArgs,
     };
@@ -479,6 +487,7 @@ fn execution_gate_round_trip() {
             extra_data: alloy_primitives::Bytes::from(vec![0u8; 32]),
             slot_number: None,
         },
+        mode: BscExecutionMode::Mining,
         validator_cache_sink: None,
         turn_length_sink: None,
         state_root_precomputed_sink: None,


### PR DESCRIPTION
Fixes #464. Also fixes #451 — same defect, different RPC.

## Root cause

`context_for_next_block` hard-coded `is_miner: true` (`src/node/evm/config.rs`). Upstream reth
has **one** "next block" hook and shares it between the miner, `eth_simulateV1`, and the local
pending block. So answering `eth_getBlockByNumber("pending")` ran Parlia block *production* —
snapshot lookup, reward distribution, slashing, system-transaction signing.

On a node with no validator key that fails with `GlobalSignerNotInitializedForMiningMode`, and
reth's `build_pool_pending_block` maps a build error to `Ok(None)`, which serializes as
`"result": null`. On a node that *does* have a key it was worse but silent: the pending block
came back containing a self-signed Parlia reward transaction nobody sent, inflating `gasUsed`.

`is_miner` was a two-state bool fusing two independent questions — whether a header already
exists, and whether Parlia finalization should run. Those move together for import and mining,
so a bool sufficed; simulation is the third combination (author a block, do **not** finalize
it) that the bool could not express.

## The fix

Replace the bool with `BscExecutionMode { Import, Mining, Simulation }` plus `authors_block()`
and `finalizes()`, which separate the two axes. `BuildPendingEnv` — the RPC-side entry point —
selects `Simulation`, covering both the pending block and `eth_simulateV1`. The miner and bid
simulator construct the attributes literally, so the new field made each an explicit
compile-time decision rather than a silent default.

Simulation also skips the Feynman/genesis contract initialization in `finish()` (it issues
system transactions of its own) and the snapshot lookup in `prepare_new_block` (only
finalization reads it) — the latter also removes an `unwrap` that could panic an RPC call
before consensus has published the snapshot provider.

`Import` and `Mining` map one-to-one onto the old `false`/`true` at every site, so block
validation and production are unchanged by construction.

BSC geth fixed the same defect the same way in bnb-chain/bsc#3433.

## Reproducing — please read before re-testing

**The steps in #464 do not reproduce the bug on an idle node.** `distribute_incoming` returns
early when the SYSTEM_ADDRESS reward is 0, so an **empty** pending block issues no system
transaction and never needs a signer — it builds fine even on the broken binary. Reproduction
requires **fee-paying transactions sitting in that node's own pool**, which is the mainnet
steady state and why the reporter hits it constantly.

Anyone re-testing without a transaction burst will wrongly conclude "not reproducible".

## Verification

Local devnet (`node-deploy-bsc`): 4 reth-bsc + 6 geth validators, plus a keyless non-validator
reth node. A/B on one chain, same datadir, **only the binary swapped**.

| | baseline `043a313a` | this branch |
|---|---|---|
| `pending` returns null (keyless node) | **25 / 25** | **0 / 25** |
| transactions in the pending block | 0 | 6 |
| `Global signer not initialized` in log | repeated | **0** |
| `pending` on a keyed validator | — | 25/25 block, `gasUsed 0x14820` = exactly 4 × 21000 |

The `gasUsed` figure is the check for the validator-side symptom: exactly the user
transactions, so no phantom self-signed reward transaction is injected.

**No regression.** With all 4 reth validators running this branch, 143 consecutive blocks
diffed against geth on `hash`, `stateRoot`, `receiptsRoot`, `transactionsRoot`, `gasUsed`,
`miner` and `difficulty`: **0 mismatches**, with the reth validators sealing **57 / 143**
(~40%, matching their 4-of-10 share).

`cargo test --lib node::evm::config` 3/3 green; `clippy -D warnings` clean.

## Test coverage

`next_block_ctx_carries_the_mode_from_the_attributes` asserts the mode **survives**
`context_for_next_block` instead of being re-decided there — which is exactly what regressed —
and that mining still finalizes, so the guard cannot be satisfied by making everything a
simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
