### PR TITLE
fix: resolve wrong validators by mismatch evm block ctx

### DIFF
--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -207,7 +207,8 @@ where
 {
     type Block = crate::node::primitives::BscBlock;
 
-    // note that assemble_block is unused, BscBlockBuiler use assemble_block_bsc instead.
+    // Unused in-tree: `BscEvmConfig::create_block_builder` returns `BscBlockBuilder`, whose
+    // `finish` calls `assemble_block_body_only`. Kept only to satisfy the `BlockAssembler` trait.
     fn assemble_block(
         &self,
         input: BlockAssemblerInput<'_, '_, F>,
@@ -324,6 +325,7 @@ where
                 &mut header,
                 &snapshot_provider,
                 block_timestamp_ms,
+                None, // no epoch validators here; this fn is dead (see the note on it)
             ).map_err(|e| BlockExecutionError::msg(format!("Failed to finalize header: {}", e)))?;
 
             let header_hash = keccak256(alloy_rlp::encode(&header));

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -207,8 +207,7 @@ where
 {
     type Block = crate::node::primitives::BscBlock;
 
-    // Unused in-tree: `BscEvmConfig::create_block_builder` returns `BscBlockBuilder`, whose
-    // `finish` calls `assemble_block_body_only`. Kept only to satisfy the `BlockAssembler` trait.
+    // note that assemble_block is unused, BscBlockBuiler use assemble_block_bsc instead.
     fn assemble_block(
         &self,
         input: BlockAssemblerInput<'_, '_, F>,
@@ -325,7 +324,7 @@ where
                 &mut header,
                 &snapshot_provider,
                 block_timestamp_ms,
-                None, // no epoch validators here; this fn is dead (see the note on it)
+                None,
             ).map_err(|e| BlockExecutionError::msg(format!("Failed to finalize header: {}", e)))?;
 
             let header_hash = keccak256(alloy_rlp::encode(&header));

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -305,8 +305,6 @@ const EIP1559_INITIAL_BASE_FEE: u64 = 0;
 
 /// The [`EvmEnv`] that `header` itself presents to the EVM — go-bsc's
 /// `core.NewEVMBlockContext(header, ..)`.
-///
-/// Consensus reads pass the *parent* header here; see [`super::pre_execution::CallBlockEnv`].
 pub(crate) fn evm_env_for_header<Spec>(spec: &Spec, header: &Header) -> EvmEnv<BscHardfork>
 where
     Spec: BscHardforks + EthChainSpec + Clone,

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -303,6 +303,56 @@ where
 
 const EIP1559_INITIAL_BASE_FEE: u64 = 0;
 
+/// The [`EvmEnv`] that `header` itself presents to the EVM — go-bsc's
+/// `core.NewEVMBlockContext(header, ..)`.
+///
+/// Consensus reads pass the *parent* header here; see [`super::pre_execution::CallBlockEnv`].
+pub(crate) fn evm_env_for_header<Spec>(spec: &Spec, header: &Header) -> EvmEnv<BscHardfork>
+where
+    Spec: BscHardforks + EthChainSpec + Clone,
+{
+    // `BscHardforks::` disambiguates from the same-named `EthereumHardforks` supertrait methods.
+    let blob_params =
+        BscHardforks::is_cancun_active_at_timestamp(spec, header.number, header.timestamp)
+            .then(|| spec.blob_params_at_timestamp(header.timestamp))
+            .flatten();
+    let hardfork =
+        revm_spec_by_timestamp_and_block_number(spec.clone(), header.timestamp(), header.number());
+    let spec_id = SpecId::from(hardfork);
+
+    let mut cfg_env = CfgEnv::new_with_spec(hardfork).with_chain_id(spec.chain().id());
+
+    if let Some(blob_params) = &blob_params {
+        cfg_env.set_max_blobs_per_tx(blob_params.max_blobs_per_tx);
+    }
+    if BscHardforks::is_osaka_active_at_timestamp(spec, header.number, header.timestamp) {
+        cfg_env.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
+    }
+
+    // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current blobparams
+    let blob_excess_gas_and_price =
+        header.excess_blob_gas.zip(blob_params).map(|(excess_blob_gas, params)| {
+            let blob_gasprice = params.calc_blob_fee(excess_blob_gas);
+            BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }
+        });
+
+    let block_env = BlockEnv {
+        number: U256::from(header.number()),
+        beneficiary: header.beneficiary(),
+        timestamp: U256::from(header.timestamp()),
+        difficulty: if spec_id >= SpecId::MERGE { U256::ZERO } else { header.difficulty() },
+        // BSC does not replace the DIFFICULTY output with prevrandao so here we are setting
+        // this to the difficulty values to ensure correct opcode outputs
+        prevrandao: if spec_id >= SpecId::MERGE { Some(header.difficulty().into()) } else { None },
+        gas_limit: header.gas_limit(),
+        basefee: header.base_fee_per_gas().unwrap_or_default(),
+        blob_excess_gas_and_price,
+        slot_num: 0,
+    };
+
+    EvmEnv { cfg_env, block_env }
+}
+
 impl ConfigureEvm for BscEvmConfig
 where
     Self: Send + Sync + Unpin + Clone + 'static,
@@ -322,60 +372,7 @@ where
     }
 
     fn evm_env(&self, header: &Header) -> Result<EvmEnv<BscHardfork>, Self::Error> {
-        let mut blob_params = None;
-        if BscHardforks::is_cancun_active_at_timestamp(
-            self.chain_spec(),
-            header.number,
-            header.timestamp,
-        ) {
-            blob_params = self.chain_spec().blob_params_at_timestamp(header.timestamp);
-        }
-        let spec = revm_spec_by_timestamp_and_block_number(
-            self.chain_spec().clone(),
-            header.timestamp(),
-            header.number(),
-        );
-        let spec_id = SpecId::from(spec);
-
-        // configure evm env based on parent block
-        let mut cfg_env = CfgEnv::new_with_spec(spec).with_chain_id(self.chain_spec().chain().id());
-
-        if let Some(blob_params) = &blob_params {
-            cfg_env.set_max_blobs_per_tx(blob_params.max_blobs_per_tx);
-        }
-        if BscHardforks::is_osaka_active_at_timestamp(self.chain_spec(), header.number, header.timestamp) {
-            cfg_env.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
-        }
-
-        // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current
-        // blobparams
-        let blob_excess_gas_and_price =
-            header.excess_blob_gas.zip(blob_params).map(|(excess_blob_gas, params)| {
-                let blob_gasprice = params.calc_blob_fee(excess_blob_gas);
-                BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }
-            });
-
-        let eth_spec = spec_id;
-
-        let block_env = BlockEnv {
-            number: U256::from(header.number()),
-            beneficiary: header.beneficiary(),
-            timestamp: U256::from(header.timestamp()),
-            difficulty: if eth_spec >= SpecId::MERGE { U256::ZERO } else { header.difficulty() },
-            // BSC does not replace the DIFFICULTY output with prevrandao so here we are setting
-            // this to the difficulty values to ensure correct opcode outputs
-            prevrandao: if eth_spec >= SpecId::MERGE {
-                Some(header.difficulty().into())
-            } else {
-                None
-            },
-            gas_limit: header.gas_limit(),
-            basefee: header.base_fee_per_gas().unwrap_or_default(),
-            blob_excess_gas_and_price,
-            slot_num: 0,
-        };
-
-        Ok(EvmEnv { cfg_env, block_env })
+        Ok(evm_env_for_header(self.chain_spec(), header))
     }
 
     fn next_evm_env(

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -146,7 +146,11 @@ where
         if is_next_epoch {  // cache validators
             // cache it on pre block.
             // for verify validators in post-check of fullnode mode and prepare new header in miner mode.
-            self.get_current_validators_with_cache(header.number, header.hash_slow())?;
+            self.get_current_validators_with_cache(
+                header.number,
+                header.hash_slow(),
+                CallBlockEnv::Current, // unchanged: this block's own env
+            )?;
         }
 
         { // cache turnlength

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -3,7 +3,7 @@ use super::error::{BscBlockExecutionError, BscBlockValidationError};
 use super::util::set_nonce;
 use super::config::revm_spec_by_timestamp_and_block_number;
 use crate::consensus::parlia::{FF_REWARD_DISTRIBUTION_INTERVAL};
-use crate::node::evm::pre_execution::TURN_LENGTH_CACHE;
+use crate::node::evm::pre_execution::{CallBlockEnv, TURN_LENGTH_CACHE};
 use crate::node::evm::util::get_header_by_hash_from_cache;
 use crate::node::miner::signer::{sign_system_transaction, is_signer_initialized};
 use crate::consensus::parlia::{DIFF_INTURN, VoteAddress, VoteAttestation, snapshot::DEFAULT_TURN_LENGTH, constants::COLLECT_ADDITIONAL_VOTES_REWARD_RATIO, util::is_breathe_block};
@@ -722,7 +722,8 @@ where
                 "Check validator cache update: block_number={}, epoch_length={}, is_next_epoch={}",
                 header_number, epoch_length, is_next_epoch
             );
-            let (validators, vote_addresses) = self.get_current_validators(header_number)?;
+            let (validators, vote_addresses) =
+                self.get_current_validators(header_number, CallBlockEnv::Current)?;
             self.shared_ctx.inner.borrow_mut().current_validators = Some((validators, vote_addresses));
         }
 

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -33,21 +33,11 @@ use crate::consensus::parlia::constants::K_ANCESTOR_GENERATION_DEPTH;
 
 const BLST_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
-/// A validator set paired with each member's BLS vote address, as `getMiningValidators()` returns
-/// them post-Luban (empty vote addresses before it).
 pub type EpochValidators = (Vec<Address>, Vec<VoteAddress>);
 
 type ValidatorCache = LruMap<BlockHash, EpochValidators, ByLength>;
 type TurnLengthCache = LruMap<BlockHash, u8, ByLength>;
 
-/// `getMiningValidators()` memoized by the block it was evaluated at.
-///
-/// INVARIANT: the entry under `hash(B)` is the result evaluated in block `B`'s env on `B`'s
-/// post-state. Block validation reads this map, so an entry derived any other way forks the node
-/// (bnb-chain/reth-bsc#465).
-///
-/// Writers use two env constructors (`evm_env_for_header`, `next_evm_env`) that agree only on
-/// `block.number` — so only a value depending on nothing else may be cached here.
 pub static VALIDATOR_CACHE: LazyLock<Mutex<ValidatorCache>> = LazyLock::new(|| {
     Mutex::new(LruMap::new(ByLength::new(1024)))
 });
@@ -219,8 +209,6 @@ where
 
         let epoch_length = snap.epoch_num;
         if header.number.is_multiple_of(epoch_length) {
-            // go-bsc `verifyValidators` reads this at `(header.ParentHash, header.Number-1)` —
-            // the parent's env, see [`CallBlockEnv`].
             let (validator_set, vote_addresses) = self.get_current_validators_with_cache(
                 header.number - 1,
                 header.parent_hash,
@@ -302,11 +290,6 @@ where
         Ok(())
     }
 
-    /// [`VALIDATOR_CACHE`] lookup for block `block_number`, computing it on a miss.
-    ///
-    /// `block_hash` must be the hash of `block_number`. Either `at` value lands on that block's own
-    /// env — `Current` when it is the block being executed, `Parent` when it is that block's parent
-    /// — so the stored entry honors the cache's invariant either way.
     pub(crate) fn get_current_validators_with_cache(
         &mut self, 
         block_number: BlockNumber,

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -1,11 +1,13 @@
+use super::config::evm_env_for_header;
 use super::executor::BscBlockExecutor;
+use super::factory::BscEvmFactory;
 use crate::evm::transaction::BscTxEnv;
 
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
-use reth_evm::{eth::receipt_builder::ReceiptBuilder, execute::BlockExecutionError, Evm, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
+use reth_evm::{eth::receipt_builder::ReceiptBuilder, execute::BlockExecutionError, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
 use reth_ethereum_primitives::TransactionSigned;
 use revm::{
-    context::{BlockEnv, TxEnv},
+    context::{result::ExecutionResult, BlockEnv, TxEnv},
     context_interface::block::Block,
     primitives::{Address, Bytes, TxKind, U256},
 };
@@ -39,6 +41,59 @@ pub static VALIDATOR_CACHE: LazyLock<Mutex<ValidatorCache>> = LazyLock::new(|| {
 pub static TURN_LENGTH_CACHE: LazyLock<Mutex<TurnLengthCache>> = LazyLock::new(|| {
     Mutex::new(LruMap::new(ByLength::new(1024)))
 });
+
+/// Which block's [`BlockEnv`] a Parlia system-contract read is evaluated in.
+///
+/// State is the parent's on both paths, so only reads whose *value* depends on the block env need
+/// [`Self::Parent`]. Today that is only `getMiningValidators()`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CallBlockEnv {
+    /// The env of the block being executed.
+    Current,
+    /// The env of its parent. Required for env-dependent reads that validate this block.
+    Parent,
+}
+
+/// The transaction shape used for read-only system-contract calls.
+///
+/// `gas_limit` is the gas limit of the block whose env the call runs in, so GASLIMIT reports it.
+/// `is_system_transaction` bypasses the EIP-7825 tx gas cap (16M), which BSC block gas limits
+/// exceed; it also zeroes BASEFEE and disables nonce checks. BSC's system-contract view functions
+/// read none of those, but a future contract reading BASEFEE would need this revisited.
+fn view_call_tx_env(to: Address, data: Bytes, gas_limit: u64, chain_id: u64) -> BscTxEnv {
+    BscTxEnv {
+        base: TxEnv {
+            caller: Address::default(),
+            kind: TxKind::Call(to),
+            nonce: 0,
+            gas_limit,
+            value: U256::ZERO,
+            data,
+            gas_price: 0,
+            chain_id: Some(chain_id),
+            gas_priority_fee: None,
+            access_list: Default::default(),
+            blob_hashes: Vec::new(),
+            max_fee_per_blob_gas: 0,
+            tx_type: 0,
+            authorization_list: Default::default(),
+        },
+        is_system_transaction: true,
+    }
+}
+
+/// Extracts the return data of a read-only system-contract call.
+fn view_call_output<H>(
+    to: Address,
+    data: &Bytes,
+    result: ExecutionResult<H>,
+) -> Result<Bytes, BlockExecutionError> {
+    if !result.is_success() {
+        tracing::error!("Failed to eth call, to: {:?}, data: {:?}", to, data);
+        return Err(BlockExecutionError::msg("ETH call failed"));
+    }
+    result.into_output().ok_or_else(|| BlockExecutionError::msg("ETH call output is None"))
+}
 
 impl<'a, EVM, Spec, R: ReceiptBuilder> BscBlockExecutor<'a, EVM, Spec, R>
 where
@@ -88,8 +143,21 @@ where
 
         let epoch_length = snap.epoch_num;
         if header.number.is_multiple_of(epoch_length) {
-            // TODO: need fix it later, it may got error when restart the node?
-            let (validator_set, vote_addresses) = self.get_current_validators_with_cache(header.number-1, header.parent_hash)?;
+            // Evaluate in the PARENT block's env, matching go-bsc `verifyValidators` ->
+            // `getCurrentValidators(header.ParentHash, N-1)`. Not cosmetic: `getMiningValidators()`
+            // draws its 21-of-45 result with seed `block.number / 200`, so an epoch block that is
+            // itself a multiple of 200 draws from a different window than its parent and returns a
+            // different set (bnb-chain/reth-bsc#465). That is every epoch block at epoch lengths
+            // 200 and 1000 (mainnet is 1000 post-Maxwell), and every second one at Lorentz's 500.
+            let (validator_set, vote_addresses) =
+                self.get_current_validators(header.number - 1, CallBlockEnv::Parent)?;
+            // Write-only, and must NOT become a read-through: `miner::util::resolve_epoch_validators`
+            // writes this same key from a snapshot, and block validation must not depend on a global
+            // with writers outside consensus. Overwriting repairs a non-conforming entry it left.
+            VALIDATOR_CACHE
+                .lock()
+                .unwrap()
+                .insert(header.parent_hash, (validator_set.clone(), vote_addresses.clone()));
             tracing::debug!("validator_set: {:?}, vote_addresses: {:?}", validator_set, vote_addresses);
             
             let vote_addrs_map = if vote_addresses.is_empty() {
@@ -105,7 +173,9 @@ where
             self.inner_ctx.current_validators = Some((validator_set, vote_addrs_map));
 
             if self.spec.is_bohr_active_at_timestamp(header.number, header.timestamp) {
-                // Keep parity with go-bsc: turn length is read from parent state.
+                // Parity with go-bsc `bohrFork.go` getTurnLength: parent state, and the Bohr gate
+                // uses the parent's number/timestamp. Evaluated in this block's env, which is sound
+                // because `getTurnLength()` is a plain storage read.
                 let expected_turn_length =
                     self.get_turn_length(parent_header.number, parent_header.timestamp)?;
                 self.inner_ctx.expected_turn_length = Some(expected_turn_length);
@@ -129,6 +199,9 @@ where
             !self.spec.is_feynman_transition_at_timestamp(header.number, header.timestamp, parent_header.timestamp) &&
             is_breathe_block(parent_header.timestamp, header.timestamp)
         {
+            // go-bsc reads both at the parent (`feynmanfork.go`), but both are plain storage reads;
+            // their results feed `updateValidatorSetV2` calldata, so moving them is state-root
+            // affecting and out of scope for #465.
             let (to, data) = self.system_contracts.get_max_elected_validators();
             let bz = self.eth_call(to, data)?;
             let max_elected_validators = self.system_contracts.unpack_data_into_max_elected_validators(bz.as_ref());
@@ -180,7 +253,7 @@ where
             }
         }
 
-        let result = self.get_current_validators(block_number)?;
+        let result = self.get_current_validators(block_number, CallBlockEnv::Current)?;
 
         {
             let mut cache = VALIDATOR_CACHE.lock().unwrap();
@@ -193,71 +266,78 @@ where
     }
 
 
+    /// Runs a read-only system-contract call in the env of the block being executed.
     pub(crate) fn eth_call(
         &mut self,
         to: Address,
         data: Bytes
     ) -> Result<Bytes, BlockExecutionError> {
-        // Use block gas limit (~36M on BSC) to match GASLIMIT opcode semantics.
-        // Mark as system transaction to bypass EIP-7825 gas limit cap (16M),
-        // since block gas limit exceeds the cap and these are internal queries.
-        //
-        // Trade-off accepted: is_system_transaction causes transact_raw to:
-        // - Set basefee to 0 (BASEFEE opcode returns 0 instead of actual basefee)
-        // - Disable nonce checks
-        // - Replace block.gas_limit with tx.gas_limit
-        //
-        // For BSC system contract reads (get_current_validators, get_validator_election_info, etc.),
-        // these side effects are acceptable because the contracts don't use BASEFEE in view functions.
-        // If future contracts depend on BASEFEE, this approach would need revisiting.
-        let tx_env = BscTxEnv {
-            base: TxEnv {
-                caller: Address::default(),
-                kind: TxKind::Call(to),
-                nonce: 0,
-                gas_limit: self.evm.block().gas_limit(),
-                value: U256::ZERO,
-                data: data.clone(),
-                gas_price: 0,
-                chain_id: Some(self.spec.chain().id()),
-                gas_priority_fee: None,
-                access_list: Default::default(),
-                blob_hashes: Vec::new(),
-                max_fee_per_blob_gas: 0,
-                tx_type: 0,
-                authorization_list: Default::default(),
-            },
-            is_system_transaction: true,
-        };
-
+        let tx_env =
+            view_call_tx_env(to, data.clone(), self.evm.block().gas_limit(), self.spec.chain().id());
         let result_and_state = self.evm.transact(tx_env.into_tx_env()).map_err(BlockExecutionError::other)?;
-        if !result_and_state.result.is_success() {
-            tracing::error!("Failed to eth call, to: {:?}, data: {:?}", to, data);
-            return Err(BlockExecutionError::msg("ETH call failed"));
-        }
-        let output = result_and_state.result.output().ok_or(BlockExecutionError::msg("ETH call output is None"))?;
-        Ok(output.clone())
+        view_call_output(to, &data, result_and_state.result)
     }
 
-    pub(crate) fn get_current_validators(
-        &mut self, 
-        block_number: BlockNumber
-    ) -> Result<(Vec<Address>, Vec<VoteAddress>), BlockExecutionError> {
+    /// Runs a read-only system-contract call in the **parent** block's env.
+    ///
+    /// go-bsc's `ethAPI.Call(args, BlockNumberOrHashWithHash(header.ParentHash, false))`. The state
+    /// is already the parent's, so only the [`BlockEnv`] has to be substituted — and since [`Evm`]
+    /// exposes no mutable block accessor, that means a throwaway EVM over the same DB. Nothing is
+    /// committed.
+    ///
+    /// PRECONDITION: only valid before any of this block's state changes are applied, i.e. from
+    /// `check_new_block` / `prepare_new_block`.
+    fn eth_call_at_parent(
+        &mut self,
+        to: Address,
+        data: Bytes,
+    ) -> Result<Bytes, BlockExecutionError> {
+        let parent = self.inner_ctx.parent_header.clone().ok_or_else(|| {
+            BlockExecutionError::msg("Missing parent header for parent-env eth call")
+        })?;
+        debug_assert_eq!(
+            parent.number + 1,
+            self.evm.block().number().to::<u64>(),
+            "parent-env call must run while executing the parent's direct child"
+        );
 
-        let result = if self.spec.is_luban_active_at_block(block_number) {
-            let (to, data) = self.system_contracts.get_current_validators();
-            let output = self.eth_call(to, data)?;
+        // Both must be built before `db_mut()` borrows `self.evm`.
+        let env = evm_env_for_header(&self.spec, &parent);
+        let tx_env = view_call_tx_env(to, data.clone(), parent.gas_limit, self.spec.chain().id());
+
+        let mut evm = BscEvmFactory::default().create_evm(self.evm.db_mut(), env);
+        // UFCS on purpose: `BscEvm` also implements `revm::ExecuteEvm::transact`, which skips the
+        // system-transaction env overrides that `Evm::transact` applies.
+        let result_and_state = Evm::transact(&mut evm, tx_env).map_err(BlockExecutionError::other)?;
+        view_call_output(to, &data, result_and_state.result)
+    }
+
+    /// Reads the active validator set from the ValidatorSet system contract.
+    ///
+    /// `block_number` selects the ABI (pre/post Luban, Euler) and must be the number of the block
+    /// whose state is being read. `at` selects the block env — see [`CallBlockEnv`].
+    pub(crate) fn get_current_validators(
+        &mut self,
+        block_number: BlockNumber,
+        at: CallBlockEnv,
+    ) -> Result<(Vec<Address>, Vec<VoteAddress>), BlockExecutionError> {
+        let is_luban = self.spec.is_luban_active_at_block(block_number);
+        let (to, data) = if is_luban {
+            self.system_contracts.get_current_validators()
+        } else {
+            self.system_contracts.get_current_validators_before_luban(block_number)
+        };
+        let output = match at {
+            CallBlockEnv::Current => self.eth_call(to, data)?,
+            CallBlockEnv::Parent => self.eth_call_at_parent(to, data)?,
+        };
+        Ok(if is_luban {
             self.system_contracts.unpack_data_into_validator_set(&output)
         } else {
-            let (to, data) = self.system_contracts.get_current_validators_before_luban(block_number);
-            let output = self.eth_call(to, data)?;
-            let validator_set = self.system_contracts.unpack_data_into_validator_set_before_luban(&output);
-            (validator_set, Vec::new())
-        };
-
-        Ok(result)
+            (self.system_contracts.unpack_data_into_validator_set_before_luban(&output), Vec::new())
+        })
     }
-    
+
     fn verify_cascading_fields(
         &self,
         header: &Header,

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -46,9 +46,7 @@ pub static TURN_LENGTH_CACHE: LazyLock<Mutex<TurnLengthCache>> = LazyLock::new(|
     Mutex::new(LruMap::new(ByLength::new(1024)))
 });
 
-/// Runs a read-only system-contract call in `header`'s env, over a DB already holding `header`'s
-/// post-state — go-bsc's `ethAPI.Call(args, BlockNumberOrHashWithHash(hash, false))`. Commits
-/// nothing.
+/// Runs a read-only system-contract call in `header`'s env over `header`'s post-state.
 fn view_call_at_header<DB, Spec>(
     db: DB,
     spec: &Spec,
@@ -68,10 +66,7 @@ where
     view_call_output(to, &data, result)
 }
 
-/// `getMiningValidators()` on `parent`'s post-state, in `parent`'s [`BlockEnv`].
-///
-/// The twin of [`BscBlockExecutor::get_current_validators`] with [`CallBlockEnv::Parent`], for
-/// callers that hold a state handle rather than an executor.
+/// `getMiningValidators()` on `parent`'s post-state in `parent`'s env.
 pub(crate) fn validators_at_parent<S, Spec>(
     state: S,
     spec: Spec,
@@ -97,12 +92,9 @@ where
     })
 }
 
-/// Which block's [`BlockEnv`] a Parlia system-contract read is evaluated in.
+/// Which block env a Parlia system-contract read uses.
 ///
-/// State is the parent's on both paths, so only reads whose *value* depends on the block env need
-/// [`Self::Parent`]. Today that is only `getMiningValidators()`: it seeds its 21-of-45 shuffle on
-/// `block.number / 200`, so blocks N and N-1 draw from different windows whenever N is a multiple
-/// of 200, and go-bsc evaluates it at the parent (bnb-chain/reth-bsc#465).
+/// Only `getMiningValidators()` needs `Parent`: the state is already the parent's on both paths.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum CallBlockEnv {
     /// The env of the block being executed.
@@ -112,11 +104,6 @@ pub(crate) enum CallBlockEnv {
 }
 
 /// The transaction shape used for read-only system-contract calls.
-///
-/// `gas_limit` is the gas limit of the block whose env the call runs in, so GASLIMIT reports it.
-/// `is_system_transaction` bypasses the EIP-7825 tx gas cap (16M), which BSC block gas limits
-/// exceed; it also zeroes BASEFEE and disables nonce checks. BSC's system-contract view functions
-/// read none of those, but a future contract reading BASEFEE would need this revisited.
 fn view_call_tx_env(to: Address, data: Bytes, gas_limit: u64, chain_id: u64) -> BscTxEnv {
     BscTxEnv {
         base: TxEnv {
@@ -330,15 +317,9 @@ where
         view_call_output(to, &data, result_and_state.result)
     }
 
-    /// Runs a read-only system-contract call in the **parent** block's env.
+    /// Runs the same read-only system call against the current DB, but under `parent`'s env.
     ///
-    /// go-bsc's `ethAPI.Call(args, BlockNumberOrHashWithHash(header.ParentHash, false))`. The state
-    /// is already the parent's, so only the [`BlockEnv`] has to be substituted — and since [`Evm`]
-    /// exposes no mutable block accessor, that means a throwaway EVM over the same DB. Nothing is
-    /// committed.
-    ///
-    /// PRECONDITION: only valid before any of this block's state changes are applied, i.e. from
-    /// `check_new_block` / `prepare_new_block`.
+    /// PRECONDITION: only valid before this block mutates state.
     fn eth_call_at_parent(
         &mut self,
         to: Address,

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -60,8 +60,7 @@ where
 {
     let tx_env = view_call_tx_env(to, data.clone(), header.gas_limit, spec.chain().id());
     let mut evm = BscEvmFactory::default().create_evm(db, evm_env_for_header(spec, header));
-    // UFCS on purpose: `BscEvm` also implements `revm::ExecuteEvm::transact`, which skips the
-    // system-transaction env overrides that `Evm::transact` applies.
+    // Use `Evm::transact` so system-transaction overrides still apply.
     let result = Evm::transact(&mut evm, tx_env).map_err(BlockExecutionError::other)?.result;
     view_call_output(to, &data, result)
 }
@@ -139,8 +138,7 @@ fn view_call_output<H>(
     let output = result
         .into_output()
         .ok_or_else(|| BlockExecutionError::msg("ETH call output is None"))?;
-    // A call to a codeless address succeeds with empty returndata, which every `unpack_*` below
-    // would then `unwrap()`-panic on. Report it as a failed read instead.
+    // Treat empty returndata as an invalid read instead of letting ABI unpack panic.
     if output.is_empty() {
         tracing::error!("Empty eth call output, to: {:?}, data: {:?}", to, data);
         return Err(BlockExecutionError::msg("ETH call returned no data"));
@@ -164,8 +162,7 @@ where
     BscTxEnv: IntoTxEnv<<EVM as alloy_evm::Evm>::Tx>,
     R::Transaction: Into<TransactionSigned>,
 {
-    /// check the new block, pre check and prepare some intermediate data for finish function.
-    /// depends on parlia, header and snapshot.
+    /// Validate block fields that depend on Parlia, the header, and the parent snapshot.
     pub(crate) fn check_new_block(
         &mut self, 
         block: &BlockEnv
@@ -216,14 +213,13 @@ where
             self.inner_ctx.current_validators = Some((validator_set, vote_addrs_map));
 
             if self.spec.is_bohr_active_at_timestamp(header.number, header.timestamp) {
-                // Keep parity with go-bsc: turn length is read from parent state.
+                // Turn length is read from the parent state.
                 let expected_turn_length =
                     self.get_turn_length(parent_header.number, parent_header.timestamp)?;
                 self.inner_ctx.expected_turn_length = Some(expected_turn_length);
             }
 
-            // Also fetch on-chain NodeIDs for validators (EVN identification) and update cache.
-            // Only available after Maxwell hardfork when StakeHub contract's getNodeIDs is deployed
+            // Also fetch validator NodeIDs after Maxwell.
             if self.spec.is_maxwell_active_at_timestamp(header.number, header.timestamp) {
                 let (to2, data2) = self.system_contracts.get_node_ids(self.inner_ctx.current_validators.as_ref().unwrap().0.clone());
                 if let Ok(output2) = self.eth_call(to2, data2) {
@@ -337,10 +333,9 @@ where
         view_call_at_header(self.evm.db_mut(), &self.spec, &parent, to, data)
     }
 
-    /// Reads the active validator set from the ValidatorSet system contract.
+    /// Reads the active validator set.
     ///
-    /// `block_number` selects the ABI (pre/post Luban, Euler) and must be the number of the block
-    /// whose state is being read. `at` selects the block env — see [`CallBlockEnv`].
+    /// `block_number` selects the ABI; `at` selects the block env.
     pub(crate) fn get_current_validators(
         &mut self,
         block_number: BlockNumber,

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -4,7 +4,7 @@ use super::factory::BscEvmFactory;
 use crate::evm::transaction::BscTxEnv;
 
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
-use reth_evm::{eth::receipt_builder::ReceiptBuilder, execute::BlockExecutionError, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
+use reth_evm::{eth::receipt_builder::ReceiptBuilder, execute::BlockExecutionError, Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
 use reth_ethereum_primitives::TransactionSigned;
 use revm::{
     context::{result::ExecutionResult, BlockEnv, TxEnv},
@@ -18,10 +18,12 @@ use crate::consensus::parlia::util::{is_breathe_block, debug_header};
 use crate::consensus::parlia::vote::MAX_ATTESTATION_EXTRA_LENGTH;
 use crate::node::evm::error::{BscBlockExecutionError, BscBlockValidationError};
 use crate::node::evm::util::HEADER_CACHE_READER;
+use crate::system_contracts::SystemContract;
+use reth_revm::{database::{EvmStateProvider, StateProviderDatabase}, db::State};
 use crate::system_contracts::feynman_fork::ValidatorElectionInfo;
 use std::{collections::HashMap, sync::{LazyLock, Mutex}};
 use schnellru::{ByLength, LruMap};
-use reth_primitives_traits::GotExpected;
+use reth_primitives_traits::{GotExpected, SealedHeader};
 use blst::{
     min_pk::{PublicKey, Signature},
     BLST_ERROR,
@@ -31,9 +33,21 @@ use crate::consensus::parlia::constants::K_ANCESTOR_GENERATION_DEPTH;
 
 const BLST_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
-type ValidatorCache = LruMap<BlockHash, (Vec<Address>, Vec<VoteAddress>), ByLength>;
+/// A validator set paired with each member's BLS vote address, as `getMiningValidators()` returns
+/// them post-Luban (empty vote addresses before it).
+pub type EpochValidators = (Vec<Address>, Vec<VoteAddress>);
+
+type ValidatorCache = LruMap<BlockHash, EpochValidators, ByLength>;
 type TurnLengthCache = LruMap<BlockHash, u8, ByLength>;
 
+/// `getMiningValidators()` memoized by the block it was evaluated at.
+///
+/// INVARIANT: the entry under `hash(B)` is the result evaluated in block `B`'s env on `B`'s
+/// post-state. Block validation reads this map, so an entry derived any other way forks the node
+/// (bnb-chain/reth-bsc#465).
+///
+/// Writers use two env constructors (`evm_env_for_header`, `next_evm_env`) that agree only on
+/// `block.number` — so only a value depending on nothing else may be cached here.
 pub static VALIDATOR_CACHE: LazyLock<Mutex<ValidatorCache>> = LazyLock::new(|| {
     Mutex::new(LruMap::new(ByLength::new(1024)))
 });
@@ -42,10 +56,63 @@ pub static TURN_LENGTH_CACHE: LazyLock<Mutex<TurnLengthCache>> = LazyLock::new(|
     Mutex::new(LruMap::new(ByLength::new(1024)))
 });
 
+/// Runs a read-only system-contract call in `header`'s env, over a DB already holding `header`'s
+/// post-state — go-bsc's `ethAPI.Call(args, BlockNumberOrHashWithHash(hash, false))`. Commits
+/// nothing.
+fn view_call_at_header<DB, Spec>(
+    db: DB,
+    spec: &Spec,
+    header: &Header,
+    to: Address,
+    data: Bytes,
+) -> Result<Bytes, BlockExecutionError>
+where
+    DB: Database,
+    Spec: EthChainSpec + crate::hardforks::BscHardforks + Clone,
+{
+    let tx_env = view_call_tx_env(to, data.clone(), header.gas_limit, spec.chain().id());
+    let mut evm = BscEvmFactory::default().create_evm(db, evm_env_for_header(spec, header));
+    // UFCS on purpose: `BscEvm` also implements `revm::ExecuteEvm::transact`, which skips the
+    // system-transaction env overrides that `Evm::transact` applies.
+    let result = Evm::transact(&mut evm, tx_env).map_err(BlockExecutionError::other)?.result;
+    view_call_output(to, &data, result)
+}
+
+/// `getMiningValidators()` on `parent`'s post-state, in `parent`'s [`BlockEnv`].
+///
+/// The twin of [`BscBlockExecutor::get_current_validators`] with [`CallBlockEnv::Parent`], for
+/// callers that hold a state handle rather than an executor.
+pub(crate) fn validators_at_parent<S, Spec>(
+    state: S,
+    spec: Spec,
+    parent: &SealedHeader,
+) -> Result<EpochValidators, BlockExecutionError>
+where
+    S: EvmStateProvider,
+    Spec: EthChainSpec + crate::hardforks::BscHardforks + Clone,
+{
+    let mut db = State::builder().with_database(StateProviderDatabase::new(state)).build();
+    let system_contracts = SystemContract::new(spec.clone());
+    let is_luban = spec.is_luban_active_at_block(parent.number());
+    let (to, data) = if is_luban {
+        system_contracts.get_current_validators()
+    } else {
+        system_contracts.get_current_validators_before_luban(parent.number())
+    };
+    let output = view_call_at_header(&mut db, &spec, parent.header(), to, data)?;
+    Ok(if is_luban {
+        system_contracts.unpack_data_into_validator_set(&output)
+    } else {
+        (system_contracts.unpack_data_into_validator_set_before_luban(&output), Vec::new())
+    })
+}
+
 /// Which block's [`BlockEnv`] a Parlia system-contract read is evaluated in.
 ///
 /// State is the parent's on both paths, so only reads whose *value* depends on the block env need
-/// [`Self::Parent`]. Today that is only `getMiningValidators()`.
+/// [`Self::Parent`]. Today that is only `getMiningValidators()`: it seeds its 21-of-45 shuffle on
+/// `block.number / 200`, so blocks N and N-1 draw from different windows whenever N is a multiple
+/// of 200, and go-bsc evaluates it at the parent (bnb-chain/reth-bsc#465).
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum CallBlockEnv {
     /// The env of the block being executed.
@@ -92,7 +159,16 @@ fn view_call_output<H>(
         tracing::error!("Failed to eth call, to: {:?}, data: {:?}", to, data);
         return Err(BlockExecutionError::msg("ETH call failed"));
     }
-    result.into_output().ok_or_else(|| BlockExecutionError::msg("ETH call output is None"))
+    let output = result
+        .into_output()
+        .ok_or_else(|| BlockExecutionError::msg("ETH call output is None"))?;
+    // A call to a codeless address succeeds with empty returndata, which every `unpack_*` below
+    // would then `unwrap()`-panic on. Report it as a failed read instead.
+    if output.is_empty() {
+        tracing::error!("Empty eth call output, to: {:?}, data: {:?}", to, data);
+        return Err(BlockExecutionError::msg("ETH call returned no data"));
+    }
+    Ok(output)
 }
 
 impl<'a, EVM, Spec, R: ReceiptBuilder> BscBlockExecutor<'a, EVM, Spec, R>
@@ -143,21 +219,7 @@ where
 
         let epoch_length = snap.epoch_num;
         if header.number.is_multiple_of(epoch_length) {
-            // Evaluate in the PARENT block's env, matching go-bsc `verifyValidators` ->
-            // `getCurrentValidators(header.ParentHash, N-1)`. Not cosmetic: `getMiningValidators()`
-            // draws its 21-of-45 result with seed `block.number / 200`, so an epoch block that is
-            // itself a multiple of 200 draws from a different window than its parent and returns a
-            // different set (bnb-chain/reth-bsc#465). That is every epoch block at epoch lengths
-            // 200 and 1000 (mainnet is 1000 post-Maxwell), and every second one at Lorentz's 500.
-            let (validator_set, vote_addresses) =
-                self.get_current_validators(header.number - 1, CallBlockEnv::Parent)?;
-            // Write-only, and must NOT become a read-through: `miner::util::resolve_epoch_validators`
-            // writes this same key from a snapshot, and block validation must not depend on a global
-            // with writers outside consensus. Overwriting repairs a non-conforming entry it left.
-            VALIDATOR_CACHE
-                .lock()
-                .unwrap()
-                .insert(header.parent_hash, (validator_set.clone(), vote_addresses.clone()));
+            let (validator_set, vote_addresses) = self.declared_epoch_validators(&header)?;
             tracing::debug!("validator_set: {:?}, vote_addresses: {:?}", validator_set, vote_addresses);
             
             let vote_addrs_map = if vote_addresses.is_empty() {
@@ -173,9 +235,7 @@ where
             self.inner_ctx.current_validators = Some((validator_set, vote_addrs_map));
 
             if self.spec.is_bohr_active_at_timestamp(header.number, header.timestamp) {
-                // Parity with go-bsc `bohrFork.go` getTurnLength: parent state, and the Bohr gate
-                // uses the parent's number/timestamp. Evaluated in this block's env, which is sound
-                // because `getTurnLength()` is a plain storage read.
+                // Keep parity with go-bsc: turn length is read from parent state.
                 let expected_turn_length =
                     self.get_turn_length(parent_header.number, parent_header.timestamp)?;
                 self.inner_ctx.expected_turn_length = Some(expected_turn_length);
@@ -199,9 +259,6 @@ where
             !self.spec.is_feynman_transition_at_timestamp(header.number, header.timestamp, parent_header.timestamp) &&
             is_breathe_block(parent_header.timestamp, header.timestamp)
         {
-            // go-bsc reads both at the parent (`feynmanfork.go`), but both are plain storage reads;
-            // their results feed `updateValidatorSetV2` calldata, so moving them is state-root
-            // affecting and out of scope for #465.
             let (to, data) = self.system_contracts.get_max_elected_validators();
             let bz = self.eth_call(to, data)?;
             let max_elected_validators = self.system_contracts.unpack_data_into_max_elected_validators(bz.as_ref());
@@ -239,11 +296,33 @@ where
         Ok(())
     }
 
+    /// [`VALIDATOR_CACHE`] lookup for block `block_number`, computing it on a miss.
+    ///
+    /// The validator set epoch block `header` must declare in its extra data.
+    ///
+    /// go-bsc `verifyValidators` reads it at `(header.ParentHash, header.Number-1)` — the parent's
+    /// env, see [`CallBlockEnv`]. Reading through [`VALIDATOR_CACHE`] is safe because every writer
+    /// evaluates in the keyed block's own env.
+    pub(crate) fn declared_epoch_validators(
+        &mut self,
+        header: &Header,
+    ) -> Result<EpochValidators, BlockExecutionError> {
+        self.get_current_validators_with_cache(
+            header.number - 1,
+            header.parent_hash,
+            CallBlockEnv::Parent,
+        )
+    }
+
+    /// `block_hash` must be the hash of `block_number`. Either `at` value lands on that block's own
+    /// env — `Current` when it is the block being executed, `Parent` when it is that block's parent
+    /// — so the stored entry honors the cache's invariant either way.
     pub(crate) fn get_current_validators_with_cache(
         &mut self, 
         block_number: BlockNumber,
-        block_hash: BlockHash
-    ) -> Result<(Vec<Address>, Vec<VoteAddress>), BlockExecutionError> {
+        block_hash: BlockHash,
+        at: CallBlockEnv,
+    ) -> Result<EpochValidators, BlockExecutionError> {
         {
             let mut cache = VALIDATOR_CACHE.lock().unwrap();
             if let Some(cached_result) = cache.get(&block_hash) {
@@ -253,7 +332,7 @@ where
             }
         }
 
-        let result = self.get_current_validators(block_number, CallBlockEnv::Current)?;
+        let result = self.get_current_validators(block_number, at)?;
 
         {
             let mut cache = VALIDATOR_CACHE.lock().unwrap();
@@ -301,15 +380,7 @@ where
             "parent-env call must run while executing the parent's direct child"
         );
 
-        // Both must be built before `db_mut()` borrows `self.evm`.
-        let env = evm_env_for_header(&self.spec, &parent);
-        let tx_env = view_call_tx_env(to, data.clone(), parent.gas_limit, self.spec.chain().id());
-
-        let mut evm = BscEvmFactory::default().create_evm(self.evm.db_mut(), env);
-        // UFCS on purpose: `BscEvm` also implements `revm::ExecuteEvm::transact`, which skips the
-        // system-transaction env overrides that `Evm::transact` applies.
-        let result_and_state = Evm::transact(&mut evm, tx_env).map_err(BlockExecutionError::other)?;
-        view_call_output(to, &data, result_and_state.result)
+        view_call_at_header(self.evm.db_mut(), &self.spec, &parent, to, data)
     }
 
     /// Reads the active validator set from the ValidatorSet system contract.
@@ -320,7 +391,7 @@ where
         &mut self,
         block_number: BlockNumber,
         at: CallBlockEnv,
-    ) -> Result<(Vec<Address>, Vec<VoteAddress>), BlockExecutionError> {
+    ) -> Result<EpochValidators, BlockExecutionError> {
         let is_luban = self.spec.is_luban_active_at_block(block_number);
         let (to, data) = if is_luban {
             self.system_contracts.get_current_validators()

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -219,7 +219,13 @@ where
 
         let epoch_length = snap.epoch_num;
         if header.number.is_multiple_of(epoch_length) {
-            let (validator_set, vote_addresses) = self.declared_epoch_validators(&header)?;
+            // go-bsc `verifyValidators` reads this at `(header.ParentHash, header.Number-1)` —
+            // the parent's env, see [`CallBlockEnv`].
+            let (validator_set, vote_addresses) = self.get_current_validators_with_cache(
+                header.number - 1,
+                header.parent_hash,
+                CallBlockEnv::Parent,
+            )?;
             tracing::debug!("validator_set: {:?}, vote_addresses: {:?}", validator_set, vote_addresses);
             
             let vote_addrs_map = if vote_addresses.is_empty() {
@@ -298,22 +304,6 @@ where
 
     /// [`VALIDATOR_CACHE`] lookup for block `block_number`, computing it on a miss.
     ///
-    /// The validator set epoch block `header` must declare in its extra data.
-    ///
-    /// go-bsc `verifyValidators` reads it at `(header.ParentHash, header.Number-1)` — the parent's
-    /// env, see [`CallBlockEnv`]. Reading through [`VALIDATOR_CACHE`] is safe because every writer
-    /// evaluates in the keyed block's own env.
-    pub(crate) fn declared_epoch_validators(
-        &mut self,
-        header: &Header,
-    ) -> Result<EpochValidators, BlockExecutionError> {
-        self.get_current_validators_with_cache(
-            header.number - 1,
-            header.parent_hash,
-            CallBlockEnv::Parent,
-        )
-    }
-
     /// `block_hash` must be the hash of `block_number`. Either `at` value lands on that block's own
     /// env — `Current` when it is the block being executed, `Parent` when it is that block's parent
     /// — so the stored entry honors the cache's invariant either way.

--- a/src/node/evm/pre_execution_tests.rs
+++ b/src/node/evm/pre_execution_tests.rs
@@ -420,3 +420,186 @@ mod tests {
         }
     }
 }
+
+/// Regression tests for bnb-chain/reth-bsc#465.
+///
+/// NOT covered: that `check_new_block` actually passes [`CallBlockEnv::Parent`]. Driving it would
+/// need a `SnapshotProvider` global plus a real secp256k1 Parlia seal and BLS attestation for
+/// `verify_seal`.
+#[cfg(test)]
+mod parent_block_env {
+    use crate::chainspec::{bsc::bsc_mainnet, BscChainSpec};
+    use crate::consensus::parlia::snapshot::{
+        DEFAULT_EPOCH_LENGTH, LORENTZ_EPOCH_LENGTH, MAXWELL_EPOCH_LENGTH,
+    };
+    use crate::evm::api::BscEvm;
+    use crate::node::evm::config::{
+        evm_env_for_header, BscBlockExecutionCtx, BscExecutionSharedCtx,
+    };
+    use crate::node::evm::executor::BscBlockExecutor;
+    use crate::node::evm::pre_execution::CallBlockEnv;
+    use crate::system_contracts::{SystemContract, VALIDATOR_CONTRACT};
+    use alloy_consensus::Header;
+    use alloy_evm::eth::EthBlockExecutionCtx;
+    use alloy_primitives::{hex, Address, Bytes, U160};
+    use reth_evm_ethereum::RethReceiptBuilder;
+    use revm::bytecode::Bytecode;
+    use revm::database::InMemoryDB;
+    use revm::inspector::NoOpInspector;
+    use revm::state::AccountInfo;
+    use std::sync::Arc;
+
+    /// `_shuffleInterval` in BSCValidatorSet.sol — hard-coded there, and unrelated to the Parlia
+    /// epoch length.
+    const SHUFFLE_INTERVAL: u64 = 200;
+
+    /// The mainnet epoch block from #465.
+    const EPOCH_BLOCK: u64 = 115_596_000;
+
+    /// Stand-in for `ValidatorSet`, returning `getMiningValidators()`-shaped output whose single
+    /// validator address is literally `block.number / 200` — so the decoded set names the shuffle
+    /// window the callee observed.
+    ///
+    /// ```text
+    /// PUSH1 0x40   PUSH1 0x00 MSTORE   head[0] = 0x40   -> address[] at 0x40
+    /// PUSH1 0x80   PUSH1 0x20 MSTORE   head[1] = 0x80   -> bytes[]   at 0x80
+    /// PUSH1 0x01   PUSH1 0x40 MSTORE   address[].len = 1
+    /// PUSH1 0xc8   NUMBER DIV
+    ///              PUSH1 0x60 MSTORE   address[0] = NUMBER / 200
+    /// PUSH1 0x01   PUSH1 0x80 MSTORE   bytes[].len = 1
+    /// PUSH1 0x20   PUSH1 0xa0 MSTORE   bytes[0] data offset = 0x20, relative to 0xa0
+    /// PUSH1 0x30   PUSH1 0xc0 MSTORE   bytes[0].len = 48; its 0xe0..0x120 payload stays zero
+    /// PUSH2 0x0120 PUSH1 0x00 RETURN
+    /// ```
+    const WINDOW_REPORTING_VALIDATOR_SET: &[u8] = &hex!(
+        "6040600052" // head[0]
+        "6080602052" // head[1]
+        "6001604052" // address[].len
+        "60c84304606052" // address[0] = NUMBER / 200
+        "6001608052" // bytes[].len
+        "602060a052" // bytes[0] data offset
+        "603060c052" // bytes[0].len
+        "6101206000f3" // return mem[0x00..0x120]
+    );
+
+    /// The address the mock reports for a callee that observed `block_number`.
+    fn window_address(block_number: u64) -> Address {
+        Address::from(U160::from(block_number / SHUFFLE_INTERVAL))
+    }
+
+    fn header_at(number: u64) -> Header {
+        Header {
+            number,
+            timestamp: 1_786_578_821, // real timestamp of EPOCH_BLOCK
+            gas_limit: 140_000_000,
+            // Cancun is long active at this timestamp, and a Cancun block env without it is
+            // rejected outright.
+            excess_blob_gas: Some(0),
+            blob_gas_used: Some(0),
+            ..Default::default()
+        }
+    }
+
+    type TestExecutor = BscBlockExecutor<
+        'static,
+        BscEvm<InMemoryDB, NoOpInspector>,
+        Arc<BscChainSpec>,
+        RethReceiptBuilder,
+    >;
+
+    /// An executor positioned on `EPOCH_BLOCK`, with the mock installed at `ValidatorSet` and
+    /// `parent_header` set as `check_new_block` sets it.
+    fn executor() -> TestExecutor {
+        let spec = Arc::new(BscChainSpec::from(bsc_mainnet()));
+        let header = header_at(EPOCH_BLOCK);
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            VALIDATOR_CONTRACT,
+            AccountInfo::default()
+                .with_code(Bytecode::new_raw(Bytes::from_static(WINDOW_REPORTING_VALIDATOR_SET))),
+        );
+
+        let evm =
+            BscEvm::new(evm_env_for_header(&spec, &header), db, NoOpInspector {}, false, false);
+
+        let ctx = BscBlockExecutionCtx {
+            base: EthBlockExecutionCtx {
+                parent_hash: header.parent_hash,
+                parent_beacon_block_root: None,
+                ommers: &[],
+                withdrawals: None,
+                extra_data: Bytes::new(),
+                tx_count_hint: None,
+                slot_number: None,
+            },
+            header: Some(header),
+            header_hash: None,
+            is_miner: false,
+            validator_cache_sink: None,
+            turn_length_sink: None,
+            state_root_precomputed_sink: None,
+            trie_handle: None,
+            state_root_deadline_ms: None,
+        };
+
+        let mut executor = BscBlockExecutor::new(
+            evm,
+            ctx,
+            BscExecutionSharedCtx::default(),
+            spec.clone(),
+            RethReceiptBuilder::default(),
+            SystemContract::new(spec),
+        );
+        executor.inner_ctx.parent_header = Some(header_at(EPOCH_BLOCK - 1));
+        executor
+    }
+
+    /// The fix: `Parent` reads the window of `N-1` (what the epoch header encodes and what go-bsc
+    /// computes), `Current` reads the window of `N` — the #465 divergence.
+    #[test]
+    fn parent_env_call_observes_the_parent_shuffle_window() {
+        assert_ne!(
+            window_address(EPOCH_BLOCK - 1),
+            window_address(EPOCH_BLOCK),
+            "fixture is useless unless the two windows differ"
+        );
+
+        let mut executor = executor();
+
+        let (validators, _) = executor
+            .get_current_validators(EPOCH_BLOCK - 1, CallBlockEnv::Parent)
+            .expect("parent-env call");
+        assert_eq!(validators, vec![window_address(EPOCH_BLOCK - 1)], "must observe the parent");
+
+        let (validators, _) = executor
+            .get_current_validators(EPOCH_BLOCK - 1, CallBlockEnv::Current)
+            .expect("current-env call");
+        assert_eq!(validators, vec![window_address(EPOCH_BLOCK)], "bug #465");
+    }
+
+    /// An epoch block `N` observes a different shuffle window than `N - 1` iff `SHUFFLE_INTERVAL`
+    /// divides `N`. At 200 and at Maxwell's 1000 — mainnet today — that is every epoch block; at
+    /// Lorentz's 500 only every second one. So the parent env is mandatory, not cosmetic.
+    #[test]
+    fn epoch_blocks_cross_a_shuffle_window_boundary() {
+        let diverging = |epoch_length: u64| {
+            (1..=10).filter(|k| (k * epoch_length).is_multiple_of(SHUFFLE_INTERVAL)).count()
+        };
+
+        assert_eq!(diverging(DEFAULT_EPOCH_LENGTH), 10, "epoch 200: every epoch block");
+        assert_eq!(diverging(MAXWELL_EPOCH_LENGTH), 10, "epoch 1000: every epoch block");
+        assert_eq!(diverging(LORENTZ_EPOCH_LENGTH), 5, "epoch 500: every second one");
+        assert!(EPOCH_BLOCK.is_multiple_of(MAXWELL_EPOCH_LENGTH), "#465 block is a Maxwell epoch");
+    }
+
+    #[test]
+    fn parent_env_call_requires_a_parent_header() {
+        let mut executor = executor();
+        executor.inner_ctx.parent_header = None;
+        let err = executor
+            .get_current_validators(EPOCH_BLOCK - 1, CallBlockEnv::Parent)
+            .expect_err("must not silently fall back to the current env");
+        assert!(err.to_string().contains("parent header"), "unexpected error: {err}");
+    }
+}

--- a/src/node/evm/pre_execution_tests.rs
+++ b/src/node/evm/pre_execution_tests.rs
@@ -421,7 +421,7 @@ mod tests {
     }
 }
 
-/// Helper-level regression tests for bnb-chain/reth-bsc#465.
+/// Helper-level regression tests for parent-vs-current validator reads.
 #[cfg(test)]
 mod parent_block_env {
     use crate::chainspec::{bsc::bsc_mainnet, BscChainSpec};
@@ -443,16 +443,14 @@ mod parent_block_env {
     use revm::state::AccountInfo;
     use std::sync::Arc;
 
-    /// `_shuffleInterval` in BSCValidatorSet.sol — hard-coded there, and unrelated to the Parlia
-    /// epoch length.
+    /// Hard-coded interval used by the mock validator contract below.
     const SHUFFLE_INTERVAL: u64 = 200;
 
-    /// The mainnet epoch block from #465.
+    /// Epoch block used by the fixture.
     const EPOCH_BLOCK: u64 = 115_596_000;
 
-    /// Stand-in for the `ValidatorSet` contract, returning `getMiningValidators()`-shaped output whose single
-    /// validator address is literally `block.number / 200` — so the decoded set names the shuffle
-    /// window the callee observed.
+    /// Stand-in for the `ValidatorSet` contract. The returned validator address is
+    /// `block.number / 200`, so the decoded set reflects the observed block env.
     ///
     /// ```text
     /// PUSH1 0x40   PUSH1 0x00 MSTORE   head[0] = 0x40   -> address[] at 0x40
@@ -494,9 +492,7 @@ mod parent_block_env {
         }
     }
 
-    /// The standalone, provider-backed twin of the executor path. Nothing re-checks its result
-    /// before the header is sealed, so a drift between the two would only surface as a
-    /// network-wide rejection (bnb-chain/reth-bsc#465).
+    /// Provider-backed twin of the executor path.
     mod standalone {
         use super::*;
         use crate::node::evm::pre_execution::validators_at_parent;
@@ -559,7 +555,7 @@ mod parent_block_env {
             assert_eq!(
                 set,
                 vec![window_address(EPOCH_BLOCK - 1)],
-                "must draw from the parent's window, not the epoch block's"
+                "must draw from the parent env"
             );
         }
 
@@ -632,8 +628,7 @@ mod parent_block_env {
         executor
     }
 
-    /// The fix: `Parent` reads the window of `N-1` (what the epoch header encodes and what go-bsc
-    /// computes), `Current` reads the window of `N` — the #465 divergence.
+    /// `Parent` reads the parent env; `Current` reads the current env.
     #[test]
     fn parent_env_call_observes_the_parent_shuffle_window() {
         assert_ne!(
@@ -652,11 +647,10 @@ mod parent_block_env {
         let (validators, _) = executor
             .get_current_validators(EPOCH_BLOCK - 1, CallBlockEnv::Current)
             .expect("current-env call");
-        assert_eq!(validators, vec![window_address(EPOCH_BLOCK)], "bug #465");
+        assert_eq!(validators, vec![window_address(EPOCH_BLOCK)], "must observe the current env");
     }
 
-    /// The miner resolves from state only on a cache miss — the post-restart window the fix exists
-    /// to close. Reintroducing #465 on this path produces a block the network rejects, silently.
+    /// On a cache miss, the miner resolves validators from parent state and env.
     #[test]
     fn the_miner_reads_the_parents_window_on_a_cache_miss() {
         use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};

--- a/src/node/evm/pre_execution_tests.rs
+++ b/src/node/evm/pre_execution_tests.rs
@@ -437,11 +437,11 @@ mod parent_block_env {
         evm_env_for_header, BscBlockExecutionCtx, BscExecutionSharedCtx,
     };
     use crate::node::evm::executor::BscBlockExecutor;
-    use crate::node::evm::pre_execution::CallBlockEnv;
+    use crate::node::evm::pre_execution::{CallBlockEnv, VALIDATOR_CACHE};
     use crate::system_contracts::{SystemContract, VALIDATOR_CONTRACT};
     use alloy_consensus::Header;
     use alloy_evm::eth::EthBlockExecutionCtx;
-    use alloy_primitives::{hex, Address, Bytes, U160};
+    use alloy_primitives::{hex, Address, Bytes, B256, U160};
     use reth_evm_ethereum::RethReceiptBuilder;
     use revm::bytecode::Bytecode;
     use revm::database::InMemoryDB;
@@ -456,7 +456,7 @@ mod parent_block_env {
     /// The mainnet epoch block from #465.
     const EPOCH_BLOCK: u64 = 115_596_000;
 
-    /// Stand-in for `ValidatorSet`, returning `getMiningValidators()`-shaped output whose single
+    /// Stand-in for the `ValidatorSet` contract, returning `getMiningValidators()`-shaped output whose single
     /// validator address is literally `block.number / 200` — so the decoded set names the shuffle
     /// window the callee observed.
     ///
@@ -498,6 +498,89 @@ mod parent_block_env {
             blob_gas_used: Some(0),
             ..Default::default()
         }
+    }
+
+    /// The standalone, provider-backed twin of the executor path. Nothing re-checks its result
+    /// before the header is sealed, so a drift between the two would only surface as a
+    /// network-wide rejection (bnb-chain/reth-bsc#465).
+    mod standalone {
+        use super::*;
+        use crate::node::evm::pre_execution::validators_at_parent;
+        use alloy_primitives::{B256, U256};
+        use reth_primitives_traits::{Account, Bytecode as PrimitivesBytecode, SealedHeader};
+        use reth_provider::ProviderResult;
+        use reth_revm::database::EvmStateProvider;
+
+        /// Serves [`WINDOW_REPORTING_VALIDATOR_SET`] as the code of `VALIDATOR_CONTRACT`, or an
+        /// empty state when `code` is `None` — i.e. the contract not deployed.
+        struct ParentState {
+            code: Option<PrimitivesBytecode>,
+        }
+
+        impl ParentState {
+            fn code_hash(&self) -> B256 {
+                self.code.as_ref().map(|c| c.hash_slow()).unwrap_or_default()
+            }
+        }
+
+        impl EvmStateProvider for ParentState {
+            fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+                Ok((self.code.is_some() && *address == VALIDATOR_CONTRACT).then_some(Account {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    bytecode_hash: Some(self.code_hash()),
+                }))
+            }
+
+            fn block_hash(&self, _: u64) -> ProviderResult<Option<B256>> {
+                Ok(None)
+            }
+
+            fn bytecode_by_hash(
+                &self,
+                code_hash: &B256,
+            ) -> ProviderResult<Option<PrimitivesBytecode>> {
+                Ok((code_hash == &self.code_hash()).then(|| self.code.clone()).flatten())
+            }
+
+            fn storage(&self, _: Address, _: B256) -> ProviderResult<Option<U256>> {
+                Ok(None)
+            }
+        }
+
+        fn parent_state() -> ParentState {
+            let code = PrimitivesBytecode(Bytecode::new_raw(Bytes::from_static(
+                WINDOW_REPORTING_VALIDATOR_SET,
+            )));
+            ParentState { code: Some(code) }
+        }
+
+        #[test]
+        fn observes_the_parent_shuffle_window() {
+            let spec = Arc::new(BscChainSpec::from(bsc_mainnet()));
+            let parent = SealedHeader::seal_slow(header_at(EPOCH_BLOCK - 1));
+
+            let (set, _) = validators_at_parent(parent_state(), spec, &parent).unwrap();
+
+            assert_eq!(
+                set,
+                vec![window_address(EPOCH_BLOCK - 1)],
+                "must draw from the parent's window, not the epoch block's"
+            );
+        }
+
+        /// A call to an address with no code succeeds with empty returndata, which the ABI unpack
+        /// would `unwrap()`-panic on — inside a payload job or the bid loop, where a panic is
+        /// permanent. It must surface as an error instead.
+        #[test]
+        fn missing_validator_set_contract_errors_rather_than_panicking() {
+            let spec = Arc::new(BscChainSpec::from(bsc_mainnet()));
+            let parent = SealedHeader::seal_slow(header_at(EPOCH_BLOCK - 1));
+
+            let err = validators_at_parent(ParentState { code: None }, spec, &parent).unwrap_err();
+            assert!(err.to_string().contains("no data"), "unexpected error: {err}");
+        }
+
     }
 
     type TestExecutor = BscBlockExecutor<
@@ -591,6 +674,71 @@ mod parent_block_env {
         assert_eq!(diverging(MAXWELL_EPOCH_LENGTH), 10, "epoch 1000: every epoch block");
         assert_eq!(diverging(LORENTZ_EPOCH_LENGTH), 5, "epoch 500: every second one");
         assert!(EPOCH_BLOCK.is_multiple_of(MAXWELL_EPOCH_LENGTH), "#465 block is a Maxwell epoch");
+    }
+
+    /// Guards the call site, not just the mechanism. `get_current_validators` is *told* which env
+    /// to use, so the test above passes even with the fix reverted — this one asks the validation
+    /// path what it actually requests for an epoch block (bnb-chain/reth-bsc#465).
+    #[test]
+    fn the_epoch_call_site_asks_for_the_parents_window() {
+        let mut executor = executor();
+        // A fresh parent hash keeps this off any other test's cache entry.
+        let header = Header { parent_hash: B256::random(), ..header_at(EPOCH_BLOCK) };
+
+        let (validators, _) =
+            executor.declared_epoch_validators(&header).expect("epoch validators");
+
+        assert_eq!(
+            validators,
+            vec![window_address(EPOCH_BLOCK - 1)],
+            "the epoch call site must ask for N-1's window, not N's"
+        );
+        // And it must file that answer under N-1, per VALIDATOR_CACHE's invariant: keying it under
+        // N would hand N-1's window to whoever validates or seals N+1.
+        assert_eq!(
+            VALIDATOR_CACHE.lock().unwrap().get(&header.parent_hash).unwrap().0,
+            vec![window_address(EPOCH_BLOCK - 1)],
+        );
+    }
+
+    /// The miner resolves from state only on a cache miss — the post-restart window the fix exists
+    /// to close. Reintroducing #465 on this path produces a block the network rejects, silently.
+    #[test]
+    fn the_miner_reads_the_parents_window_on_a_cache_miss() {
+        use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+
+        let client = MockEthProvider::default();
+        client.add_account(
+            VALIDATOR_CONTRACT,
+            ExtendedAccount::new(0, alloy_primitives::U256::ZERO)
+                .with_bytecode(Bytes::from_static(WINDOW_REPORTING_VALIDATOR_SET)),
+        );
+        // A fresh hash forces the miss; `epoch_num` makes EPOCH_BLOCK the next epoch block.
+        let parent = reth_primitives_traits::SealedHeader::new(
+            header_at(EPOCH_BLOCK - 1),
+            alloy_primitives::B256::random(),
+        );
+        let snap = crate::consensus::parlia::Snapshot::new(
+            vec![Address::with_last_byte(1)],
+            EPOCH_BLOCK - 1,
+            parent.hash(),
+            MAXWELL_EPOCH_LENGTH,
+            None,
+        );
+
+        let resolved = crate::node::miner::util::epoch_validators_for_next_block(
+            &client,
+            &Arc::new(BscChainSpec::from(bsc_mainnet())),
+            &snap,
+            &parent,
+        )
+        .expect("state read on cache miss");
+
+        assert_eq!(
+            resolved.map(|(validators, _)| validators),
+            Some(vec![window_address(EPOCH_BLOCK - 1)]),
+            "the miner must evaluate at the parent, not at the epoch block"
+        );
     }
 
     #[test]

--- a/src/node/evm/pre_execution_tests.rs
+++ b/src/node/evm/pre_execution_tests.rs
@@ -421,17 +421,11 @@ mod tests {
     }
 }
 
-/// Regression tests for bnb-chain/reth-bsc#465.
-///
-/// NOT covered: the arguments `check_new_block` itself passes — driving it needs a
-/// `SnapshotProvider` global plus a real secp256k1 Parlia seal and BLS attestation for
-/// `verify_seal`. So a call site edited to `CallBlockEnv::Current` would not fail here.
+/// Helper-level regression tests for bnb-chain/reth-bsc#465.
 #[cfg(test)]
 mod parent_block_env {
     use crate::chainspec::{bsc::bsc_mainnet, BscChainSpec};
-    use crate::consensus::parlia::snapshot::{
-        DEFAULT_EPOCH_LENGTH, LORENTZ_EPOCH_LENGTH, MAXWELL_EPOCH_LENGTH,
-    };
+    use crate::consensus::parlia::snapshot::MAXWELL_EPOCH_LENGTH;
     use crate::evm::api::BscEvm;
     use crate::node::evm::config::{
         evm_env_for_header, BscBlockExecutionCtx, BscExecutionSharedCtx,
@@ -659,21 +653,6 @@ mod parent_block_env {
             .get_current_validators(EPOCH_BLOCK - 1, CallBlockEnv::Current)
             .expect("current-env call");
         assert_eq!(validators, vec![window_address(EPOCH_BLOCK)], "bug #465");
-    }
-
-    /// An epoch block `N` observes a different shuffle window than `N - 1` iff `SHUFFLE_INTERVAL`
-    /// divides `N`. At 200 and at Maxwell's 1000 — mainnet today — that is every epoch block; at
-    /// Lorentz's 500 only every second one. So the parent env is mandatory, not cosmetic.
-    #[test]
-    fn epoch_blocks_cross_a_shuffle_window_boundary() {
-        let diverging = |epoch_length: u64| {
-            (1..=10).filter(|k| (k * epoch_length).is_multiple_of(SHUFFLE_INTERVAL)).count()
-        };
-
-        assert_eq!(diverging(DEFAULT_EPOCH_LENGTH), 10, "epoch 200: every epoch block");
-        assert_eq!(diverging(MAXWELL_EPOCH_LENGTH), 10, "epoch 1000: every epoch block");
-        assert_eq!(diverging(LORENTZ_EPOCH_LENGTH), 5, "epoch 500: every second one");
-        assert!(EPOCH_BLOCK.is_multiple_of(MAXWELL_EPOCH_LENGTH), "#465 block is a Maxwell epoch");
     }
 
     /// The miner resolves from state only on a cache miss — the post-restart window the fix exists

--- a/src/node/evm/pre_execution_tests.rs
+++ b/src/node/evm/pre_execution_tests.rs
@@ -423,9 +423,9 @@ mod tests {
 
 /// Regression tests for bnb-chain/reth-bsc#465.
 ///
-/// NOT covered: that `check_new_block` actually passes [`CallBlockEnv::Parent`]. Driving it would
-/// need a `SnapshotProvider` global plus a real secp256k1 Parlia seal and BLS attestation for
-/// `verify_seal`.
+/// NOT covered: the arguments `check_new_block` itself passes — driving it needs a
+/// `SnapshotProvider` global plus a real secp256k1 Parlia seal and BLS attestation for
+/// `verify_seal`. So a call site edited to `CallBlockEnv::Current` would not fail here.
 #[cfg(test)]
 mod parent_block_env {
     use crate::chainspec::{bsc::bsc_mainnet, BscChainSpec};
@@ -441,7 +441,7 @@ mod parent_block_env {
     use crate::system_contracts::{SystemContract, VALIDATOR_CONTRACT};
     use alloy_consensus::Header;
     use alloy_evm::eth::EthBlockExecutionCtx;
-    use alloy_primitives::{hex, Address, Bytes, B256, U160};
+    use alloy_primitives::{hex, Address, Bytes, U160};
     use reth_evm_ethereum::RethReceiptBuilder;
     use revm::bytecode::Bytecode;
     use revm::database::InMemoryDB;
@@ -676,31 +676,6 @@ mod parent_block_env {
         assert!(EPOCH_BLOCK.is_multiple_of(MAXWELL_EPOCH_LENGTH), "#465 block is a Maxwell epoch");
     }
 
-    /// Guards the call site, not just the mechanism. `get_current_validators` is *told* which env
-    /// to use, so the test above passes even with the fix reverted — this one asks the validation
-    /// path what it actually requests for an epoch block (bnb-chain/reth-bsc#465).
-    #[test]
-    fn the_epoch_call_site_asks_for_the_parents_window() {
-        let mut executor = executor();
-        // A fresh parent hash keeps this off any other test's cache entry.
-        let header = Header { parent_hash: B256::random(), ..header_at(EPOCH_BLOCK) };
-
-        let (validators, _) =
-            executor.declared_epoch_validators(&header).expect("epoch validators");
-
-        assert_eq!(
-            validators,
-            vec![window_address(EPOCH_BLOCK - 1)],
-            "the epoch call site must ask for N-1's window, not N's"
-        );
-        // And it must file that answer under N-1, per VALIDATOR_CACHE's invariant: keying it under
-        // N would hand N-1's window to whoever validates or seals N+1.
-        assert_eq!(
-            VALIDATOR_CACHE.lock().unwrap().get(&header.parent_hash).unwrap().0,
-            vec![window_address(EPOCH_BLOCK - 1)],
-        );
-    }
-
     /// The miner resolves from state only on a cache miss — the post-restart window the fix exists
     /// to close. Reintroducing #465 on this path produces a block the network rejects, silently.
     #[test]
@@ -738,6 +713,11 @@ mod parent_block_env {
             resolved.map(|(validators, _)| validators),
             Some(vec![window_address(EPOCH_BLOCK - 1)]),
             "the miner must evaluate at the parent, not at the epoch block"
+        );
+        // And file it under the parent, per VALIDATOR_CACHE's invariant.
+        assert_eq!(
+            VALIDATOR_CACHE.lock().unwrap().get(&parent.hash()).unwrap().0,
+            vec![window_address(EPOCH_BLOCK - 1)],
         );
     }
 

--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -21,6 +21,7 @@ use crate::consensus::parlia::{
 use crate::hardforks::BscHardforks;
 use crate::node::miner::block_mev_info::{set_block_mev_info, BlockMevInfoVersion};
 use crate::node::miner::signer::sign_system_transaction;
+use crate::node::evm::pre_execution::EpochValidators;
 use crate::node::miner::util::finalize_new_header;
 use crate::node::primitives::{BscBlobTransactionSidecar, BscBlock, BscBlockBody};
 use alloy_consensus::transaction::RlpEcdsaDecodableTx;
@@ -869,7 +870,8 @@ pub fn set_bid_block_mev_info(header: &mut Header, builder: Address, prague_acti
 /// as the builder set them so the re-executed state root matches the builder's.
 ///
 /// `vanity` is the validator's extra-data vanity (finalize appends the 65-byte seal slot);
-/// `block_timestamp_ms` is the millisecond timestamp for Lorentz.
+/// `block_timestamp_ms` is the millisecond timestamp for Lorentz; `epoch_validators` is the set an
+/// epoch block must carry, forwarded to `finalize_new_header` (see it for the `None` contract).
 #[allow(clippy::too_many_arguments)]
 pub fn simulate_bid_block(
     parlia: Arc<Parlia<BscChainSpec>>,
@@ -882,6 +884,7 @@ pub fn simulate_bid_block(
     expected_gas_limit: u64,
     vanity: Bytes,
     block_timestamp_ms: u64,
+    epoch_validators: Option<EpochValidators>,
 ) -> Result<BidBlockTask, SimulateBidBlockError> {
     let (system_tx_start, gas_fee) =
         verify_bid_block_payload(chain_spec, decoded, parent.header(), validator, expected_gas_limit)
@@ -909,6 +912,7 @@ pub fn simulate_bid_block(
         &mut header,
         snapshot_provider,
         block_timestamp_ms,
+        epoch_validators,
     )
     .map_err(|e| SimulateBidBlockError::Finalize(e.to_string()))?;
 
@@ -1867,6 +1871,7 @@ mod tests {
             30_000_000,
             Bytes::from(vec![0u8; 32]),
             1_000,
+            None, // not an epoch block
         )
         .expect("simulate");
 

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -900,10 +900,7 @@ where
                 return;
             }
         };
-        // A consensus precondition no other check here covers. Without it a builder can name an
-        // arbitrary ancestor and make this "zero-simulate" intake path read historical state, and
-        // the epoch test below (`parent.number + 1`) can disagree with the one in
-        // `finalize_new_header` (`header.number`).
+        // BidBlocks must build directly on the selected parent.
         if decoded.block_number() != parent.number() + 1 {
             debug!(
                 "BidBlock: block {} is not a child of parent {} ({parent_hash})",
@@ -936,8 +933,7 @@ where
         ) {
             Ok(v) => v,
             Err(e) => {
-                // Unlike the bid-specific rejections around it, this is an infrastructure failure
-                // that drops every BidBlock for this epoch block.
+                // This is an infrastructure failure, not a bid-specific rejection.
                 warn!(
                     "BidBlock: failed to resolve epoch validators for block {}, builder={}: {e}",
                     decoded.block_number(),
@@ -971,11 +967,7 @@ where
             }
         };
 
-        // BEP-675 zero-simulate: do NOT execute here. Keep the highest-fee sealed BidBlock per
-        // parent (go-bsc `AddBidBlock`). Execution + state-root verification are deferred until the
-        // block has been selected and broadcast — see `ImportService::on_new_bid_block` — matching
-        // go-bsc's broadcast-then-`InsertChain` flow in `handleBidBlockResult`. Selection is by the
-        // deposit-derived `gas_fee`, which needs no execution.
+        // Keep the highest-fee sealed BidBlock per parent. Execution is deferred.
         let mut best = self.best_bid_block.write();
         let replace = best.get(&parent_hash).is_none_or(|t| task.gas_fee > t.gas_fee);
         // Log the key we store under. `collect_best_bid_block` logs the key it looks up, so a

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -7,7 +7,7 @@ use crate::node::engine::BscBuiltPayload;
 use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes, ValidatorCacheSink};
 use crate::node::miner::bsc_miner::MiningContext;
 use crate::node::miner::payload::DELAY_LEFT_OVER;
-use crate::node::miner::util::prepare_new_attributes;
+use crate::node::miner::util::{epoch_validators_for_next_block, prepare_new_attributes};
 use crate::node::primitives::BscBlobTransactionSidecar;
 use alloy_consensus::BlobTransactionSidecar;
 use alloy_consensus::BlockHeader as _;
@@ -40,7 +40,7 @@ use reth_revm::{database::StateProviderDatabase, db::State};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 const PAY_BID_TX_GAS_LIMIT: u64 = 25000;
 const TX_GAS: u64 = 21000;
 
@@ -900,6 +900,18 @@ where
                 return;
             }
         };
+        // A consensus precondition no other check here covers. Without it a builder can name an
+        // arbitrary ancestor and make this "zero-simulate" intake path read historical state, and
+        // the epoch test below (`parent.number + 1`) can disagree with the one in
+        // `finalize_new_header` (`header.number`).
+        if decoded.block_number() != parent.number() + 1 {
+            debug!(
+                "BidBlock: block {} is not a child of parent {} ({parent_hash})",
+                decoded.block_number(),
+                parent.number(),
+            );
+            return;
+        }
         let Some(parent_snap) = self.snapshot_provider.snapshot_by_hash(&parent_hash) else {
             debug!("BidBlock: no snapshot for parent {parent_hash}");
             return;
@@ -916,6 +928,25 @@ where
         };
         let block_timestamp_ms = calculate_millisecond_timestamp(&decoded.header);
 
+        let epoch_validators = match epoch_validators_for_next_block(
+            &self.client,
+            &self.chain_spec,
+            &parent_snap,
+            &parent,
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                // Unlike the bid-specific rejections around it, this is an infrastructure failure
+                // that drops every BidBlock for this epoch block.
+                warn!(
+                    "BidBlock: failed to resolve epoch validators for block {}, builder={}: {e}",
+                    decoded.block_number(),
+                    decoded.builder,
+                );
+                return;
+            }
+        };
+
         let task = match simulate_bid_block(
             self.parlia.clone(),
             &self.chain_spec,
@@ -927,6 +958,7 @@ where
             expected_gas_limit,
             vanity,
             block_timestamp_ms,
+            epoch_validators,
         ) {
             Ok(task) => task,
             Err(e) => {

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -7,12 +7,12 @@ use crate::hardforks::BscHardforks;
 use crate::metrics::{BscConsensusMetrics, BscMinerMetrics};
 use crate::node::engine::{BscBuiltPayload, BuildKind};
 use crate::node::evm::config::{BscEvmConfig, BscNextBlockEnvAttributes, ValidatorCacheSink};
-use crate::node::evm::pre_execution::{TURN_LENGTH_CACHE, VALIDATOR_CACHE};
+use crate::node::evm::pre_execution::{EpochValidators, TURN_LENGTH_CACHE, VALIDATOR_CACHE};
 use crate::node::miner::bid_block::{validate_bid_block_blob_kzg, BidBlockTask};
 use crate::node::miner::bid_simulator::BidSimulator;
 use crate::node::miner::block_mev_info::{set_block_mev_info, BlockMevInfoVersion};
 use crate::node::miner::bsc_miner::{MiningContext, SubmitContext};
-use crate::node::miner::util::finalize_new_header;
+use crate::node::miner::util::{epoch_validators_for_next_block, finalize_new_header};
 use crate::node::pool::BlacklistedAddressError;
 use crate::node::primitives::{BscBlobTransactionSidecar, BscBlock};
 use alloy_consensus::{BlockHeader, Transaction};
@@ -2584,12 +2584,21 @@ where
         let gas_usage_percent =
             if gas_limit > 0 { (gas_used as f64 / gas_limit as f64 * 100.0) as u64 } else { 0 };
 
+        let epoch_validators = epoch_validators_for_next_block(
+            &self.builder.client,
+            &self.builder.chain_spec,
+            &self.mining_ctx.parent_snapshot,
+            &self.mining_ctx.parent_header,
+        )
+        .map_err(|e| Box::new(BscPayloadJobError::PayloadBuildingError(e.to_string())))?;
+
         finalize_payload(
             &mut best_payload,
             self.parlia.clone(),
             &self.mining_ctx.parent_snapshot,
             &self.mining_ctx.parent_header,
             self.mining_ctx.block_timestamp_ms,
+            epoch_validators,
         )
         .map_err(|e| {
             warn!(
@@ -2766,6 +2775,7 @@ fn finalize_payload(
     parent_snapshot: &Snapshot,
     parent_header: &SealedHeader<alloy_consensus::Header>,
     block_timestamp_ms: u64,
+    epoch_validators: Option<EpochValidators>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let snapshot_provider = crate::shared::get_snapshot_provider().cloned().ok_or_else(|| {
         Box::new(std::io::Error::other("Snapshot provider not available"))
@@ -2803,6 +2813,7 @@ fn finalize_payload(
         &mut plain_block.header,
         &snapshot_provider,
         block_timestamp_ms,
+        epoch_validators,
     )
     .map_err(|e| {
         Box::new(std::io::Error::other(e.to_string())) as Box<dyn std::error::Error + Send + Sync>

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -2757,18 +2757,8 @@ fn refresh_and_reseal_bid_block(
 
 /// Finalize a built payload in-place.
 ///
-/// Runs `finalize_new_header()` on the payload's header (sets difficulty, prepares validators
-/// for epoch blocks, assembles vote attestation, and ECDSA-seals the header), then:
-///
-/// 1. Writes `pending_validators` / `pending_turn_length` to the global caches keyed by
-///    the now-deterministic final block hash.
-/// 2. Rebuilds `executed_block.recovered_block` with the finalized header so the engine
-///    tree can identify the block by its correct hash.
-/// 3. Rebuilds `block` (sealed block with sidecars) with the finalized header.
-///
-/// This function is intentionally separate from the builder path so that finalization is
-/// deferred until `pick_best_payload_and_finalize()` chooses the winning payload — giving more time for
-/// FF votes to arrive.
+/// This seals the header, writes pending cache entries under the final hash, and rebuilds the
+/// payload objects with the finalized header.
 fn finalize_payload(
     payload: &mut BscBuiltPayload,
     parlia: Arc<Parlia<BscChainSpec>>,

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -40,8 +40,7 @@ where
         return Ok(None);
     }
     let parent_hash = parent_header.hash();
-    // Bind the lookup so the guard drops here: under edition 2021 an `if let` on the guard itself
-    // would hold the lock across its whole body.
+    // Bind the lookup so the lock guard drops before the branch body.
     let cached = VALIDATOR_CACHE.lock().unwrap().get(&parent_hash).cloned();
     if let Some(validators) = cached {
         tracing::debug!(
@@ -63,8 +62,7 @@ where
     let state = client.state_by_block_hash(parent_hash).map_err(|e| failed(&e))?;
     let validators = validators_at_parent(&state, chain_spec.clone(), parent_header)
         .map_err(|e| failed(&e))?;
-    // Worth a `warn!`: the parent should have filled the cache, so a miss here means this process
-    // did not execute it — the restart window #465 stalls in.
+    // A cache miss means this process did not execute the parent block.
     tracing::warn!(
         target: "bsc::miner",
         block_number = parent_header.number() + 1,
@@ -76,14 +74,7 @@ where
     Ok(Some(validators))
 }
 
-/// Prepare a new block's header and derive the payload builder attributes.
-///
-/// Populates on `ctx`:
-/// - `header`: the freshly constructed unsealed header for this block.
-/// - `block_timestamp_ms`: block timestamp in ms fixed by `prepare_timestamp`, reused
-///   verbatim by `finalize_new_header` to avoid seconds/ms drift at sealing time.
-/// - `end_mining_timestamp_ms`: wall-clock deadline for this mining job, computed as
-///   `now_ms + parlia.delay_for_ramanujan_fork(...)`.
+/// Prepare a new block header and payload attributes.
 pub fn prepare_new_attributes(
     ctx: &mut MiningContext,
     parlia: Arc<Parlia<BscChainSpec>>,
@@ -91,7 +82,7 @@ pub fn prepare_new_attributes(
     signer: Address,
 ) -> EthPayloadAttributes {
     let mut new_header = prepare_new_header(parlia.clone(), parent_header, signer);
-    // Cache the planned millisecond timestamp so finalize_new_header can reuse it verbatim.
+    // Reuse the planned millisecond timestamp during finalization.
     ctx.block_timestamp_ms =
         parlia.prepare_timestamp(&ctx.parent_snapshot, parent_header.header(), &mut new_header);
 
@@ -103,9 +94,7 @@ pub fn prepare_new_attributes(
         parlia.delay_for_ramanujan_fork(&ctx.parent_snapshot, &new_header);
     ctx.end_mining_timestamp_ms = now_ms + end_mining_delay_ms as u128;
 
-    // BSC uses the PREVRANDAO opcode to return difficulty (not a random value like
-    // Ethereum PoS). The validation path in BscEvmConfig::evm_env sets
-    // `prevrandao = header.difficulty()`, so the building path must match.
+    // In BSC, PREVRANDAO returns difficulty, so the build path must match validation.
     let difficulty = calculate_difficulty(&ctx.parent_snapshot, signer);
     let mut attributes = EthPayloadAttributes {
         timestamp: new_header.timestamp,
@@ -126,7 +115,7 @@ pub fn prepare_new_attributes(
     attributes
 }
 
-/// prepare a tmp new header for preparing attributes.
+/// Prepare a temporary header for attribute derivation.
 pub fn prepare_new_header<ChainSpec>(
     parlia: Arc<Parlia<ChainSpec>>,
     parent_header: &SealedHeader,
@@ -143,8 +132,7 @@ where
         number: parent_header.number() + 1,
         parent_hash: parent_header.hash(),
         beneficiary: signer,
-        // Set timestamp to present time (or parent + 1 if present time is not greater)
-        // This avoids header.timestamp = 0 when back_off_time is called inside prepare_timestamp
+        // Initialize timestamp before `prepare_timestamp` adjusts it.
         timestamp,
         ..Default::default()
     };
@@ -203,8 +191,7 @@ where
     // })
 
     {
-        // prepare validators
-        // Use epoch_num from parent snapshot for epoch boundary check
+        // Prepare validators on epoch boundaries.
         let epoch_length = parent_snap.epoch_num;
         if (new_header.number).is_multiple_of(epoch_length) {
             let validators = epoch_validators.ok_or_else(|| {
@@ -233,7 +220,7 @@ where
     }
 
     {
-        // seal header
+        // Seal the header.
         let mut extra_data = new_header.extra_data.to_vec();
         extra_data.extend_from_slice(&[0u8; EXTRA_SEAL_LEN]);
         new_header.extra_data = Bytes::from(extra_data);

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -9,10 +9,11 @@ use crate::consensus::parlia::util::{
     calculate_difficulty, debug_header, set_millisecond_part_of_timestamp,
 };
 use crate::consensus::parlia::Snapshot;
-use crate::consensus::parlia::VoteAddress;
 use crate::consensus::parlia::{EXTRA_SEAL_LEN, EXTRA_VANITY_LEN};
 use crate::hardforks::BscHardforks;
-use crate::node::evm::pre_execution::VALIDATOR_CACHE;
+use crate::node::evm::pre_execution::{
+    validators_at_parent, EpochValidators, VALIDATOR_CACHE,
+};
 use crate::node::miner::bsc_miner::MiningContext;
 use crate::node::miner::signer::{seal_header_with_global_signer, SignerError};
 use alloy_consensus::{BlockHeader, Header};
@@ -20,50 +21,62 @@ use alloy_primitives::{Address, Bytes, B256};
 use reth_node_ethereum::engine::EthPayloadAttributes;
 use reth_chainspec::EthChainSpec;
 use reth_primitives_traits::SealedHeader;
+use reth_provider::StateProviderFactory;
 use std::sync::Arc;
 
-fn resolve_epoch_validators(
+/// The epoch validator set that block `parent_header.number + 1` must carry, or `None` when that
+/// block is not an epoch block.
+///
+/// Read on the parent's state and in the parent's env — see `CallBlockEnv`. Resolved here rather
+/// than in [`finalize_new_header`] so `simulate_bid_block` needs no state handle, and memoized under
+/// the parent hash, so sealing after the parent has executed reads no state.
+pub(crate) fn epoch_validators_for_next_block<C>(
+    client: &C,
+    chain_spec: &Arc<BscChainSpec>,
     parent_snap: &Snapshot,
     parent_header: &SealedHeader,
-) -> Result<(Vec<Address>, Vec<VoteAddress>), SignerError> {
+) -> Result<Option<EpochValidators>, SignerError>
+where
+    C: StateProviderFactory,
+{
+    if !(parent_header.number() + 1).is_multiple_of(parent_snap.epoch_num) {
+        return Ok(None);
+    }
     let parent_hash = parent_header.hash();
-    let mut cache = VALIDATOR_CACHE.lock().unwrap();
-    if let Some(cached_result) = cache.get(&parent_hash) {
+    // Bind the lookup so the guard drops here: under edition 2021 an `if let` on the guard itself
+    // would hold the lock across its whole body.
+    let cached = VALIDATOR_CACHE.lock().unwrap().get(&parent_hash).cloned();
+    if let Some(validators) = cached {
         tracing::debug!(
-            "Succeed to query cached validator result, block_number: {}, block_hash: {}",
-            parent_header.number(),
-            parent_hash
+            target: "bsc::miner",
+            block_number = parent_header.number() + 1,
+            validators = ?validators.0,
+            "Epoch validators from cache"
         );
-        return Ok(cached_result.clone());
+        return Ok(Some(validators));
     }
 
-    if parent_snap.validators.is_empty() {
-        return Err(SignerError::SigningFailed(format!(
-            "Missing epoch validators for parent block {} ({})",
-            parent_header.number(), parent_hash
-        )));
-    }
-
-    let validators = parent_snap.validators.clone();
-    let vote_addresses = validators
-        .iter()
-        .map(|validator| {
-            parent_snap
-                .validators_map
-                .get(validator)
-                .map(|info| info.vote_addr)
-                .unwrap_or(VoteAddress::ZERO)
-        })
-        .collect::<Vec<_>>();
-
+    let failed = |e: &dyn std::fmt::Display| {
+        SignerError::SigningFailed(format!(
+            "Failed to read epoch validators from parent block {} ({}): {e}",
+            parent_header.number(),
+            parent_hash,
+        ))
+    };
+    let state = client.state_by_block_hash(parent_hash).map_err(|e| failed(&e))?;
+    let validators = validators_at_parent(&state, chain_spec.clone(), parent_header)
+        .map_err(|e| failed(&e))?;
+    // Worth a `warn!`: the parent should have filled the cache, so a miss here means this process
+    // did not execute it — the restart window #465 stalls in.
     tracing::warn!(
         target: "bsc::miner",
-        block_number = parent_header.number(),
-        block_hash = %parent_hash,
-        "Validator cache miss on epoch boundary, falling back to parent snapshot validators"
+        block_number = parent_header.number() + 1,
+        %parent_hash,
+        validators = ?validators.0,
+        "Epoch validators read from parent state after a cache miss"
     );
-    cache.insert(parent_hash, (validators.clone(), vote_addresses.clone()));
-    Ok((validators, vote_addresses))
+    VALIDATOR_CACHE.lock().unwrap().insert(parent_hash, validators.clone());
+    Ok(Some(validators))
 }
 
 /// Prepare a new block's header and derive the payload builder attributes.
@@ -160,6 +173,10 @@ where
 ///
 /// `block_timestamp_ms` is the millisecond timestamp decided by `prepare_timestamp` and
 /// cached on `MiningContext`.
+///
+/// `epoch_validators` is the set the block must carry when it is an epoch block, and `None`
+/// otherwise; an epoch block with `None` is rejected rather than sealed with a guess. Produced by
+/// `epoch_validators_for_next_block`.
 pub fn finalize_new_header<ChainSpec>(
     parlia: Arc<Parlia<ChainSpec>>,
     parent_snap: &Snapshot,
@@ -167,6 +184,7 @@ pub fn finalize_new_header<ChainSpec>(
     new_header: &mut Header,
     snapshot_provider: &Arc<dyn SnapshotProvider + Send + Sync>,
     block_timestamp_ms: u64,
+    epoch_validators: Option<EpochValidators>,
 ) -> Result<(), crate::node::miner::signer::SignerError>
 where
     ChainSpec: EthChainSpec + crate::hardforks::BscHardforks + 'static,
@@ -197,7 +215,13 @@ where
         // Use epoch_num from parent snapshot for epoch boundary check
         let epoch_length = parent_snap.epoch_num;
         if (new_header.number).is_multiple_of(epoch_length) {
-            let validators = resolve_epoch_validators(parent_snap, parent_header)?;
+            let validators = epoch_validators.ok_or_else(|| {
+                SignerError::SigningFailed(format!(
+                    "Epoch block {} needs epoch validators, but none were supplied (parent {})",
+                    new_header.number,
+                    parent_header.hash(),
+                ))
+            })?;
             parlia.prepare_validators(parent_snap, Some(validators), new_header);
         }
     }
@@ -353,80 +377,142 @@ mod tests {
         VALIDATOR_BYTES_LEN_AFTER_LUBAN, VALIDATOR_NUMBER_SIZE,
     };
     use crate::consensus::parlia::vote::{VoteAttestation, VoteData};
+    use crate::chainspec::bsc::bsc_mainnet;
+    use crate::consensus::parlia::VoteAddress;
+    use reth_provider::test_utils::MockEthProvider;
     use alloy_primitives::B256;
 
     fn unique_parent_header(number: u64) -> Header {
         Header { number, parent_hash: B256::random(), ..Default::default() }
     }
 
+    /// The gate: a non-epoch child needs no set, and deciding that must not touch state.
     #[test]
-    fn resolve_epoch_validators_falls_back_to_snapshot_on_cache_miss() {
-        let parent_header = unique_parent_header(499);
-        let parent_hash = parent_header.hash_slow();
+    fn epoch_validators_are_only_resolved_for_epoch_blocks() {
+        let parent = SealedHeader::seal_slow(Header { number: 5, ..Default::default() });
+        // `epoch_num = 2` makes 6 an epoch block and 7 not one.
+        let at_boundary = Snapshot::new(vec![Address::with_last_byte(1)], 5, parent.hash(), 2, None);
+        let off_boundary =
+            Snapshot::new(vec![Address::with_last_byte(1)], 5, parent.hash(), 4, None);
+        let spec = Arc::new(BscChainSpec::from(bsc_mainnet()));
+        // A provider that knows nothing: reaching it at all is a failure, not a `None`.
+        let client = MockEthProvider::default();
 
-        let validators = vec![
-            Address::with_last_byte(2),
-            Address::with_last_byte(1),
-            Address::with_last_byte(3),
-        ];
-        let vote_addresses = vec![
-            VoteAddress::with_last_byte(22),
-            VoteAddress::with_last_byte(11),
-            VoteAddress::with_last_byte(33),
-        ];
-        let parent_snap =
-            Snapshot::new(validators, 499, B256::random(), 500, Some(vote_addresses.clone()));
-
-        let resolved =
-            resolve_epoch_validators(&parent_snap, &SealedHeader::seal_slow(parent_header)).unwrap();
-
-        assert_eq!(resolved.0, parent_snap.validators);
-        assert_eq!(resolved.1.len(), parent_snap.validators.len());
-        for (i, validator) in parent_snap.validators.iter().enumerate() {
-            assert_eq!(resolved.1[i], parent_snap.validators_map.get(validator).unwrap().vote_addr);
-        }
-
-        let mut cache = VALIDATOR_CACHE.lock().unwrap();
-        let cached = cache.get(&parent_hash).unwrap();
-        assert_eq!(cached.0, resolved.0);
-        assert_eq!(cached.1, resolved.1);
+        assert_eq!(
+            epoch_validators_for_next_block(&client, &spec, &off_boundary, &parent).unwrap(),
+            None,
+            "block 6 is not a multiple of 4, so no state should be read"
+        );
+        epoch_validators_for_next_block(&client, &spec, &at_boundary, &parent)
+            .expect_err("block 6 is a multiple of 2, so the empty provider must surface an error");
     }
 
+    /// The memo: an entry the parent's own execution already left is used as-is, so sealing an
+    /// epoch block reads no state. Its key and value are [`VALIDATOR_CACHE`]'s (see its invariant).
     #[test]
-    fn resolve_epoch_validators_prefers_cache() {
-        let parent_header = unique_parent_header(799);
-        let parent_hash = parent_header.hash_slow();
+    fn epoch_validators_come_from_the_cache_when_the_parent_filled_it() {
+        let parent = SealedHeader::seal_slow(Header {
+            number: 5,
+            parent_hash: B256::random(), // unique, so this test owns its cache entry
+            ..Default::default()
+        });
+        let snap = Snapshot::new(vec![Address::with_last_byte(1)], 5, parent.hash(), 2, None);
+        let expected = (vec![Address::with_last_byte(9)], vec![VoteAddress::with_last_byte(99)]);
+        VALIDATOR_CACHE.lock().unwrap().insert(parent.hash(), expected.clone());
 
-        let cached_validators = vec![Address::with_last_byte(9), Address::with_last_byte(7)];
-        let cached_vote_addresses =
-            vec![VoteAddress::with_last_byte(99), VoteAddress::with_last_byte(77)];
-        {
-            let mut cache = VALIDATOR_CACHE.lock().unwrap();
-            cache.insert(parent_hash, (cached_validators.clone(), cached_vote_addresses.clone()));
-        }
+        let resolved = epoch_validators_for_next_block(
+            &MockEthProvider::default(),
+            &Arc::new(BscChainSpec::from(bsc_mainnet())),
+            &snap,
+            &parent,
+        )
+        .expect("cache hit must not need the provider");
 
-        let parent_snap =
-            Snapshot::new(vec![Address::with_last_byte(1)], 799, B256::random(), 500, None);
-        let resolved =
-            resolve_epoch_validators(&parent_snap, &SealedHeader::seal_slow(parent_header)).unwrap();
-
-        assert_eq!(resolved.0, cached_validators);
-        assert_eq!(resolved.1, cached_vote_addresses);
+        assert_eq!(resolved, Some(expected));
     }
 
-    #[test]
-    fn resolve_epoch_validators_errors_when_no_cache_or_snapshot_validators() {
-        let parent_header = unique_parent_header(999);
-        let parent_snap = Snapshot::default();
+    /// A single-validator epoch block at height 2: `epoch_num = 2` makes it an epoch boundary
+    /// while staying under the height-3 short-circuit in `assemble_vote_attestation`. Bohr is not
+    /// enabled by `lorentz_chain_spec`, so no turn-length byte follows the validator records.
+    fn epoch_block_fixture() -> (Arc<Parlia<BscChainSpec>>, Snapshot, SealedHeader, Header) {
+        let parlia = Arc::new(Parlia::new(lorentz_chain_spec(), 200));
+        let parent = SealedHeader::seal_slow(Header {
+            number: 1,
+            timestamp: 1_776_727_552,
+            ..Default::default()
+        });
+        let validator = Address::with_last_byte(1);
+        let parent_snap = Snapshot::new(vec![validator], 1, parent.hash(), 2, None);
+        let header = Header {
+            number: 2,
+            parent_hash: parent.hash(),
+            beneficiary: validator,
+            timestamp: parent.timestamp() + 1,
+            extra_data: Bytes::from(vec![0u8; EXTRA_VANITY_LEN]),
+            ..Default::default()
+        };
+        (parlia, parent_snap, parent, header)
+    }
 
-        let err =
-            resolve_epoch_validators(&parent_snap, &SealedHeader::seal_slow(parent_header))
-                .unwrap_err();
+    /// Fail-closed at an epoch block: there is no fallback, because the only set reachable without
+    /// the parent's state (the snapshot's) is the *outgoing* one — sealing that would produce a
+    /// block the rest of the network rejects (bnb-chain/reth-bsc#465).
+    #[test]
+    fn finalize_new_header_rejects_an_epoch_block_without_validators() {
+        let (parlia, parent_snap, parent, mut header) = epoch_block_fixture();
+        let sp: Arc<dyn SnapshotProvider + Send + Sync> =
+            Arc::new(MockSnapshotProvider { snapshot: parent_snap.clone() });
+        let planned_ms = header.timestamp * 1000;
+
+        let err = finalize_new_header(
+            parlia,
+            &parent_snap,
+            &parent,
+            &mut header,
+            &sp,
+            planned_ms,
+            None,
+        )
+        .unwrap_err();
+
         match err {
             SignerError::SigningFailed(msg) => {
-                assert!(msg.contains("Missing epoch validators"), "unexpected message: {}", msg);
+                assert!(msg.contains("needs epoch validators"), "unexpected message: {msg}");
             }
-            other => panic!("unexpected error: {:?}", other),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// Whatever set the caller supplies is what the epoch block's extra data carries —
+    /// `finalize_new_header` no longer sources it itself.
+    #[test]
+    fn finalize_new_header_writes_the_supplied_epoch_validators() {
+        ensure_test_signer();
+        let (parlia, parent_snap, parent, mut header) = epoch_block_fixture();
+        let sp: Arc<dyn SnapshotProvider + Send + Sync> =
+            Arc::new(MockSnapshotProvider { snapshot: parent_snap.clone() });
+        let planned_ms = header.timestamp * 1000;
+        let mut validators = vec![Address::with_last_byte(9), Address::with_last_byte(7)];
+
+        finalize_new_header(
+            parlia,
+            &parent_snap,
+            &parent,
+            &mut header,
+            &sp,
+            planned_ms,
+            Some((validators.clone(), vec![VoteAddress::ZERO; validators.len()])),
+        )
+        .expect("finalize_new_header should succeed");
+
+        // Assert the layout, not mere presence: these addresses are 19 zero bytes plus one
+        // significant byte and sit among long zero runs, so a substring search matches by chance.
+        let payload = &header.extra_data[EXTRA_VANITY_LEN..];
+        assert_eq!(payload[0] as usize, validators.len(), "validator count");
+        validators.sort(); // prepare_validators sorts before writing
+        for (i, validator) in validators.iter().enumerate() {
+            let at = VALIDATOR_NUMBER_SIZE + i * VALIDATOR_BYTES_LEN_AFTER_LUBAN;
+            assert_eq!(&payload[at..at + 20], validator.as_slice(), "validator {i}");
         }
     }
 
@@ -895,6 +981,7 @@ mod tests {
             &mut header,
             &sp,
             planned_ms,
+            None, // block 2 is not an epoch block at epoch_num 500
         )
         .expect("finalize_new_header should succeed");
 

--- a/src/node/miner/util.rs
+++ b/src/node/miner/util.rs
@@ -24,12 +24,9 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::StateProviderFactory;
 use std::sync::Arc;
 
-/// The epoch validator set that block `parent_header.number + 1` must carry, or `None` when that
-/// block is not an epoch block.
+/// Returns the validator set for `parent_header.number + 1`, or `None` off the epoch boundary.
 ///
-/// Read on the parent's state and in the parent's env — see `CallBlockEnv`. Resolved here rather
-/// than in [`finalize_new_header`] so `simulate_bid_block` needs no state handle, and memoized under
-/// the parent hash, so sealing after the parent has executed reads no state.
+/// Reads under the parent's state/env and caches by `parent.hash()`.
 pub(crate) fn epoch_validators_for_next_block<C>(
     client: &C,
     chain_spec: &Arc<BscChainSpec>,
@@ -169,14 +166,9 @@ where
     new_header
 }
 
-/// finalize a new header and seal it.
+/// Finalize a new header and seal it.
 ///
-/// `block_timestamp_ms` is the millisecond timestamp decided by `prepare_timestamp` and
-/// cached on `MiningContext`.
-///
-/// `epoch_validators` is the set the block must carry when it is an epoch block, and `None`
-/// otherwise; an epoch block with `None` is rejected rather than sealed with a guess. Produced by
-/// `epoch_validators_for_next_block`.
+/// Epoch blocks require an explicit validator set from the caller.
 pub fn finalize_new_header<ChainSpec>(
     parlia: Arc<Parlia<ChainSpec>>,
     parent_snap: &Snapshot,

--- a/testing/bsc-ef-tests/tests/bid_block_harness.rs
+++ b/testing/bsc-ef-tests/tests/bid_block_harness.rs
@@ -392,6 +392,7 @@ fn round_trip_build_finalize_reexecute_agree() {
         &mut plain.header,
         &snapshot_provider,
         (parent.timestamp + 3) * 1000,
+        None, // not an epoch block
     )
     .expect("finalize header");
 
@@ -501,7 +502,7 @@ fn execution_gate_round_trip() {
         let BlockBuilderOutcome { execution_result, block, .. } = out;
         let senders = block.senders().to_vec();
         let mut plain = block.sealed_block().clone_block();
-        finalize_new_header(parlia.clone(), &genesis_snap, &genesis, &mut plain.header, &snapshot_provider, (genesis.timestamp + 3) * 1000)
+        finalize_new_header(parlia.clone(), &genesis_snap, &genesis, &mut plain.header, &snapshot_provider, (genesis.timestamp + 3) * 1000, None) // not an epoch block
             .expect("finalize b1");
         let output = BlockExecutionOutput { state: db.take_bundle(), result: execution_result };
         (RecoveredBlock::new_unhashed(plain, senders), output)
@@ -589,6 +590,7 @@ fn execution_gate_round_trip() {
         block1_sealed.gas_limit,
         alloy_primitives::Bytes::from(vec![0u8; 32]),
         (block1_sealed.timestamp + 3) * 1000,
+        None, // not an epoch block
     )
     .expect("simulate bid block");
 


### PR DESCRIPTION
### Description

Fix two intermittent validator-set bugs that only surface at epoch boundaries after restart or unwind invalidates the validator-set cache.

Affected cases:
* sealing an epoch block with validator bytes in `header.extra` derived from the wrong source
* re-validating an epoch block after a cache miss with the validator set recomputed in the current block env instead of the parent block env

### Rationale

The validator-set contract read is env-sensitive.

In `BSCValidatorSet.sol`, `getMiningValidators()` derives `shuffleNumber` from `block.number / 200` and uses it to shuffle the mining validator set. Evaluating the call at `N` vs `N-1` can therefore produce different validator sets at an epoch boundary.

Reference:
* [`getMiningValidators()` in `BSCValidatorSet.sol`](https://github.com/bnb-chain/bsc-genesis-contract/blob/master/contracts/BSCValidatorSet.sol#L351-L390)

Before this change:
* sealing could finalize an epoch header with validator bytes derived from the wrong context
* validation could fail after restart or unwind because a cache miss recomputed the validator set in the current block env

### Example

* Validator path: an epoch-boundary block can be sealed with the wrong validator bytes and get rejected by peers.
* Fullnode path: the node can get stuck like [#465](https://github.com/bnb-chain/reth-bsc/issues/465) and keep failing epoch-block validation after restart or unwind.

Temporary workaround:
* stop the node
* run `reth-bsc stage unwind --chain bsc --datadir <dir>  --to-block <stuck_block - 2>`
* start the node and retry synchronization

### Changes

* `src/node/evm/pre_execution.rs`: fix epoch-boundary validator reads in validation.
* `src/node/miner/util.rs`: fix epoch-boundary validator resolution in sealing.
* `src/node/miner/payload.rs`, `src/node/miner/bid_*`, `src/node/evm/post_execution.rs`: keep sealing and cache updates on the same validator-set source.
* `src/node/evm/pre_execution_tests.rs`, `src/node/miner/util.rs`: add regression coverage for parent-context reads and cache-miss sealing.

### Potential Impacts
N/A.
