### PR TITLE
fix(network): stop requiring the bsc subprotocol handshake

### DIFF
--- a/src/node/network/bsc_protocol/stream.rs
+++ b/src/node/network/bsc_protocol/stream.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::bytes::BytesMut;
 use alloy_rlp::{Decodable, Encodable};
 use bytes::Bytes;
-use futures::Future;
 use futures::{Stream, StreamExt};
 use reth_eth_wire::multiplex::ProtocolConnection;
 use reth_network_api::PeerId;
@@ -11,11 +10,9 @@ use std::{
     task::{ready, Context, Poll},
 };
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
-use tokio::time::{Duration, Sleep};
+use tokio::time::Duration;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-/// Handshake timeout, mirroring the Go implementation.
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 /// TTL for pending range requests before being pruned
 const PENDING_REQ_TTL: Duration = Duration::from_secs(15);
 /// Minimum interval between pending-request pruning passes
@@ -44,17 +41,19 @@ pub enum BscCommand {
     BlocksByRange(BlocksByRangePacket),
 }
 
+/// In-flight `GetBlocksByRange` requests, keyed by request id, each with the
+/// waiter to resolve and the instant it was issued (for TTL pruning).
+type PendingRangeReqs =
+    HashMap<u64, (oneshot::Sender<Result<BlocksByRangePacket, String>>, std::time::Instant)>;
+
 /// Stream that handles incoming BSC protocol messages and returns outgoing messages to send.
 pub struct BscProtocolConnection {
     conn: ProtocolConnection,
     commands: UnboundedReceiverStream<BscCommand>,
-    handshake_deadline: Option<std::pin::Pin<Box<Sleep>>>,
-    handshake_completed: bool,
     is_dialer: bool,
     initial_capability: Option<BscCommand>,
     /// Pending in-flight GetBlocksByRange requests mapped by request_id
-    pending_range_reqs:
-        HashMap<u64, (oneshot::Sender<Result<BlocksByRangePacket, String>>, std::time::Instant)>,
+    pending_range_reqs: PendingRangeReqs,
     /// Protocol version negotiated for this connection (1 or 2)
     proto_version: u64,
     /// PeerId for this connection, if known
@@ -71,8 +70,10 @@ impl BscProtocolConnection {
         proto_version: u64,
         peer_id: Option<PeerId>,
     ) -> Self {
-        let handshake_deadline = Some(Box::pin(tokio::time::sleep(HANDSHAKE_TIMEOUT)));
-        // Both sides should send initial capability in BSC protocol
+        // We still send the capability packet as our first frame: nodes older than
+        // bsc#3483 block on reading it before they will talk to us. Peers on
+        // bsc#3737 and later no longer send one, and drop ours in their no-op
+        // `handleBscCap`, so sending it stays safe across every peer generation.
         // BSC sends []byte{00} which in RLP is encoded as a single byte 0x00
         let initial_capability = Some(BscCommand::Capability {
             protocol_version: proto_version,
@@ -82,8 +83,6 @@ impl BscProtocolConnection {
         Self {
             conn,
             commands: UnboundedReceiverStream::new(commands),
-            handshake_deadline,
-            handshake_completed: false,
             is_dialer,
             initial_capability,
             pending_range_reqs: HashMap::new(),
@@ -217,73 +216,43 @@ impl BscProtocolConnection {
         Poll::Ready(Some(Some(raw)))
     }
 
-    /// Handle handshake-related frames
-    fn handle_handshake_frame(
-        &mut self,
-        frame: &BytesMut,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Option<BytesMut>>> {
-        tracing::debug!(target: "bsc_protocol", "Handshake not completed, processing handshake frame");
-        // Check for handshake timeout
-        if let Some(deadline) = self.handshake_deadline.as_mut() {
-            if Future::poll(deadline.as_mut(), cx).is_ready() {
-                tracing::warn!(target: "bsc_protocol", "BSC handshake timed out");
-                return Poll::Ready(None);
-            }
-        }
-
-        let slice = frame.as_ref();
-        let msg_id = slice[0];
-
-        tracing::debug!(target: "bsc_protocol", "Handshake not completed, processing handshake frame, msg_id: {:?}", msg_id);
-        if msg_id != BscProtoMessageId::Capability as u8 {
-            tracing::warn!(target: "bsc_protocol", got = format_args!("{:#04x}", msg_id), "Expected capability during handshake");
-            return Poll::Ready(None);
-        }
-
-        // Debug: Show what we received
-        tracing::trace!(
-            target: "bsc_protocol",
-            frame_len = slice.len(),
-            frame_bytes = format!("{:02x?}", &slice[..slice.len().min(16)]),
-            "Raw received frame in handshake"
-        );
-
-        match BscCapPacket::decode(&mut &slice[..]) {
-            Ok(pkt) => {
-                if pkt.protocol_version != self.proto_version {
-                    tracing::warn!(target: "bsc_protocol", "Protocol version mismatch: {} != {}", pkt.protocol_version, self.proto_version);
-                    return Poll::Ready(None);
-                }
-
-                tracing::trace!(target: "bsc_protocol", version = pkt.protocol_version, "Received peer capability");
-
-                tracing::trace!(
-                    target: "bsc_protocol",
-                    is_dialer = self.is_dialer,
-                    "BSC handshake completed successfully"
-                );
-
-                self.handshake_completed = true;
-                self.handshake_deadline = None;
-                tracing::trace!(target: "bsc_protocol", "BSC handshake completed");
-                Poll::Ready(Some(None))
-            }
-            Err(e) => {
-                tracing::warn!(target: "bsc_protocol", error = %e, "Failed to decode BSC capability during handshake");
-                Poll::Ready(None)
-            }
-        }
+    /// Handle an inbound protocol message.
+    ///
+    /// Thin wrapper over [`Self::dispatch`] so the dispatch path can be
+    /// exercised without a [`ProtocolConnection`], which has no public
+    /// constructor.
+    fn handle_protocol_message(&mut self, frame: &BytesMut) -> Option<BytesMut> {
+        Self::dispatch(frame, &mut self.pending_range_reqs, self._peer_id, self.proto_version)
     }
 
-    /// Handle normal protocol messages after handshake
-    fn handle_protocol_message(&mut self, frame: &BytesMut) -> Option<BytesMut> {
-        tracing::trace!(target: "bsc_protocol", "Handshake completed, processing normal message");
+    /// Route one inbound frame by message id, returning a frame to send back if
+    /// the message requires a reply.
+    ///
+    /// There is deliberately no handshake gate here. The `bsc` subprotocol used
+    /// to require `Capability` (0x00) as the first inbound frame, but bsc#3483
+    /// removed the blocking read and bsc#3737 stops sending the packet
+    /// altogether, so a peer's first frame is normally `Votes`. Rejecting that
+    /// tore down the whole RLPx session — a satellite stream ending drops the
+    /// `eth` primary with it — so 0x00 is now ignored exactly like geth's
+    /// no-op `handleBscCap`.
+    fn dispatch(
+        frame: &BytesMut,
+        pending_range_reqs: &mut PendingRangeReqs,
+        peer_id: Option<PeerId>,
+        proto_version: u64,
+    ) -> Option<BytesMut> {
         let slice = frame.as_ref();
         let msg_id = slice[0];
 
-        tracing::trace!(target: "bsc_protocol", "Handshake completed, processing normal message, msg_id: {:?}", msg_id);
+        tracing::trace!(target: "bsc_protocol", msg_id = format_args!("{msg_id:#04x}"), "Processing message");
         match msg_id {
+            x if x == BscProtoMessageId::Capability as u8 => {
+                // Legacy handshake packet. Peers older than bsc#3737 still send
+                // it; the version it carries was only ever a restatement of the
+                // devp2p-negotiated version we already hold, so drop it.
+                tracing::trace!(target: "bsc_protocol", peer = ?peer_id, "Ignoring legacy BSC capability message");
+                None
+            }
             x if x == BscProtoMessageId::Votes as u8 => {
                 tracing::trace!(target: "bsc_protocol", "Processing votes message");
                 match VotesPacket::decode(&mut &slice[..]) {
@@ -335,7 +304,7 @@ impl BscProtocolConnection {
                             blocks = res.blocks.len(),
                             "Received BlocksByRange"
                         );
-                        if let Some((waiter, _)) = self.pending_range_reqs.remove(&res.request_id) {
+                        if let Some((waiter, _)) = pending_range_reqs.remove(&res.request_id) {
                             let _ = waiter.send(Ok(res));
                         } else {
                             tracing::trace!(target: "bsc_protocol", "No waiter for request_id; dropping BlocksByRange");
@@ -350,14 +319,14 @@ impl BscProtocolConnection {
                         tracing::warn!(
                             target: "bsc_protocol",
                             error = %err.error,
-                            peer = ?self._peer_id,
-                            proto_version = self.proto_version,
+                            peer = ?peer_id,
+                            proto_version,
                             frame_len = slice.len(),
                             request_id = ?err.request_id,
                             "Failed to decode BlocksByRangePacket"
                         );
                         if let Some(req_id) = err.request_id {
-                            if let Some((waiter, _)) = self.pending_range_reqs.remove(&req_id) {
+                            if let Some((waiter, _)) = pending_range_reqs.remove(&req_id) {
                                 let _ = waiter.send(Err(format!(
                                     "failed to decode BlocksByRangePacket: {}",
                                     err.error
@@ -406,21 +375,156 @@ impl Stream for BscProtocolConnection {
                 Poll::Pending => return Poll::Pending,
             };
 
-            // Process the frame based on handshake state
-            if !this.handshake_completed {
-                match this.handle_handshake_frame(&raw_frame, cx) {
-                    Poll::Ready(Some(Some(response))) => return Poll::Ready(Some(response)),
-                    Poll::Ready(Some(None)) => continue, // Handshake complete, no response needed
-                    Poll::Ready(None) => return Poll::Ready(None), // Handshake failed
-                    Poll::Pending => return Poll::Pending,
-                }
-            } else if let Some(response) = this.handle_protocol_message(&raw_frame) {
+            if let Some(response) = this.handle_protocol_message(&raw_frame) {
                 return Poll::Ready(Some(response));
-            } else {
-                // After handshake, check if there are more messages to process
-                // If not, we'll loop back and check for commands/incoming frames
-                continue;
             }
+            // No reply needed; loop back for more commands/incoming frames.
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consensus::parlia::{
+        vote::{VoteData, VoteEnvelope},
+        votes,
+    };
+    use alloy_primitives::{FixedBytes, B256};
+
+    /// `ProtocolConnection` has no public constructor, so these tests drive
+    /// [`BscProtocolConnection::dispatch`] directly. That is the function the
+    /// deleted handshake gate used to sit in front of.
+    fn dispatch(frame: &BytesMut) -> Option<BytesMut> {
+        let mut pending = HashMap::new();
+        BscProtocolConnection::dispatch(frame, &mut pending, None, 2)
+    }
+
+    fn frame_of(msg: impl Encodable) -> BytesMut {
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf);
+        buf
+    }
+
+    fn cap_frame(protocol_version: u64) -> BytesMut {
+        frame_of(BscCapPacket { protocol_version, extra: Bytes::from_static(&[0x00u8]) })
+    }
+
+    /// A synthetic vote. Signature/address are never verified on this path, and
+    /// `target_number` is kept high so vote-pool pruning cannot evict it.
+    fn vote(target_number: u64, target_hash: B256) -> VoteEnvelope {
+        VoteEnvelope {
+            vote_address: FixedBytes::<48>::repeat_byte(0xab),
+            signature: FixedBytes::<96>::repeat_byte(0xcd),
+            data: VoteData {
+                source_number: target_number - 1,
+                source_hash: B256::repeat_byte(0x11),
+                target_number,
+                target_hash,
+            },
+        }
+    }
+
+    // === The bsc#3737 peer generation ===
+
+    /// A peer on bsc#3737 sends no capability packet at all, so its first frame
+    /// is a vote. The old handshake gate answered that with `Poll::Ready(None)`,
+    /// which ended the satellite stream and took the whole RLPx session (`eth`
+    /// included) down with it. It must now be processed normally.
+    #[test]
+    fn votes_as_very_first_frame_are_processed() {
+        let target_hash = B256::repeat_byte(0x5a);
+        let before = votes::len();
+
+        let reply = dispatch(&frame_of(VotesPacket(vec![vote(30_000_000, target_hash)])));
+
+        assert!(reply.is_none(), "a votes frame needs no reply");
+        assert_eq!(votes::len(), before + 1, "the vote must reach the pool");
+    }
+
+    /// Same peer generation, but the first frame is a range request. The old
+    /// gate dropped the session here too, which is what broke fork recovery.
+    #[test]
+    fn get_blocks_by_range_as_very_first_frame_is_answered() {
+        let req = GetBlocksByRangePacket {
+            request_id: 0xfeed,
+            start_block_height: 1,
+            start_block_hash: B256::repeat_byte(0x22),
+            count: 1,
+        };
+
+        let reply = dispatch(&frame_of(req)).expect("a range request must be answered");
+
+        assert_eq!(reply[0], BscProtoMessageId::BlocksByRange as u8);
+        let decoded =
+            crate::node::network::blocks_by_range::decode_blocks_by_range(&mut &reply[..])
+                .expect("reply must decode");
+        assert_eq!(decoded.request_id, 0xfeed, "reply must echo the request id");
+    }
+
+    // === Legacy capability packet: tolerated, never fatal ===
+
+    /// Peers older than bsc#3737 still send the packet. Ignore it, as geth's
+    /// no-op `handleBscCap` does.
+    #[test]
+    fn legacy_capability_frame_is_ignored() {
+        assert!(dispatch(&cap_frame(2)).is_none());
+    }
+
+    /// The old gate tore the session down on a version mismatch. The devp2p
+    /// `Hello` exchange already fixed the version, so this packet's copy of it
+    /// carries no authority and a disagreement must not be fatal.
+    #[test]
+    fn capability_frame_with_mismatched_version_is_ignored() {
+        assert!(dispatch(&cap_frame(1)).is_none(), "version 1 cap on a v2 conn");
+        assert!(dispatch(&cap_frame(99)).is_none(), "nonsense version");
+    }
+
+    /// The old gate also tore the session down when the packet failed to decode.
+    /// We no longer decode it at all, so a truncated or garbage body is inert.
+    #[test]
+    fn malformed_capability_frame_is_ignored() {
+        let mut truncated = cap_frame(2);
+        truncated.truncate(2);
+        assert!(dispatch(&truncated).is_none(), "truncated cap payload");
+
+        let bare_id = BytesMut::from(&[BscProtoMessageId::Capability as u8][..]);
+        assert!(dispatch(&bare_id).is_none(), "message id with no payload");
+    }
+
+    // === Unchanged behaviour, guarded against the refactor ===
+
+    #[test]
+    fn blocks_by_range_resolves_the_pending_waiter() {
+        let (tx, rx) = oneshot::channel();
+        let mut pending = HashMap::new();
+        pending.insert(7u64, (tx, std::time::Instant::now()));
+
+        let frame = frame_of(BlocksByRangePacket { request_id: 7, blocks: Vec::new() });
+        let reply = BscProtocolConnection::dispatch(&frame, &mut pending, None, 2);
+
+        assert!(reply.is_none(), "a range response needs no reply");
+        assert!(pending.is_empty(), "the waiter must be consumed");
+        let resolved = rx.blocking_recv().expect("waiter must be resolved");
+        assert_eq!(resolved.expect("response must be Ok").request_id, 7);
+    }
+
+    #[test]
+    fn unknown_message_id_is_ignored() {
+        assert!(dispatch(&BytesMut::from(&[0x7fu8, 0xc0][..])).is_none());
+    }
+
+    /// We must keep *sending* the capability packet: nodes older than bsc#3483
+    /// block on reading it. Guards the frame we put on the wire first.
+    #[test]
+    fn outbound_capability_frame_is_still_well_formed() {
+        let encoded = BscProtocolConnection::encode_command(BscCommand::Capability {
+            protocol_version: 2,
+            extra: Bytes::from_static(&[0x00u8]),
+        });
+
+        assert_eq!(encoded[0], BscProtoMessageId::Capability as u8);
+        let decoded = BscCapPacket::decode(&mut &encoded[..]).expect("must round-trip");
+        assert_eq!(decoded.protocol_version, 2);
     }
 }

--- a/src/system_contracts/mod.rs
+++ b/src/system_contracts/mod.rs
@@ -710,16 +710,15 @@ fn hardfork_to_dir_name(hardfork: &BscHardfork) -> Result<String, SystemContract
 fn read_all_system_contracts(
     spec: &ChainSpec,
 ) -> HashMap<String, HashMap<Address, Option<Bytecode>>> {
-    let dir: String;
-    if spec.chain.eq(&Chain::bsc_mainnet()) {
-        dir = "mainnet".to_string();
+    let dir: String = if spec.chain.eq(&Chain::bsc_mainnet()) {
+        "mainnet".to_string()
     } else if spec.chain.eq(&Chain::bsc_testnet()) {
-        dir = "chapel".to_string();
+        "chapel".to_string()
     } else if spec.chain.eq(&Chain::from_id(714)) {
-        dir = "rialto".to_string();
+        "rialto".to_string()
     } else {
         panic!("invalid spec");
-    }
+    };
 
     let all_contracts = get_all_system_contracts();
     let hardforks = hardforks_with_system_contracts();


### PR DESCRIPTION
### Description

Removes the inbound handshake gate from the `bsc` satellite subprotocol. Message `0x00` (`BscCapMsg`) is no longer required as a peer's first frame — it is now ignored when it arrives, matching geth's no-op `handleBscCap`. We continue to *send* the packet.

Also adds the first tests for `src/node/network/bsc_protocol/stream.rs`.

### Rationale

Upstream geth is dismantling this handshake in two steps:

* [bnb-chain/bsc#3483](https://github.com/bnb-chain/bsc/pull/3483) (merged 2025-12-12) replaced the blocking `Handshake()` with a fire-and-forget `SendBscCap()` and stopped waiting for the peer's packet.
* [bnb-chain/bsc#3737](https://github.com/bnb-chain/bsc/pull/3737) (open) stops sending the packet altogether, so `RunPeer` mirrors `snap`.

Our implementation still enforced the old strict semantics: `handle_handshake_frame` gated every inbound frame on `handshake_completed`, and returned `Poll::Ready(None)` if the first frame was not `0x00`, if the version disagreed, or if the payload failed to decode.

Against a peer on #3737 no capability packet ever arrives, so the first frame is normally a `VotesMsg` — which the gate rejected. **This is not contained to the `bsc` side channel.** A satellite stream returning `Poll::Ready(None)` ends the whole `RlpxSatelliteStream` (`crates/net/eth-wire/src/multiplex.rs:590` in the pinned reth), taking the `eth` primary down with it. The result is a connect/drop churn loop against every bsc-capable peer, costing block sync, vote propagation and `GetBlocksByRange` fork recovery.

#3483 already exposes us intermittently today: its bare `go func()` send can lose the race against geth's vote-broadcast loop, so the vote arrives first and we drop the peer. Symptom in logs is `Expected capability during handshake`.

Nothing is lost by dropping the check. The version the packet carried only restated what the devp2p `Hello` exchange already negotiated, and the version we actually act on comes from the selected connection handler (`register_peer(peer_id, tx, 1|2)`), never from this packet.

### Example

The frame sequence that used to kill the session, and now does not:

```
geth (#3737) → reth-bsc:  VotesMsg (0x01)          # no 0x00 is ever sent
before:                   "Expected capability during handshake" → session dropped (eth included)
after:                    vote ingested, session healthy
```

### Changes

Notable changes:

* `src/node/network/bsc_protocol/stream.rs`: removed `handshake_completed`, `handshake_deadline`, `HANDSHAKE_TIMEOUT` and `handle_handshake_frame`; `poll_next` no longer branches on handshake state.
* Added a `Capability` arm to the message dispatch that logs and ignores the packet.
* Kept the outbound capability packet as our first frame — nodes older than #3483 block on reading it, and #3737-and-later peers discard it in `handleBscCap`, so sending it is safe against every peer generation.
* Extracted the routing logic into an associated `dispatch(frame, pending_range_reqs, peer_id, proto_version)` so it can be tested without a `ProtocolConnection` (which has no public constructor); `handle_protocol_message` is now a one-line wrapper. No behaviour moved with it.
* Added a `PendingRangeReqs` type alias (satisfies `clippy::type_complexity` on the new signature).
* 8 new tests — the first in this file — covering all three geth generations (never-sends / async-races / sends the packet), plus the mismatched-version and malformed-packet cases the old gate treated as fatal, and the `BlocksByRange` waiter path as a refactor guard.

### Potential Impacts

* **Peer lifecycle:** connections are no longer torn down for handshake reasons. A misbehaving peer that sends garbage on the `bsc` channel is now ignored per-message rather than disconnected. This matches geth, where unknown codes are the only tear-down reason (`errInvalidMsgCode`).
* **Version enforcement:** we no longer cross-check the peer's claimed `bsc` version against ours. `is_v2_peer` / `list_v2_peers` are unaffected — they read the handler-supplied version from the devp2p negotiation.
* **Timeouts:** the 5s handshake deadline is gone. It was never an independent timer (only polled when a frame arrived, so a silent peer was never timed out, while a valid-but-late packet was rejected), so removing it changes nothing in practice.
* **Wire format:** unchanged. Same message ids, same `protocolLengths`, same encodings. No coordination needed on the geth side to merge this.
* **Rollout ordering:** this should land and deploy **before** bsc#3737 rolls out. It is compatible with all three geth generations, so it can go first safely. Conversely, geth cannot drop `0x00`/`handleBscCap` entirely until reth-bsc stops sending the packet — worth recording on #3737.

### Testing

* `RUSTFLAGS="-D warnings" cargo clippy --workspace --tests --all-features` — clean
* `cargo test --all -- --test-threads=1` — 453 lib + 6 harness tests, 0 failures (445 lib before, so all 8 new tests run)
* `cargo fmt` not run: the local nightly (rustfmt 1.10.0, 2026-08-11) reformats 110 files / ~4k lines on pristine `develop`, so CI pins an older one. Formatting was done by hand and verified against the repo's `rustfmt.toml` — 3 pre-existing hunks in this file before the change, 3 after, none added.

### Live validation on a 10-validator devnet

Verified against real nodes on the `node-deploy-bsc` harness, not only unit tests. Four binaries were built so that each axis differs by exactly one change:

| binary | provenance |
|---|---|
| reth pre-PR | `develop` @ 58dd11ec9 |
| reth with-PR | this branch @ 6a1060abc |
| geth "current" | the devnet's own geth, bnb-chain/bsc @ 46a496005 (contains #3483; **sends** `BscCapMsg`) |
| geth "future" | 46a496005 + #3737 cherry-picked — a 4-file, one-commit delta (**sends nothing**) |

Each binary was confirmed by its embedded strings: the pre-PR reth contains `Expected capability during handshake`, the with-PR one does not; geth-current contains `Failed to send bsc capability message` (from the deleted `handshake.go`), geth-future does not.

#### Case 1 — fully upgraded network (all geth on #3737)

reth pre-PR against six geth-future validators:

* `Expected capability during handshake` × 31, with `got=0x02` and `got=0x03`
* peers: reth **1** (only the other reth node) vs geth **5** (all geth, zero reth)
* **hard chain split** — at height 52600, reth held `0xcf17aebf…` while all six geth held `0xcf7066d9…`
* reth head **frozen at 52604** while geth advanced past 53444

The wedge mechanism is worth noting, because it is more severe than "loses votes". reth learned of geth's better chain from announcements but could not fetch the block range to compute total difficulty — every session died first — so fork choice failed permanently:

```
incoming_number=53437  current_number=52604
error=Unknown total difficulty for block 0x4c48… at number 53439
fork_choice_updated returned error after recovery
```

#### Case 2 — partially upgraded network (the realistic rollout)

One chain, 8 live nodes (max 7 peers each): node0 = reth pre-PR, node2 = reth with-PR, node4-6 = geth current, node7-9 = geth future.

| node | peers | reading |
|---|---|---|
| node0 (reth **pre-PR**) | **4** | 7 − 3: missing exactly the three geth-future nodes |
| node2 (reth **with-PR**) | **7** | connected to everything, geth-future included |
| node4,5,6 (geth current) | 7 | see everyone, node0 included |
| node7,8,9 (geth **future**) | **6** | 7 − 1: everyone **except** node0 |

The arithmetic corroborates from both sides independently — node0 loses exactly three peers, and each geth-future node loses exactly one, the same one. Logs: 16 `Expected capability during handshake` on node0, **0** on node2. Counts held constant from block ~250 to ~11,700.

Resulting matrix:

| | geth current | geth future (#3737) |
|---|---|---|
| reth pre-PR | ✓ connected | ✗ **cannot connect** |
| reth with-PR | ✓ connected | ✓ connected |

In this mixed case the pre-PR node degrades rather than forking (geth-current still relays blocks to it), trailing the chain by ~28 blocks. That is the quiet-degradation mode a staged mainnet upgrade would produce.

#### Correction to the Rationale above

The rationale says a post-#3737 peer's first frame "is normally `Votes`". In practice the frames that triggered the teardown were `0x02`/`0x03` — **`GetBlocksByRange` / `BlocksByRange`** — because a syncing node exchanges block-range traffic before any vote arrives. The bug therefore does not depend on BLS voting being active; any `bsc`-channel traffic triggers it. This widens the impact rather than narrowing it.

#### Limitations of this run

* The with-PR binary was measured against geth-future in the mixed case only; the all-geth-future configuration was never re-run against it after the devnet was reset.
* Two of the four reth validators were unavailable throughout (unrelated stuck processes holding their ports), so the mixed run used one reth node per flavour rather than two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

