### PR TITLE
chore: bump reth deps to include rpc deadlock fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7535,7 +7535,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7586,7 +7586,7 @@ dependencies = [
  "metrics",
  "reth-chain-state",
  "reth-execution-cache",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7620,7 +7620,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
@@ -7636,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7656,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7769,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7847,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7886,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7899,7 +7899,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -7915,7 +7915,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7941,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7990,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8015,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8028,7 +8028,7 @@ dependencies = [
  "rand 0.9.4",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
@@ -8039,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -8063,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8079,7 +8079,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -8098,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8149,7 +8149,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8174,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8201,7 +8201,7 @@ dependencies = [
  "reth-evm",
  "reth-execution-cache",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8263,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8328,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8342,7 +8342,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-peers",
  "reth-primitives-traits",
  "serde",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8382,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "clap",
  "eyre",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8437,7 +8437,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8481,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8495,7 +8495,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8518,7 +8518,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8550,14 +8550,14 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
  "metrics",
  "parking_lot",
  "reth-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8600,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8617,7 +8617,7 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8662,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "bindgen",
  "cc",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "futures",
  "metrics",
@@ -8762,7 +8762,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8771,7 +8771,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8785,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8816,7 +8816,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-net-banlist",
  "reth-network-api",
  "reth-network-p2p",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8891,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8906,7 +8906,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8937,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8961,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -9124,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9185,7 +9185,7 @@ dependencies = [
  "metrics-util",
  "procfs",
  "reqwest 0.13.4",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9219,7 +9219,7 @@ dependencies = [
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
  "reth-execution-cache",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -9232,7 +9232,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9244,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9268,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9333,7 +9333,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9370,7 +9370,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9418,7 +9418,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9461,7 +9461,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9541,7 +9541,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-api",
  "reth-node-core",
  "reth-payload-primitives",
@@ -9569,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9590,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9602,7 +9602,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9669,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9694,7 +9694,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -9718,7 +9718,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.1",
@@ -9732,7 +9732,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9828,7 +9828,7 @@ dependencies = [
  "reth-codecs",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9936,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -9946,7 +9946,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rayon",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "thiserror 2.0.18",
  "thread-priority",
  "tokio",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "clap",
  "eyre",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "clap",
  "eyre",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10040,7 +10040,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10073,7 +10073,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10116,14 +10116,14 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "metrics",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-api",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10150,7 +10150,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?tag=v0.1.2#f66079c21e934f51f65cfa7c60f254cd94a59e6c"
+source = "git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0#a6b5402140b7fe6d6b65f06ce73378d267da5eb0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10173,7 +10173,7 @@ dependencies = [
  "metrics",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
@@ -10271,7 +10271,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-ipc",
- "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?tag=v0.1.2)",
+ "reth-metrics 2.2.0 (git+https://github.com/bnb-chain/reth.git?rev=a6b5402140b7fe6d6b65f06ce73378d267da5eb0)",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,60 +16,60 @@ name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-cli = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-cli = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-cli-commands = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-basic-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-engine-local = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-engine-tree = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-node-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-cli-util = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-discv4 = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "test-utils",
 ] }
-reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "serde",
 ] }
-reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-ipc = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-metrics = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-node-core = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-network = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth-ethereum-payload-builder = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-payload-builder-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-chain-state = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-eth-wire = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-eth-wire-types = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-execution-types = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-ipc = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-metrics = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-node-core = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-network = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "test-utils",
 ] }
-reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-network-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth-network-p2p = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-network-api = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-node-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "test-utils",
 ] }
-reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
+reth-network-peers = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-payload-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-ethereum-engine-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
 reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2" }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "test-utils",
 ] }
-reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-tasks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
+reth-rpc-eth-api = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-rpc-convert = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-rpc-engine-api = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-rpc-server-types = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-trie-common = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-tasks = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-transaction-pool = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
 
 revm = "38.0.0"
 revm-database = "13.0.0"

--- a/testing/bsc-ef-tests/Cargo.toml
+++ b/testing/bsc-ef-tests/Cargo.toml
@@ -16,30 +16,30 @@ reth_bsc = { path = "../.." }
 rand = "0.9"
 
 # reth dependencies aligned with the root crate's reth tag to avoid duplicate crate versions
-reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth-chainspec = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-ethereum-forks = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-db = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "mdbx",
     "test-utils",
     "disable-lock",
 ] }
-reth-db-api = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-db-common = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-evm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
+reth-db-api = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-db-common = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-ethereum-consensus = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-ethereum-primitives = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-evm = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-evm-ethereum = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
 reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.3.1-v2", default-features = false }
-reth-provider = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth-provider = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "test-utils",
 ] }
-reth-revm = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2", features = [
+reth-revm = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0", features = [
     "std",
 ] }
-reth-tracing = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-trie = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
-reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", tag = "v0.1.2" }
+reth-tracing = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-trie = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
+reth-trie-db = { git = "https://github.com/bnb-chain/reth.git", rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0" }
 
 # revm
 revm = { version = "38.0.0", features = [


### PR DESCRIPTION
### Description

This change updates `reth-bsc` to the `bnb-chain/reth` commit that contains the RPC blocking-pool deadlock fix from [bnb-chain/reth#218](https://github.com/bnb-chain/reth/pull/218).

### Rationale

`reth-bsc` was still pinned to older `reth` sources and did not include the upstream RPC fix. Bumping both the root crate and `testing/bsc-ef-tests` to the same `reth` commit keeps the workspace consistent and brings in the deadlock fix.

### Example

Before:

* `reth-bsc` depended on older `reth` sources and did not include the RPC deadlock fix

After:

* `reth-bsc` and `testing/bsc-ef-tests` both depend on `bnb-chain/reth@a6b5402140b7fe6d6b65f06ce73378d267da5eb0`
* the workspace builds with the updated `reth` dependency set

### Changes

Notable changes:
* update root `reth` dependencies from `tag = "v0.1.2"` to `rev = "a6b5402140b7fe6d6b65f06ce73378d267da5eb0"`
* update `testing/bsc-ef-tests` to the same `reth` commit to avoid mixed workspace sources
* refresh `Cargo.lock` for the new `reth` source

### Potential Impacts

* pulls in the RPC deadlock fix from [bnb-chain/reth#218](https://github.com/bnb-chain/reth/pull/218)
* no intended behavior change beyond the `reth` dependency bump
