### PR TITLE
fix(parlia): resolve epoch checkpoints by parent hash and harden vote journal writes

### DIFF
--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -197,15 +197,9 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
         })
     }
 
-    /// Port of geth parlia's `FindAncientHeader`: walk ancestors by parent hash.
-    /// Never look up by number here - it resolves to whoever occupies that height, which on
-    /// a fork binds the snapshot to the *other* branch's epoch validators.
+    /// Walk ancestors by parent hash.
     fn find_ancient_header(&self, header: &Header, steps: u64) -> Option<Header> {
         (0..steps).try_fold(header.clone(), |h, _| {
-            // Re-check the hash: the by-hash fallback resolves HeaderNumbers[hash] ->
-            // Headers[number], a by-number read that can hand back another branch's header
-            // mid-reorg. The checkpoint is only parsed, never applied, so Snapshot::apply's
-            // parent-hash gate would not catch it.
             self.get_header_by_hash(&h.parent_hash).filter(|p| p.hash_slow() == h.parent_hash)
         })
     }

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -7,7 +7,7 @@ use crate::chainspec::BscChainSpec;
 
 use crate::consensus::parlia::{CHECKPOINT_INTERVAL, Parlia, VoteAddress};
 use crate::node::evm::error::{BscBlockExecutionError, BscBlockValidationError};
-use crate::node::evm::util::{get_cannonical_header_from_cache, get_header_by_hash_from_cache};
+use crate::node::evm::util::get_header_by_hash_from_cache;
 use alloy_primitives::{Address};
 use alloy_primitives::{BlockHash};
 
@@ -128,13 +128,6 @@ impl<DB: Database> DbSnapshotProvider<DB> {
         let block_number = tx.get::<HeaderNumbers>(*block_hash).ok()??;
         tx.get::<Headers<alloy_consensus::Header>>(block_number).ok()?
     }
-
-    /// Fetch a canonical header by block number directly from the DB.
-    /// Used as fallback when the in-memory header cache is empty (e.g. at startup).
-    fn get_canonical_header_by_number_from_db(&self, block_number: u64) -> Option<Header> {
-        let tx = self.db.tx().ok()?;
-        tx.get::<Headers<alloy_consensus::Header>>(block_number).ok()?
-    }
 }
 
 impl<DB: Database + 'static> SnapshotProvider for DbSnapshotProvider<DB> {
@@ -204,14 +197,17 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
         })
     }
 
-    /// Get canonical header by number: in-memory cache first, DB as fallback.
-    fn get_canonical_header_by_number(&self, number: u64) -> Option<Header> {
-        get_cannonical_header_from_cache(number).or_else(|| {
-            let h = self.base.get_canonical_header_by_number_from_db(number);
-            if h.is_some() {
-                tracing::debug!(target: "parlia::snapshot", "Canonical header cache miss, loaded from DB for number {}", number);
-            }
-            h
+    /// Port of geth `consensus/parlia/snapshot.go:582-607` `FindAncientHeader`.
+    /// Never look up by number here: it resolves to whoever occupies that height, which on
+    /// a fork binds the snapshot to the *other* branch's epoch validators.
+    /// `get_header_by_hash` covers `candidateParents` (`:588-597`); `None` == `:599-601`.
+    fn find_ancient_header(&self, header: &Header, ite: u64) -> Option<Header> {
+        (0..ite).try_fold(header.clone(), |h, _| {
+            // Re-check the hash: every by-hash fallback resolves
+            // `HeaderNumbers[hash] -> Headers[number]`, a by-number read that can hand back
+            // another branch's header mid-reorg. The checkpoint is only parsed, never
+            // applied, so `Snapshot::apply`'s parent-hash gate would not catch that.
+            self.get_header_by_hash(&h.parent_hash).filter(|p| p.hash_slow() == h.parent_hash)
         })
     }
 
@@ -285,31 +281,33 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
             let mut turn_length = None;
 
             let validators_info = if is_epoch_boundary {
-                let checkpoint_block_number = header.number - miner_check_len;
+                // geth snapshot.go:384-387
+                let Some(checkpoint_header) = self.find_ancient_header(&header, miner_check_len)
+                else {
+                    tracing::error!(target: "parlia::snapshot",
+                        "Unknown ancestor walking back to epoch checkpoint, block: {}, ite: {}",
+                        header.number, miner_check_len);
+                    return None; // geth: consensus.ErrUnknownAncestor
+                };
                 tracing::debug!("Updating validator set at epoch boundary, checkpoint_block: {}, current_block: {}",
-                    checkpoint_block_number, header.number);
+                    checkpoint_header.number, header.number);
 
-                if let Some(checkpoint_header) = self.get_canonical_header_by_number(checkpoint_block_number) {
-                    let parsed = 
-                        self.parlia.parse_validators_from_header(&checkpoint_header, working_snapshot.epoch_num)
-                            .map_err(|err| {
-                                tracing::error!("Failed to parse validators from checkpoint header: {:?}", err);
-                                err
-                            });
-                    
-                    turn_length = 
-                        self.parlia.get_turn_length_from_header(
-                            &checkpoint_header, 
-                            working_snapshot.epoch_num).map_err(|err| {
-                        tracing::error!("Failed to get turn length from checkpoint header, block_number: {}, checkpoint_block_number: {}, epoch_num: {}, error: {:?}", 
-                            header.number, checkpoint_block_number, working_snapshot.epoch_num, err);
-                        err
-                    }).ok()?;
-                    parsed
-                } else {
-                    tracing::error!("Failed to find checkpoint header for block {}", checkpoint_block_number);
-                    return None;
-                }
+                let parsed =
+                    self.parlia.parse_validators_from_header(&checkpoint_header, working_snapshot.epoch_num)
+                        .map_err(|err| {
+                            tracing::error!("Failed to parse validators from checkpoint header: {:?}", err);
+                            err
+                        });
+
+                turn_length =
+                    self.parlia.get_turn_length_from_header(
+                        &checkpoint_header,
+                        working_snapshot.epoch_num).map_err(|err| {
+                    tracing::error!("Failed to get turn length from checkpoint header, block_number: {}, checkpoint_block_number: {}, epoch_num: {}, error: {:?}",
+                        header.number, checkpoint_header.number, working_snapshot.epoch_num, err);
+                    err
+                }).ok()?;
+                parsed
             } else {
                 Ok(ValidatorsInfo {
                     consensus_addrs: Vec::new(),

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -197,15 +197,11 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
         })
     }
 
-    /// Port of geth parlia's `FindAncientHeader`: walk ancestors by parent hash.
-    /// Never look up by number here - it resolves to whoever occupies that height, which on
-    /// a fork binds the snapshot to the *other* branch's epoch validators.
+    /// Walk ancestors by parent hash.
+    /// Epoch checkpoints must stay on the branch being rebuilt.
     fn find_ancient_header(&self, header: &Header, ite: u64) -> Option<Header> {
         (0..ite).try_fold(header.clone(), |h, _| {
-            // Re-check the hash: the by-hash fallback resolves HeaderNumbers[hash] ->
-            // Headers[number], a by-number read that can hand back another branch's header
-            // mid-reorg. The checkpoint is only parsed, never applied, so Snapshot::apply's
-            // parent-hash gate would not catch it.
+            // Re-check the returned hash because DB fallback resolves by hash -> number -> header.
             self.get_header_by_hash(&h.parent_hash).filter(|p| p.hash_slow() == h.parent_hash)
         })
     }

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -197,16 +197,15 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
         })
     }
 
-    /// Port of geth `consensus/parlia/snapshot.go:582-607` `FindAncientHeader`.
-    /// Never look up by number here: it resolves to whoever occupies that height, which on
+    /// Port of geth parlia's `FindAncientHeader`: walk ancestors by parent hash.
+    /// Never look up by number here - it resolves to whoever occupies that height, which on
     /// a fork binds the snapshot to the *other* branch's epoch validators.
-    /// `get_header_by_hash` covers `candidateParents` (`:588-597`); `None` == `:599-601`.
     fn find_ancient_header(&self, header: &Header, ite: u64) -> Option<Header> {
         (0..ite).try_fold(header.clone(), |h, _| {
-            // Re-check the hash: every by-hash fallback resolves
-            // `HeaderNumbers[hash] -> Headers[number]`, a by-number read that can hand back
-            // another branch's header mid-reorg. The checkpoint is only parsed, never
-            // applied, so `Snapshot::apply`'s parent-hash gate would not catch that.
+            // Re-check the hash: the by-hash fallback resolves HeaderNumbers[hash] ->
+            // Headers[number], a by-number read that can hand back another branch's header
+            // mid-reorg. The checkpoint is only parsed, never applied, so Snapshot::apply's
+            // parent-hash gate would not catch it.
             self.get_header_by_hash(&h.parent_hash).filter(|p| p.hash_slow() == h.parent_hash)
         })
     }
@@ -281,7 +280,6 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
             let mut turn_length = None;
 
             let validators_info = if is_epoch_boundary {
-                // geth snapshot.go:384-387
                 let Some(checkpoint_header) = self.find_ancient_header(&header, miner_check_len)
                 else {
                     tracing::error!(target: "parlia::snapshot",

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -197,8 +197,15 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
         })
     }
 
+    /// Port of geth parlia's `FindAncientHeader`: walk ancestors by parent hash.
+    /// Never look up by number here - it resolves to whoever occupies that height, which on
+    /// a fork binds the snapshot to the *other* branch's epoch validators.
     fn find_ancient_header(&self, header: &Header, steps: u64) -> Option<Header> {
         (0..steps).try_fold(header.clone(), |h, _| {
+            // Re-check the hash: the by-hash fallback resolves HeaderNumbers[hash] ->
+            // Headers[number], a by-number read that can hand back another branch's header
+            // mid-reorg. The checkpoint is only parsed, never applied, so Snapshot::apply's
+            // parent-hash gate would not catch it.
             self.get_header_by_hash(&h.parent_hash).filter(|p| p.hash_slow() == h.parent_hash)
         })
     }
@@ -278,7 +285,7 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
                     tracing::error!(target: "parlia::snapshot",
                         "Unknown ancestor walking back to epoch checkpoint, block: {}, steps: {}",
                         header.number, miner_check_len);
-                    return None;
+                    return None; // geth: consensus.ErrUnknownAncestor
                 };
                 tracing::debug!("Updating validator set at epoch boundary, checkpoint_block: {}, current_block: {}",
                     checkpoint_header.number, header.number);
@@ -315,6 +322,7 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
                 err
             }).ok()?;
 
+            // Apply header to snapshot
             working_snapshot = match working_snapshot.apply(
                 header.beneficiary,
                 &header,

--- a/src/consensus/parlia/provider.rs
+++ b/src/consensus/parlia/provider.rs
@@ -197,11 +197,8 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
         })
     }
 
-    /// Walk ancestors by parent hash.
-    /// Epoch checkpoints must stay on the branch being rebuilt.
-    fn find_ancient_header(&self, header: &Header, ite: u64) -> Option<Header> {
-        (0..ite).try_fold(header.clone(), |h, _| {
-            // Re-check the returned hash because DB fallback resolves by hash -> number -> header.
+    fn find_ancient_header(&self, header: &Header, steps: u64) -> Option<Header> {
+        (0..steps).try_fold(header.clone(), |h, _| {
             self.get_header_by_hash(&h.parent_hash).filter(|p| p.hash_slow() == h.parent_hash)
         })
     }
@@ -279,9 +276,9 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
                 let Some(checkpoint_header) = self.find_ancient_header(&header, miner_check_len)
                 else {
                     tracing::error!(target: "parlia::snapshot",
-                        "Unknown ancestor walking back to epoch checkpoint, block: {}, ite: {}",
+                        "Unknown ancestor walking back to epoch checkpoint, block: {}, steps: {}",
                         header.number, miner_check_len);
-                    return None; // geth: consensus.ErrUnknownAncestor
+                    return None;
                 };
                 tracing::debug!("Updating validator set at epoch boundary, checkpoint_block: {}, current_block: {}",
                     checkpoint_header.number, header.number);
@@ -318,7 +315,6 @@ impl<DB: Database + 'static> EnhancedDbSnapshotProvider<DB> {
                 err
             }).ok()?;
 
-            // Apply header to snapshot
             working_snapshot = match working_snapshot.apply(
                 header.beneficiary,
                 &header,

--- a/src/consensus/parlia/snapshot.rs
+++ b/src/consensus/parlia/snapshot.rs
@@ -155,8 +155,8 @@ impl Snapshot {
         ChainSpec: crate::hardforks::BscHardforks,
     {
         let block_number = next_header.number();
-        // geth snapshot.go:299-302 gates on number *and* parent hash; number alone lets a
-        // competing branch's sibling apply onto this snapshot.
+        // Gate on number *and* parent hash (geth parlia snapshot.go apply): number alone
+        // lets a competing branch's sibling apply onto this snapshot.
         if self.block_number + 1 != block_number || self.block_hash != next_header.parent_hash() {
             return None;
         }

--- a/src/consensus/parlia/snapshot.rs
+++ b/src/consensus/parlia/snapshot.rs
@@ -155,24 +155,20 @@ impl Snapshot {
         ChainSpec: crate::hardforks::BscHardforks,
     {
         let block_number = next_header.number();
-        // Require both number and parent-hash continuity.
         if self.block_number + 1 != block_number || self.block_hash != next_header.parent_hash() {
             return None;
         }
 
-        // Clone base.
         let original_snap = self.clone();
         let mut snap = self.clone();
         snap.block_hash = next_header.hash_slow();
         snap.block_number = block_number;
 
-        // Maintain recent proposer window.
         let limit = self.miner_history_check_len() + 1;
         if block_number >= limit {
             snap.recent_proposers.remove(&(block_number - limit));
         }
 
-        // Maintain recent fork hash window.
         let version_limit = self.version_history_check_len();
         if block_number >= version_limit {
             snap.recent_fork_hashes.remove(&(block_number - version_limit));

--- a/src/consensus/parlia/snapshot.rs
+++ b/src/consensus/parlia/snapshot.rs
@@ -155,20 +155,25 @@ impl Snapshot {
         ChainSpec: crate::hardforks::BscHardforks,
     {
         let block_number = next_header.number();
+        // Gate on number *and* parent hash (geth parlia snapshot.go apply): number alone
+        // lets a competing branch's sibling apply onto this snapshot.
         if self.block_number + 1 != block_number || self.block_hash != next_header.parent_hash() {
             return None;
         }
 
+        // Clone base.
         let original_snap = self.clone();
         let mut snap = self.clone();
         snap.block_hash = next_header.hash_slow();
         snap.block_number = block_number;
 
+        // Maintain recent proposer window.
         let limit = self.miner_history_check_len() + 1;
         if block_number >= limit {
             snap.recent_proposers.remove(&(block_number - limit));
         }
 
+        // Maintain recent fork hash window.
         let version_limit = self.version_history_check_len();
         if block_number >= version_limit {
             snap.recent_fork_hashes.remove(&(block_number - version_limit));

--- a/src/consensus/parlia/snapshot.rs
+++ b/src/consensus/parlia/snapshot.rs
@@ -155,10 +155,8 @@ impl Snapshot {
         ChainSpec: crate::hardforks::BscHardforks,
     {
         let block_number = next_header.number();
-        // Gate on number *and* parent hash (geth parlia snapshot.go apply): number alone
-        // lets a competing branch's sibling apply onto this snapshot.
         if self.block_number + 1 != block_number || self.block_hash != next_header.parent_hash() {
-            return None;
+            return None; // non-continuous block
         }
 
         // Clone base.
@@ -670,7 +668,7 @@ mod tests {
 
         let header = MockHeader {
             number: 1,
-            parent_hash: block_hash, // apply() gates on parent hash
+            parent_hash: block_hash,
             beneficiary: validators[0],
             extra_data: alloy_primitives::Bytes::new(),
         };

--- a/src/consensus/parlia/snapshot.rs
+++ b/src/consensus/parlia/snapshot.rs
@@ -155,8 +155,7 @@ impl Snapshot {
         ChainSpec: crate::hardforks::BscHardforks,
     {
         let block_number = next_header.number();
-        // Gate on number *and* parent hash (geth parlia snapshot.go apply): number alone
-        // lets a competing branch's sibling apply onto this snapshot.
+        // Require both number and parent-hash continuity.
         if self.block_number + 1 != block_number || self.block_hash != next_header.parent_hash() {
             return None;
         }

--- a/src/consensus/parlia/snapshot.rs
+++ b/src/consensus/parlia/snapshot.rs
@@ -155,8 +155,10 @@ impl Snapshot {
         ChainSpec: crate::hardforks::BscHardforks,
     {
         let block_number = next_header.number();
-        if self.block_number + 1 != block_number {
-            return None; // non-continuous block
+        // geth snapshot.go:299-302 gates on number *and* parent hash; number alone lets a
+        // competing branch's sibling apply onto this snapshot.
+        if self.block_number + 1 != block_number || self.block_hash != next_header.parent_hash() {
+            return None;
         }
 
         // Clone base.
@@ -583,6 +585,7 @@ mod tests {
         // Create a mock header for apply operation
         struct MockHeader {
             number: u64,
+            parent_hash: alloy_primitives::B256,
             beneficiary: Address,
             extra_data: alloy_primitives::Bytes,
         }
@@ -625,7 +628,7 @@ mod tests {
                 alloy_primitives::Bloom::ZERO
             }
             fn parent_hash(&self) -> alloy_primitives::B256 {
-                alloy_primitives::B256::ZERO
+                self.parent_hash
             }
             fn ommers_hash(&self) -> alloy_primitives::B256 {
                 alloy_primitives::B256::ZERO
@@ -667,6 +670,7 @@ mod tests {
 
         let header = MockHeader {
             number: 1,
+            parent_hash: block_hash, // apply() gates on parent hash
             beneficiary: validators[0],
             extra_data: alloy_primitives::Bytes::new(),
         };

--- a/src/consensus/parlia/tests/mod.rs
+++ b/src/consensus/parlia/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Unit tests for Parlia consensus implementation.
 
+mod rebuild_fork_checkpoint;
 mod snapshot_persistence;
 mod validator_tests;

--- a/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
+++ b/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
@@ -1,0 +1,84 @@
+//! Regression: the epoch checkpoint must be reached by `parent_hash`, not by block number
+//! (geth `consensus/parlia/snapshot.go:384` `FindAncientHeader`). The by-number header cache
+//! can hold a rejected sibling, which on a fork loads the other branch's validators.
+
+use super::super::{
+    provider::{EnhancedDbSnapshotProvider, SnapshotProvider},
+    snapshot::Snapshot,
+};
+use super::snapshot_persistence::TestCleanup;
+use crate::chainspec::{bsc_testnet, BscChainSpec};
+use crate::consensus::parlia::constants::{EXTRA_SEAL_LEN, EXTRA_VANITY_LEN};
+use crate::hardforks::BscHardforks;
+use crate::node::evm::util::insert_header_to_cache_with_hash;
+use alloy_consensus::Header;
+use alloy_primitives::{Address, B256};
+use reth_db::{init_db, mdbx::DatabaseArguments};
+use std::sync::Arc;
+use uuid::Uuid;
+
+const EPOCH: u64 = 200;
+const CHECKPOINT: u64 = 200;
+/// +2 because 5 validators, turn_length 1 => miner_history_check_len == 2. Two hops, so an
+/// off-by-one in the walk is caught.
+const TRANSITION: u64 = CHECKPOINT + 2;
+
+fn addrs(seed: u8) -> Vec<Address> {
+    (0..5u8).map(|i| Address::repeat_byte(seed + i)).collect()
+}
+
+/// Empty `validators` -> plain header; otherwise a pre-Luban epoch checkpoint.
+fn header(number: u64, parent: B256, validators: &[Address]) -> Header {
+    let mut extra = vec![0u8; EXTRA_VANITY_LEN];
+    validators.iter().for_each(|v| extra.extend_from_slice(v.as_slice()));
+    extra.extend_from_slice(&[0u8; EXTRA_SEAL_LEN]);
+    Header {
+        number,
+        parent_hash: parent,
+        beneficiary: Address::repeat_byte(0x10),
+        extra_data: extra.into(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> {
+    let db_path = std::env::temp_dir().join(format!("bsc_fork_checkpoint_{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&db_path)?;
+    let _cleanup = TestCleanup { path: db_path.clone() };
+    let db = init_db(&db_path, DatabaseArguments::new(Default::default()))?;
+    let chain_spec = Arc::new(BscChainSpec::from(bsc_testnet()));
+    // Both matter: Luban changes the validator layout, Bohr makes `extra[32]` a validator
+    // count and the hand-built extra_data would parse as garbage.
+    assert!(!chain_spec.is_luban_active_at_block(TRANSITION), "extra_data above is pre-Luban");
+    assert!(!chain_spec.is_bohr_active_at_timestamp(TRANSITION, 0), "no turn_length byte");
+    let provider = EnhancedDbSnapshotProvider::new(db, 256, chain_spec);
+
+    let base = addrs(0x10);
+    let (canon_v, fork_v) = (addrs(0x20), addrs(0x30));
+    let grandparent = B256::repeat_byte(0xaa);
+
+    // Insert order matters: the by-number map keeps only the last writer, so after this loop
+    // by-number[CHECKPOINT] is the *fork* checkpoint. Any fall back to height therefore makes
+    // the canonical branch load the fork's validators, and the first assertion below fails.
+    let mut tips = Vec::new();
+    for validators in [&canon_v, &fork_v] {
+        let cp = header(CHECKPOINT, grandparent, validators);
+        let mid = header(CHECKPOINT + 1, cp.hash_slow(), &[]);
+        let mid_hash = mid.hash_slow();
+        let next = header(TRANSITION, mid_hash, &[]);
+        tips.push(next.hash_slow());
+        // Seed at the intermediate block so the rebuild replays exactly one header.
+        provider.insert(Snapshot::new(base.clone(), CHECKPOINT + 1, mid_hash, EPOCH, None));
+        for h in [cp, mid, next] {
+            insert_header_to_cache_with_hash(h, None);
+        }
+    }
+
+    for (tip, mut expected) in tips.iter().zip([canon_v, fork_v]) {
+        expected.sort();
+        let snap = provider.snapshot_by_hash(tip).expect("branch snapshot should rebuild");
+        assert_eq!(snap.validators, expected, "branch must load its own checkpoint ancestor");
+    }
+    Ok(())
+}

--- a/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
+++ b/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
@@ -1,6 +1,5 @@
-//! Regression: the epoch checkpoint must be reached by `parent_hash`, not by block number
-//! (geth `consensus/parlia/snapshot.go:384` `FindAncientHeader`). The by-number header cache
-//! can hold a rejected sibling, which on a fork loads the other branch's validators.
+//! Regression: the epoch checkpoint must be reached by parent_hash, not by number - the
+//! by-number header cache can hold a rejected sibling (geth parlia `FindAncientHeader`).
 
 use super::super::{
     provider::{EnhancedDbSnapshotProvider, SnapshotProvider},
@@ -13,7 +12,10 @@ use crate::hardforks::BscHardforks;
 use crate::node::evm::util::insert_header_to_cache_with_hash;
 use alloy_consensus::Header;
 use alloy_primitives::{Address, B256};
-use reth_db::{init_db, mdbx::DatabaseArguments};
+use reth_db::{
+    init_db, mdbx::DatabaseArguments, tables::{HeaderNumbers, Headers}, transaction::{DbTx, DbTxMut},
+    Database,
+};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -80,5 +82,45 @@ fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> 
         let snap = provider.snapshot_by_hash(tip).expect("branch snapshot should rebuild");
         assert_eq!(snap.validators, expected, "branch must load its own checkpoint ancestor");
     }
+    Ok(())
+}
+
+/// The DB fallback resolves `HeaderNumbers[hash] -> Headers[number]`, i.e. a by-number read,
+/// so mid-reorg it can hand back the sibling that now owns that height. Nothing is seeded into
+/// the header cache here on purpose: the lookup has to miss it and go through MDBX.
+#[test]
+fn db_fallback_rejects_a_header_that_is_not_the_requested_hash() -> eyre::Result<()> {
+    let db_path = std::env::temp_dir().join(format!("bsc_fork_db_fallback_{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&db_path)?;
+    let _cleanup = TestCleanup { path: db_path.clone() };
+    let db = Arc::new(init_db(&db_path, DatabaseArguments::new(Default::default()))?);
+    let provider =
+        EnhancedDbSnapshotProvider::new(db.clone(), 256, Arc::new(BscChainSpec::from(bsc_testnet())));
+
+    // Seeds distinct from the test above: the header cache is process-global with no reset, so
+    // every hash built here must be one no other test inserted.
+    let grandparent = B256::repeat_byte(0xbb);
+    let cp = header(CHECKPOINT, grandparent, &addrs(0x40));
+    let mid = header(CHECKPOINT + 1, cp.hash_slow(), &[]);
+    let mid_hash = mid.hash_slow();
+    let tip = header(TRANSITION, mid_hash, &[]);
+    let tip_hash = tip.hash_slow();
+    provider.insert(Snapshot::new(addrs(0x10), CHECKPOINT + 1, mid_hash, EPOCH, None));
+
+    let tx = db.tx_mut()?;
+    for h in [&cp, &mid, &tip] {
+        tx.put::<HeaderNumbers>(h.hash_slow(), h.number)?;
+    }
+    tx.put::<Headers<Header>>(TRANSITION, tip)?;
+    tx.put::<Headers<Header>>(CHECKPOINT + 1, mid)?;
+    // The reorg: HeaderNumbers still maps the checkpoint hash to CHECKPOINT, but that height is
+    // now owned by a sibling carrying a different validator set.
+    tx.put::<Headers<Header>>(CHECKPOINT, header(CHECKPOINT, grandparent, &addrs(0x50)))?;
+    tx.commit()?;
+
+    assert!(
+        provider.snapshot_by_hash(&tip_hash).is_none(),
+        "checkpoint resolved to another branch's header, the rebuild must fail",
+    );
     Ok(())
 }

--- a/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
+++ b/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
@@ -1,4 +1,5 @@
-//! Regression: epoch checkpoints must be resolved from the branch being rebuilt.
+//! Regression: the epoch checkpoint must be reached by parent_hash, not by number - the
+//! by-number header cache can hold a rejected sibling (geth parlia `FindAncientHeader`).
 
 use super::super::{
     provider::{EnhancedDbSnapshotProvider, SnapshotProvider},
@@ -20,13 +21,15 @@ use uuid::Uuid;
 
 const EPOCH: u64 = 200;
 const CHECKPOINT: u64 = 200;
-/// Two hops catch an off-by-one in the ancestor walk.
+/// +2 because 5 validators, turn_length 1 => miner_history_check_len == 2. Two hops, so an
+/// off-by-one in the walk is caught.
 const TRANSITION: u64 = CHECKPOINT + 2;
 
 fn addrs(seed: u8) -> Vec<Address> {
     (0..5u8).map(|i| Address::repeat_byte(seed + i)).collect()
 }
 
+/// Empty `validators` -> plain header; otherwise a pre-Luban epoch checkpoint.
 fn header(number: u64, parent: B256, validators: &[Address]) -> Header {
     let mut extra = vec![0u8; EXTRA_VANITY_LEN];
     validators.iter().for_each(|v| extra.extend_from_slice(v.as_slice()));
@@ -47,6 +50,8 @@ fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> 
     let _cleanup = TestCleanup { path: db_path.clone() };
     let db = init_db(&db_path, DatabaseArguments::new(Default::default()))?;
     let chain_spec = Arc::new(BscChainSpec::from(bsc_testnet()));
+    // Both matter: Luban changes the validator layout, Bohr makes `extra[32]` a validator
+    // count and the hand-built extra_data would parse as garbage.
     assert!(!chain_spec.is_luban_active_at_block(TRANSITION), "extra_data above is pre-Luban");
     assert!(!chain_spec.is_bohr_active_at_timestamp(TRANSITION, 0), "no turn_length byte");
     let provider = EnhancedDbSnapshotProvider::new(db, 256, chain_spec);
@@ -65,6 +70,7 @@ fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> 
         let mid_hash = mid.hash_slow();
         let next = header(TRANSITION, mid_hash, &[]);
         tips.push(next.hash_slow());
+        // Seed at the intermediate block so the rebuild replays exactly one header.
         provider.insert(Snapshot::new(base.clone(), CHECKPOINT + 1, mid_hash, EPOCH, None));
         for h in [cp, mid, next] {
             insert_header_to_cache_with_hash(h, None);
@@ -79,7 +85,9 @@ fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> 
     Ok(())
 }
 
-/// Exercise the DB fallback path without seeding the header cache.
+/// The DB fallback resolves `HeaderNumbers[hash] -> Headers[number]`, i.e. a by-number read,
+/// so mid-reorg it can hand back the sibling that now owns that height. Nothing is seeded into
+/// the header cache here on purpose: the lookup has to miss it and go through MDBX.
 #[test]
 fn db_fallback_rejects_a_header_that_is_not_the_requested_hash() -> eyre::Result<()> {
     let db_path = std::env::temp_dir().join(format!("bsc_fork_db_fallback_{}", Uuid::new_v4()));
@@ -89,7 +97,8 @@ fn db_fallback_rejects_a_header_that_is_not_the_requested_hash() -> eyre::Result
     let provider =
         EnhancedDbSnapshotProvider::new(db.clone(), 256, Arc::new(BscChainSpec::from(bsc_testnet())));
 
-    // The header cache is process-global, so use distinct hashes here.
+    // Seeds distinct from the test above: the header cache is process-global with no reset, so
+    // every hash built here must be one no other test inserted.
     let grandparent = B256::repeat_byte(0xbb);
     let cp = header(CHECKPOINT, grandparent, &addrs(0x40));
     let mid = header(CHECKPOINT + 1, cp.hash_slow(), &[]);
@@ -104,7 +113,8 @@ fn db_fallback_rejects_a_header_that_is_not_the_requested_hash() -> eyre::Result
     }
     tx.put::<Headers<Header>>(TRANSITION, tip)?;
     tx.put::<Headers<Header>>(CHECKPOINT + 1, mid)?;
-    // Simulate a reorg where the checkpoint height is now owned by a sibling header.
+    // The reorg: HeaderNumbers still maps the checkpoint hash to CHECKPOINT, but that height is
+    // now owned by a sibling carrying a different validator set.
     tx.put::<Headers<Header>>(CHECKPOINT, header(CHECKPOINT, grandparent, &addrs(0x50)))?;
     tx.commit()?;
 

--- a/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
+++ b/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
@@ -20,15 +20,13 @@ use uuid::Uuid;
 
 const EPOCH: u64 = 200;
 const CHECKPOINT: u64 = 200;
-/// +2 because 5 validators, turn_length 1 => miner_history_check_len == 2. Two hops, so an
-/// off-by-one in the walk is caught.
+/// Two hops catch an off-by-one in the ancestor walk.
 const TRANSITION: u64 = CHECKPOINT + 2;
 
 fn addrs(seed: u8) -> Vec<Address> {
     (0..5u8).map(|i| Address::repeat_byte(seed + i)).collect()
 }
 
-/// Empty `validators` -> plain header; otherwise a pre-Luban epoch checkpoint.
 fn header(number: u64, parent: B256, validators: &[Address]) -> Header {
     let mut extra = vec![0u8; EXTRA_VANITY_LEN];
     validators.iter().for_each(|v| extra.extend_from_slice(v.as_slice()));
@@ -49,8 +47,6 @@ fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> 
     let _cleanup = TestCleanup { path: db_path.clone() };
     let db = init_db(&db_path, DatabaseArguments::new(Default::default()))?;
     let chain_spec = Arc::new(BscChainSpec::from(bsc_testnet()));
-    // Both matter: Luban changes the validator layout, Bohr makes `extra[32]` a validator
-    // count and the hand-built extra_data would parse as garbage.
     assert!(!chain_spec.is_luban_active_at_block(TRANSITION), "extra_data above is pre-Luban");
     assert!(!chain_spec.is_bohr_active_at_timestamp(TRANSITION, 0), "no turn_length byte");
     let provider = EnhancedDbSnapshotProvider::new(db, 256, chain_spec);
@@ -69,7 +65,6 @@ fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> 
         let mid_hash = mid.hash_slow();
         let next = header(TRANSITION, mid_hash, &[]);
         tips.push(next.hash_slow());
-        // Seed at the intermediate block so the rebuild replays exactly one header.
         provider.insert(Snapshot::new(base.clone(), CHECKPOINT + 1, mid_hash, EPOCH, None));
         for h in [cp, mid, next] {
             insert_header_to_cache_with_hash(h, None);

--- a/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
+++ b/src/consensus/parlia/tests/rebuild_fork_checkpoint.rs
@@ -1,5 +1,4 @@
-//! Regression: the epoch checkpoint must be reached by parent_hash, not by number - the
-//! by-number header cache can hold a rejected sibling (geth parlia `FindAncientHeader`).
+//! Regression: epoch checkpoints must be resolved from the branch being rebuilt.
 
 use super::super::{
     provider::{EnhancedDbSnapshotProvider, SnapshotProvider},
@@ -85,9 +84,7 @@ fn epoch_checkpoint_is_read_from_the_branch_being_rebuilt() -> eyre::Result<()> 
     Ok(())
 }
 
-/// The DB fallback resolves `HeaderNumbers[hash] -> Headers[number]`, i.e. a by-number read,
-/// so mid-reorg it can hand back the sibling that now owns that height. Nothing is seeded into
-/// the header cache here on purpose: the lookup has to miss it and go through MDBX.
+/// Exercise the DB fallback path without seeding the header cache.
 #[test]
 fn db_fallback_rejects_a_header_that_is_not_the_requested_hash() -> eyre::Result<()> {
     let db_path = std::env::temp_dir().join(format!("bsc_fork_db_fallback_{}", Uuid::new_v4()));
@@ -97,8 +94,7 @@ fn db_fallback_rejects_a_header_that_is_not_the_requested_hash() -> eyre::Result
     let provider =
         EnhancedDbSnapshotProvider::new(db.clone(), 256, Arc::new(BscChainSpec::from(bsc_testnet())));
 
-    // Seeds distinct from the test above: the header cache is process-global with no reset, so
-    // every hash built here must be one no other test inserted.
+    // The header cache is process-global, so use distinct hashes here.
     let grandparent = B256::repeat_byte(0xbb);
     let cp = header(CHECKPOINT, grandparent, &addrs(0x40));
     let mid = header(CHECKPOINT + 1, cp.hash_slow(), &[]);
@@ -113,8 +109,7 @@ fn db_fallback_rejects_a_header_that_is_not_the_requested_hash() -> eyre::Result
     }
     tx.put::<Headers<Header>>(TRANSITION, tip)?;
     tx.put::<Headers<Header>>(CHECKPOINT + 1, mid)?;
-    // The reorg: HeaderNumbers still maps the checkpoint hash to CHECKPOINT, but that height is
-    // now owned by a sibling carrying a different validator set.
+    // Simulate a reorg where the checkpoint height is now owned by a sibling header.
     tx.put::<Headers<Header>>(CHECKPOINT, header(CHECKPOINT, grandparent, &addrs(0x50)))?;
     tx.commit()?;
 

--- a/src/consensus/parlia/tests/snapshot_persistence.rs
+++ b/src/consensus/parlia/tests/snapshot_persistence.rs
@@ -210,8 +210,8 @@ fn test_snapshot_cache_behavior() -> eyre::Result<()> {
 }
 
 /// RAII guard to cleanup test database directory
-struct TestCleanup {
-    path: std::path::PathBuf,
+pub(super) struct TestCleanup {
+    pub(super) path: std::path::PathBuf,
 }
 
 impl Drop for TestCleanup {

--- a/src/consensus/parlia/tests/validator_tests.rs
+++ b/src/consensus/parlia/tests/validator_tests.rs
@@ -4,8 +4,25 @@ use super::super::{
     snapshot::{Snapshot, ValidatorInfo},
     vote::{VoteAddress, VoteAttestation, VoteData},
 };
+use crate::chainspec::{bsc_testnet, BscChainSpec};
+use alloy_consensus::Header;
 use alloy_primitives::{Address, B256};
 use alloy_rlp::Bytes;
+
+/// geth `snapshot.go:299-302` gates on number *and* parent hash.
+#[test]
+fn apply_rejects_a_header_from_another_branch() {
+    let validators = vec![Address::repeat_byte(1)];
+    let snap_hash = B256::repeat_byte(0xaa);
+    let snapshot = Snapshot::new(validators.clone(), 100, snap_hash, 200, None);
+    let chain_spec = BscChainSpec::from(bsc_testnet());
+    let apply = |parent_hash| {
+        let h = Header { number: 101, parent_hash, beneficiary: validators[0], ..Default::default() };
+        snapshot.apply(validators[0], &h, vec![], None, None, None, &chain_spec)
+    };
+    assert!(apply(snap_hash).is_some(), "a genuine child must still apply");
+    assert!(apply(B256::repeat_byte(0xbb)).is_none(), "a same-height sibling must be rejected");
+}
 
 /// Test validator info creation and index assignment
 #[test]

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -76,8 +76,6 @@ impl HeaderCacheReader {
         let block_number = header.number();
         let block_hash = block_hash.unwrap_or_else(|| header.hash_slow());
         let header_clone_for_log = header.clone();
-        // Not fork-safe: the last writer wins for a block number.
-        // Do not use by-number lookups on consensus paths.
         self.blocknumber_to_header.insert(block_number, header.clone());
         self.blockhash_to_header.insert(block_hash, header);
         tracing::trace!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header_clone_for_log);

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -76,9 +76,8 @@ impl HeaderCacheReader {
         let block_number = header.number();
         let block_hash = block_hash.unwrap_or_else(|| header.hash_slow());
         let header_clone_for_log = header.clone();
-        // NOT fork-safe: last writer wins, and BscBlockExecutor::new writes here *before*
-        // Parlia validation, so a rejected sibling can own this slot. Remaining readers only
-        // ask for block 0. Never add a by-number lookup on a consensus path (see provider.rs).
+        // Not fork-safe: the last writer wins for a block number.
+        // Do not use by-number lookups on consensus paths.
         self.blocknumber_to_header.insert(block_number, header.clone());
         self.blockhash_to_header.insert(block_hash, header);
         tracing::trace!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header_clone_for_log);

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -76,6 +76,9 @@ impl HeaderCacheReader {
         let block_number = header.number();
         let block_hash = block_hash.unwrap_or_else(|| header.hash_slow());
         let header_clone_for_log = header.clone();
+        // NOT fork-safe: last writer wins, and BscBlockExecutor::new writes here *before*
+        // Parlia validation, so a rejected sibling can own this slot. Remaining readers only
+        // ask for block 0. Never add a by-number lookup on a consensus path (see provider.rs).
         self.blocknumber_to_header.insert(block_number, header.clone());
         self.blockhash_to_header.insert(block_hash, header);
         tracing::trace!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header_clone_for_log);

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -76,9 +76,6 @@ impl HeaderCacheReader {
         let block_number = header.number();
         let block_hash = block_hash.unwrap_or_else(|| header.hash_slow());
         let header_clone_for_log = header.clone();
-        // NOT fork-safe: last writer wins, and BscBlockExecutor::new writes here *before*
-        // Parlia validation, so a rejected sibling can own this slot. Remaining readers only
-        // ask for block 0. Never add a by-number lookup on a consensus path (see provider.rs).
         self.blocknumber_to_header.insert(block_number, header.clone());
         self.blockhash_to_header.insert(block_hash, header);
         tracing::trace!("Insert header to cache, block_number: {:?}, block_hash: {:?}, header: {:?}", block_number, block_hash, header_clone_for_log);

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -95,6 +95,8 @@ impl VoteJournal {
         Self { path, lru }
     }
 
+    /// Check vote rules against the in-memory buffer.
+    /// Returns true if the vote is allowed under rules, along with the provided source/target context.
     pub fn under_rules(&self, source_number: u64, target_number: u64) -> bool {
         // Rule 1: must not publish two distinct votes for the same height
         if self.lru.contains(target_number) { 
@@ -134,12 +136,16 @@ impl VoteJournal {
 
     /// Append a vote to the journal and update the in-memory cache.
     pub fn write_vote(&mut self, env: &VoteEnvelope) -> std::io::Result<()> {
+        // Authoritative check. The caller's `under_rules` runs under a *separate* lock
+        // acquisition with BLS signing in between, so two head events at one height can both
+        // pass it. Here check and LRU update share one lock, so they are atomic.
         if !self.under_rules(env.data.source_number, env.data.target_number) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
                 "vote violates journal rules",
             ));
         }
+        // Allow memory-only mode via env toggle.
         let mem_only = std::env::var("BSC_VOTE_JOURNAL_MEMORY_ONLY")
             .is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"));
         let mut written = Ok(());
@@ -148,31 +154,48 @@ impl VoteJournal {
             let mut line = serde_json::to_string(env).map_err(std::io::Error::other)?;
             line.push('\n');
             let mut file = Self::open_file_append(&self.path)?;
+            // One write_all: a failure between payload and newline leaves an unterminated
+            // line the next append glues onto, and `load_from_disk` drops it - silently
+            // erasing a vote we already broadcast. Hence the rollback on error.
             let len_before = file.metadata()?.len();
+            // `File::flush` is a no-op for `std::fs::File`; only fsync survives power loss,
+            // and the vote is broadcast right after this returns.
             written = file.write_all(line.as_bytes()).and_then(|()| file.sync_all());
             if written.is_err() {
                 let _ = file.set_len(len_before);
             }
             if is_new_file {
+                // The directory entry must be durable too, or a crash after the first vote
+                // loses the journal and the guard resets to "never voted". Best effort:
+                // platforms that will not fsync a dir handle must not cost us the vote.
                 if let Some(dir) = self.path.parent() {
                     let _ = File::open(dir).and_then(|d| d.sync_all());
                 }
             }
         }
+        // Claim the height once we tried to write: even on failure we return Err (caller must
+        // not broadcast), but the bytes may be there - re-voting the height would equivocate.
         self.lru.add(env.data.target_number, env.data);
         written
     }
 }
 
+/// Global vote journal instance, initialized lazily on first use.
 static GLOBAL_JOURNAL: LazyLock<Mutex<VoteJournal>> = LazyLock::new(|| {
     let path = VoteJournal::resolve_default_path();
     Mutex::new(VoteJournal::new(path))
 });
 
+/// Get a guard to the global vote journal.
 pub fn global() -> std::sync::MutexGuard<'static, VoteJournal> { GLOBAL_JOURNAL.lock().expect("vote journal poisoned") }
 
+/// Helper for external modules to check the rules via global journal.
 pub fn under_rules(source_number: u64, target_number: u64) -> bool { global().under_rules(source_number, target_number) }
 
+/// Helper for external modules to persist a signed vote via global journal.
+///
+/// `io::Error` as-is: `AlreadyExists` = violates the journal rules (benign during a reorg),
+/// anything else = storage fault. A `String` would make those indistinguishable.
 pub fn persist_vote(env: &VoteEnvelope) -> std::io::Result<()> {
     global().write_vote(env)
 }
@@ -205,12 +228,17 @@ mod tests {
         let dup = mk_env(90, B256::from([1u8; 32]), 100, B256::from([3u8; 32]));
         j.write_vote(&env).unwrap();
         assert!(!j.under_rules(95, 100));
+        // write_vote itself must refuse, not just the pre-filter: the caller's check runs
+        // under a separate lock acquisition, so two tasks can both get past it.
         let err = j.write_vote(&dup).expect_err("equivocating vote must be refused");
         assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
     }
 
     #[test]
     fn open_failure_is_reported_and_not_recorded() {
+        // Parent is a regular file, so create_dir_all + open cannot succeed. Only failures
+        // *before* any byte is written leave the journal untouched; a write or fsync that
+        // fails afterwards still claims the height (see `lru.add` in `write_vote`).
         let blocker = tmp_path("journal_blocker");
         std::fs::write(&blocker, b"x").unwrap();
         let mut j = VoteJournal::new(blocker.join("votes.jsonl"));

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -136,9 +136,7 @@ impl VoteJournal {
 
     /// Append a vote to the journal and update the in-memory cache.
     pub fn write_vote(&mut self, env: &VoteEnvelope) -> std::io::Result<()> {
-        // Authoritative check. The caller's `under_rules` runs under a *separate* lock
-        // acquisition with BLS signing in between, so two head events at one height can both
-        // pass it. Here check and LRU update share one lock, so they are atomic.
+        // Re-check under the journal lock.
         if !self.under_rules(env.data.source_number, env.data.target_number) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
@@ -154,27 +152,21 @@ impl VoteJournal {
             let mut line = serde_json::to_string(env).map_err(std::io::Error::other)?;
             line.push('\n');
             let mut file = Self::open_file_append(&self.path)?;
-            // One write_all: a failure between payload and newline leaves an unterminated
-            // line the next append glues onto, and `load_from_disk` drops it - silently
-            // erasing a vote we already broadcast. Hence the rollback on error.
+            // Roll back partial appends on error.
             let len_before = file.metadata()?.len();
-            // `File::flush` is a no-op for `std::fs::File`; only fsync survives power loss,
-            // and the vote is broadcast right after this returns.
+            // Persist before the vote can leave the node.
             written = file.write_all(line.as_bytes()).and_then(|()| file.sync_all());
             if written.is_err() {
                 let _ = file.set_len(len_before);
             }
             if is_new_file {
-                // The directory entry must be durable too, or a crash after the first vote
-                // loses the journal and the guard resets to "never voted". Best effort:
-                // platforms that will not fsync a dir handle must not cost us the vote.
+                // Best-effort directory sync for the first journal file.
                 if let Some(dir) = self.path.parent() {
                     let _ = File::open(dir).and_then(|d| d.sync_all());
                 }
             }
         }
-        // Claim the height once we tried to write: even on failure we return Err (caller must
-        // not broadcast), but the bytes may be there - re-voting the height would equivocate.
+        // Claim the height once a write was attempted.
         self.lru.add(env.data.target_number, env.data);
         written
     }

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -243,8 +243,10 @@ mod tests {
     fn rule2_backward_across_span_disallowed() {
         let path = tmp_path("journal_rule2_back");
         let mut j = VoteJournal::new(path);
+        // Previous vote with target 125 and source 120
         let env = mk_env(120, B256::from([3u8; 32]), 125, B256::from([4u8; 32]));
         j.write_vote(&env).unwrap();
+        // New vote spans across: source 110, target 130 should be invalid (sees prior at 125 with higher source)
         assert!(!j.under_rules(110, 130));
     }
 
@@ -252,8 +254,10 @@ mod tests {
     fn rule2_forward_within_span_disallowed() {
         let path = tmp_path("journal_rule2_forward");
         let mut j = VoteJournal::new(path);
+        // Previous vote with target 110 and lower source 90
         let env = mk_env(90, B256::from([5u8; 32]), 110, B256::from([6u8; 32]));
         j.write_vote(&env).unwrap();
+        // New vote source 100, target 105: forward window includes 106..116; contains 110 with vd.source=90 < 100 => invalid
         assert!(!j.under_rules(100, 105));
     }
 
@@ -261,6 +265,7 @@ mod tests {
     fn allowed_vote_when_no_conflict() {
         let path = tmp_path("journal_ok");
         let mut j = VoteJournal::new(path);
+        // Old vote far behind
         let env = mk_env(80, B256::from([7u8; 32]), 90, B256::from([8u8; 32]));
         j.write_vote(&env).unwrap();
         assert!(j.under_rules(100, 110));
@@ -276,8 +281,11 @@ mod tests {
             j.write_vote(&env1).unwrap();
             j.write_vote(&env2).unwrap();
         }
+        // Reopen
         let j2 = VoteJournal::new(path);
+        // Rule1: contains 40
         assert!(!j2.under_rules(35, 40));
+        // Rule2 forward: with source 35 target 33, forward window includes 34..44; 40 present with vd.source=30 < 35 => invalid
         assert!(!j2.under_rules(35, 33));
     }
 }

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -82,7 +82,6 @@ impl VoteJournal {
                         buf.push(env.data);
                         if buf.len() > MAX_RECENT_ENTRIES { buf.remove(0); }
                     }
-                    // Log unreadable lines instead of silently forgetting them.
                     Err(e) => tracing::error!(target: "bsc::vote", error=%e, "Unparsable line in vote journal, skipping"),
                 }
             }
@@ -96,8 +95,6 @@ impl VoteJournal {
         Self { path, lru }
     }
 
-    /// Check vote rules against the in-memory buffer.
-    /// Returns true if the vote is allowed under rules, along with the provided source/target context.
     pub fn under_rules(&self, source_number: u64, target_number: u64) -> bool {
         // Rule 1: must not publish two distinct votes for the same height
         if self.lru.contains(target_number) { 
@@ -137,14 +134,12 @@ impl VoteJournal {
 
     /// Append a vote to the journal and update the in-memory cache.
     pub fn write_vote(&mut self, env: &VoteEnvelope) -> std::io::Result<()> {
-        // Recheck under the journal lock so the rule check and LRU update stay atomic.
         if !self.under_rules(env.data.source_number, env.data.target_number) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
                 "vote violates journal rules",
             ));
         }
-        // Allow memory-only mode via env toggle.
         let mem_only = std::env::var("BSC_VOTE_JOURNAL_MEMORY_ONLY")
             .is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"));
         let mut written = Ok(());
@@ -153,41 +148,31 @@ impl VoteJournal {
             let mut line = serde_json::to_string(env).map_err(std::io::Error::other)?;
             line.push('\n');
             let mut file = Self::open_file_append(&self.path)?;
-            // Write the full line and roll back partial appends on error.
             let len_before = file.metadata()?.len();
-            // Persist the vote before it can leave the node.
             written = file.write_all(line.as_bytes()).and_then(|()| file.sync_all());
             if written.is_err() {
                 let _ = file.set_len(len_before);
             }
             if is_new_file {
-                // Best-effort directory sync for the first journal file.
                 if let Some(dir) = self.path.parent() {
                     let _ = File::open(dir).and_then(|d| d.sync_all());
                 }
             }
         }
-        // Claim the height in memory once a write was attempted.
         self.lru.add(env.data.target_number, env.data);
         written
     }
 }
 
-/// Global vote journal instance, initialized lazily on first use.
 static GLOBAL_JOURNAL: LazyLock<Mutex<VoteJournal>> = LazyLock::new(|| {
     let path = VoteJournal::resolve_default_path();
     Mutex::new(VoteJournal::new(path))
 });
 
-/// Get a guard to the global vote journal.
 pub fn global() -> std::sync::MutexGuard<'static, VoteJournal> { GLOBAL_JOURNAL.lock().expect("vote journal poisoned") }
 
-/// Helper for external modules to check the rules via global journal.
 pub fn under_rules(source_number: u64, target_number: u64) -> bool { global().under_rules(source_number, target_number) }
 
-/// Helper for external modules to persist a signed vote via global journal.
-///
-/// Keep `AlreadyExists` distinct from storage errors.
 pub fn persist_vote(env: &VoteEnvelope) -> std::io::Result<()> {
     global().write_vote(env)
 }
@@ -220,14 +205,12 @@ mod tests {
         let dup = mk_env(90, B256::from([1u8; 32]), 100, B256::from([3u8; 32]));
         j.write_vote(&env).unwrap();
         assert!(!j.under_rules(95, 100));
-        // `write_vote` must reject duplicates even if the caller's pre-check races.
         let err = j.write_vote(&dup).expect_err("equivocating vote must be refused");
         assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
     }
 
     #[test]
     fn open_failure_is_reported_and_not_recorded() {
-        // Opening under a regular file fails before any byte is written.
         let blocker = tmp_path("journal_blocker");
         std::fs::write(&blocker, b"x").unwrap();
         let mut j = VoteJournal::new(blocker.join("votes.jsonl"));
@@ -240,10 +223,8 @@ mod tests {
     fn rule2_backward_across_span_disallowed() {
         let path = tmp_path("journal_rule2_back");
         let mut j = VoteJournal::new(path);
-        // Previous vote with target 125 and source 120
         let env = mk_env(120, B256::from([3u8; 32]), 125, B256::from([4u8; 32]));
         j.write_vote(&env).unwrap();
-        // New vote spans across: source 110, target 130 should be invalid (sees prior at 125 with higher source)
         assert!(!j.under_rules(110, 130));
     }
 
@@ -251,10 +232,8 @@ mod tests {
     fn rule2_forward_within_span_disallowed() {
         let path = tmp_path("journal_rule2_forward");
         let mut j = VoteJournal::new(path);
-        // Previous vote with target 110 and lower source 90
         let env = mk_env(90, B256::from([5u8; 32]), 110, B256::from([6u8; 32]));
         j.write_vote(&env).unwrap();
-        // New vote source 100, target 105: forward window includes 106..116; contains 110 with vd.source=90 < 100 => invalid
         assert!(!j.under_rules(100, 105));
     }
 
@@ -262,7 +241,6 @@ mod tests {
     fn allowed_vote_when_no_conflict() {
         let path = tmp_path("journal_ok");
         let mut j = VoteJournal::new(path);
-        // Old vote far behind
         let env = mk_env(80, B256::from([7u8; 32]), 90, B256::from([8u8; 32]));
         j.write_vote(&env).unwrap();
         assert!(j.under_rules(100, 110));
@@ -278,11 +256,8 @@ mod tests {
             j.write_vote(&env1).unwrap();
             j.write_vote(&env2).unwrap();
         }
-        // Reopen
         let j2 = VoteJournal::new(path);
-        // Rule1: contains 40
         assert!(!j2.under_rules(35, 40));
-        // Rule2 forward: with source 35 target 33, forward window includes 34..44; 40 present with vd.source=30 < 35 => invalid
         assert!(!j2.under_rules(35, 33));
     }
 }

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -160,7 +160,7 @@ impl VoteJournal {
             // erasing a vote we already broadcast. Hence the rollback on error.
             let len_before = file.metadata()?.len();
             // `File::flush` is a no-op for `std::fs::File`; only fsync survives power loss,
-            // and the vote is broadcast right after this returns. geth: tidwall/wal, NoSync=false.
+            // and the vote is broadcast right after this returns.
             written = file.write_all(line.as_bytes()).and_then(|()| file.sync_all());
             if written.is_err() {
                 let _ = file.set_len(len_before);
@@ -236,8 +236,10 @@ mod tests {
     }
 
     #[test]
-    fn failed_write_is_reported_and_not_recorded() {
-        // Parent is a regular file, so create_dir_all + open cannot succeed.
+    fn open_failure_is_reported_and_not_recorded() {
+        // Parent is a regular file, so create_dir_all + open cannot succeed. Only failures
+        // *before* any byte is written leave the journal untouched; a write or fsync that
+        // fails afterwards still claims the height (see `lru.add` in `write_vote`).
         let blocker = tmp_path("journal_blocker");
         std::fs::write(&blocker, b"x").unwrap();
         let mut j = VoteJournal::new(blocker.join("votes.jsonl"));

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -82,7 +82,7 @@ impl VoteJournal {
                         buf.push(env.data);
                         if buf.len() > MAX_RECENT_ENTRIES { buf.remove(0); }
                     }
-                    // A vote we cannot read back is a height the double-sign rules forget.
+                    // Log unreadable lines instead of silently forgetting them.
                     Err(e) => tracing::error!(target: "bsc::vote", error=%e, "Unparsable line in vote journal, skipping"),
                 }
             }
@@ -137,9 +137,7 @@ impl VoteJournal {
 
     /// Append a vote to the journal and update the in-memory cache.
     pub fn write_vote(&mut self, env: &VoteEnvelope) -> std::io::Result<()> {
-        // Authoritative check. The caller's `under_rules` runs under a *separate* lock
-        // acquisition with BLS signing in between, so two head events at one height can both
-        // pass it. Here check and LRU update share one lock, so they are atomic.
+        // Recheck under the journal lock so the rule check and LRU update stay atomic.
         if !self.under_rules(env.data.source_number, env.data.target_number) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
@@ -155,27 +153,21 @@ impl VoteJournal {
             let mut line = serde_json::to_string(env).map_err(std::io::Error::other)?;
             line.push('\n');
             let mut file = Self::open_file_append(&self.path)?;
-            // One write_all: a failure between payload and newline leaves an unterminated
-            // line the next append glues onto, and `load_from_disk` drops it - silently
-            // erasing a vote we already broadcast. Hence the rollback on error.
+            // Write the full line and roll back partial appends on error.
             let len_before = file.metadata()?.len();
-            // `File::flush` is a no-op for `std::fs::File`; only fsync survives power loss,
-            // and the vote is broadcast right after this returns.
+            // Persist the vote before it can leave the node.
             written = file.write_all(line.as_bytes()).and_then(|()| file.sync_all());
             if written.is_err() {
                 let _ = file.set_len(len_before);
             }
             if is_new_file {
-                // The directory entry must be durable too, or a crash after the first vote
-                // loses the journal and the guard resets to "never voted". Best effort:
-                // platforms that will not fsync a dir handle must not cost us the vote.
+                // Best-effort directory sync for the first journal file.
                 if let Some(dir) = self.path.parent() {
                     let _ = File::open(dir).and_then(|d| d.sync_all());
                 }
             }
         }
-        // Claim the height once we tried to write: even on failure we return Err (caller must
-        // not broadcast), but the bytes may be there - re-voting the height would equivocate.
+        // Claim the height in memory once a write was attempted.
         self.lru.add(env.data.target_number, env.data);
         written
     }
@@ -195,8 +187,7 @@ pub fn under_rules(source_number: u64, target_number: u64) -> bool { global().un
 
 /// Helper for external modules to persist a signed vote via global journal.
 ///
-/// `io::Error` as-is: `AlreadyExists` = violates the journal rules (benign during a reorg),
-/// anything else = storage fault. A `String` would make those indistinguishable.
+/// Keep `AlreadyExists` distinct from storage errors.
 pub fn persist_vote(env: &VoteEnvelope) -> std::io::Result<()> {
     global().write_vote(env)
 }
@@ -229,17 +220,14 @@ mod tests {
         let dup = mk_env(90, B256::from([1u8; 32]), 100, B256::from([3u8; 32]));
         j.write_vote(&env).unwrap();
         assert!(!j.under_rules(95, 100));
-        // write_vote itself must refuse, not just the pre-filter: the caller's check runs
-        // under a separate lock acquisition, so two tasks can both get past it.
+        // `write_vote` must reject duplicates even if the caller's pre-check races.
         let err = j.write_vote(&dup).expect_err("equivocating vote must be refused");
         assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
     }
 
     #[test]
     fn open_failure_is_reported_and_not_recorded() {
-        // Parent is a regular file, so create_dir_all + open cannot succeed. Only failures
-        // *before* any byte is written leave the journal untouched; a write or fsync that
-        // fails afterwards still claims the height (see `lru.add` in `write_vote`).
+        // Opening under a regular file fails before any byte is written.
         let blocker = tmp_path("journal_blocker");
         std::fs::write(&blocker, b"x").unwrap();
         let mut j = VoteJournal::new(blocker.join("votes.jsonl"));

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -74,14 +74,16 @@ impl VoteJournal {
         let mut lru = VoteDataLru::new(MAX_RECENT_ENTRIES);
         if let Ok(file) = Self::open_file_read(path) {
             let reader = BufReader::new(file);
-            // Read all lines and keep the last MAX_RECENT_ENTRIES
-            // Each line is expected to be a JSON-serialized VoteEnvelope
             let mut buf: Vec<VoteData> = Vec::with_capacity(MAX_RECENT_ENTRIES);
             for line in reader.lines().map_while(Result::ok) {
                 if line.is_empty() { continue; }
-                if let Ok(env) = serde_json::from_str::<VoteEnvelope>(&line) {
-                    buf.push(env.data);
-                    if buf.len() > MAX_RECENT_ENTRIES { buf.remove(0); }
+                match serde_json::from_str::<VoteEnvelope>(&line) {
+                    Ok(env) => {
+                        buf.push(env.data);
+                        if buf.len() > MAX_RECENT_ENTRIES { buf.remove(0); }
+                    }
+                    // A vote we cannot read back is a height the double-sign rules forget.
+                    Err(e) => tracing::error!(target: "bsc::vote", error=%e, "Unparsable line in vote journal, skipping"),
                 }
             }
             for vd in buf { lru.add(vd.target_number, vd); }
@@ -135,21 +137,47 @@ impl VoteJournal {
 
     /// Append a vote to the journal and update the in-memory cache.
     pub fn write_vote(&mut self, env: &VoteEnvelope) -> std::io::Result<()> {
+        // Authoritative check. The caller's `under_rules` runs under a *separate* lock
+        // acquisition with BLS signing in between, so two head events at one height can both
+        // pass it. Here check and LRU update share one lock, so they are atomic.
+        if !self.under_rules(env.data.source_number, env.data.target_number) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "vote violates journal rules",
+            ));
+        }
         // Allow memory-only mode via env toggle.
         let mem_only = std::env::var("BSC_VOTE_JOURNAL_MEMORY_ONLY")
-            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
-            .unwrap_or(false);
+            .is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"));
+        let mut written = Ok(());
         if !mem_only {
+            let is_new_file = !self.path.exists();
+            let mut line = serde_json::to_string(env).map_err(std::io::Error::other)?;
+            line.push('\n');
             let mut file = Self::open_file_append(&self.path)?;
-            let line = serde_json::to_string(env).unwrap_or_else(|_| String::new());
-            if !line.is_empty() {
-                file.write_all(line.as_bytes())?;
-                file.write_all(b"\n")?;
-                file.flush()?;
+            // One write_all: a failure between payload and newline leaves an unterminated
+            // line the next append glues onto, and `load_from_disk` drops it - silently
+            // erasing a vote we already broadcast. Hence the rollback on error.
+            let len_before = file.metadata()?.len();
+            // `File::flush` is a no-op for `std::fs::File`; only fsync survives power loss,
+            // and the vote is broadcast right after this returns. geth: tidwall/wal, NoSync=false.
+            written = file.write_all(line.as_bytes()).and_then(|()| file.sync_all());
+            if written.is_err() {
+                let _ = file.set_len(len_before);
+            }
+            if is_new_file {
+                // The directory entry must be durable too, or a crash after the first vote
+                // loses the journal and the guard resets to "never voted". Best effort:
+                // platforms that will not fsync a dir handle must not cost us the vote.
+                if let Some(dir) = self.path.parent() {
+                    let _ = File::open(dir).and_then(|d| d.sync_all());
+                }
             }
         }
+        // Claim the height once we tried to write: even on failure we return Err (caller must
+        // not broadcast), but the bytes may be there - re-voting the height would equivocate.
         self.lru.add(env.data.target_number, env.data);
-        Ok(())
+        written
     }
 }
 
@@ -166,8 +194,11 @@ pub fn global() -> std::sync::MutexGuard<'static, VoteJournal> { GLOBAL_JOURNAL.
 pub fn under_rules(source_number: u64, target_number: u64) -> bool { global().under_rules(source_number, target_number) }
 
 /// Helper for external modules to persist a signed vote via global journal.
-pub fn persist_vote(env: &VoteEnvelope) -> Result<(), String> {
-    global().write_vote(env).map_err(|e| format!("Failed to write vote journal: {e}"))
+///
+/// `io::Error` as-is: `AlreadyExists` = violates the journal rules (benign during a reorg),
+/// anything else = storage fault. A `String` would make those indistinguishable.
+pub fn persist_vote(env: &VoteEnvelope) -> std::io::Result<()> {
+    global().write_vote(env)
 }
 
 #[cfg(test)]
@@ -193,11 +224,26 @@ mod tests {
 
     #[test]
     fn rule1_duplicate_height_disallowed() {
-        let path = tmp_path("journal_rule1");
-        let mut j = VoteJournal::new(path);
+        let mut j = VoteJournal::new(tmp_path("journal_rule1"));
         let env = mk_env(90, B256::from([1u8; 32]), 100, B256::from([2u8; 32]));
+        let dup = mk_env(90, B256::from([1u8; 32]), 100, B256::from([3u8; 32]));
         j.write_vote(&env).unwrap();
         assert!(!j.under_rules(95, 100));
+        // write_vote itself must refuse, not just the pre-filter: the caller's check runs
+        // under a separate lock acquisition, so two tasks can both get past it.
+        let err = j.write_vote(&dup).expect_err("equivocating vote must be refused");
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn failed_write_is_reported_and_not_recorded() {
+        // Parent is a regular file, so create_dir_all + open cannot succeed.
+        let blocker = tmp_path("journal_blocker");
+        std::fs::write(&blocker, b"x").unwrap();
+        let mut j = VoteJournal::new(blocker.join("votes.jsonl"));
+        assert!(j.write_vote(&mk_env(90, B256::ZERO, 100, B256::ZERO)).is_err());
+        assert!(j.under_rules(95, 100), "failed write must leave the journal untouched");
+        let _ = std::fs::remove_file(&blocker);
     }
 
     #[test]

--- a/src/node/vote_producer.rs
+++ b/src/node/vote_producer.rs
@@ -213,11 +213,9 @@ pub fn maybe_produce_and_broadcast_for_head(
     // Sign and insert/broadcast
     match bls_signer::sign_vote_with_global(data) {
         Ok(envelope) => {
-            // An unjournalled vote must not leave this node (geth vote_manager.go: a
-            // WriteVote error skips PutVote + broadcast). Lost vote = rewards; double = stake.
+            // Do not broadcast votes that failed to persist in the journal.
             if let Err(e) = vote_journal::persist_vote(&envelope) {
                 if e.kind() == std::io::ErrorKind::AlreadyExists {
-                    // Journal refused it (duplicate height or span), not a storage fault.
                     tracing::debug!(target: "bsc::vote", reason = "journal-rules-failed", target_number=target_number, "skip vote production");
                 } else {
                     tracing::error!(target: "bsc::vote", error=%e, "Failed to write vote into journal, skipping vote");
@@ -260,10 +258,7 @@ mod tests {
         Header { number, timestamp: now, ..Default::default() }
     }
 
-    /// A journal write failure has to stop the vote before it reaches the pool or the wire:
-    /// a vote that left without being journalled can be signed again at the same height after
-    /// a restart, which is slashable. Positive and negative case share one test because the
-    /// journal path is resolved once per process.
+    /// Journal failure must stop the vote before it reaches the pool or the wire.
     #[tokio::test(flavor = "current_thread")]
     async fn journal_error_blocks_pool_and_broadcast() {
         let dir = std::env::temp_dir().join(format!("vote_producer_{}", uuid::Uuid::new_v4()));

--- a/src/node/vote_producer.rs
+++ b/src/node/vote_producer.rs
@@ -202,6 +202,7 @@ pub fn maybe_produce_and_broadcast_for_head(
         }
     }
 
+    // Cheap pre-filter only; `write_vote` re-runs the rules atomically under its own lock.
     if !vote_journal::under_rules(source_number, target_number) {
         tracing::debug!(target: "bsc::vote", reason = "under-rules-failed", source_number=source_number, target_number=target_number, "skip vote production");
         return;
@@ -209,10 +210,14 @@ pub fn maybe_produce_and_broadcast_for_head(
 
     let data = VoteData { source_number, source_hash, target_number, target_hash };
 
+    // Sign and insert/broadcast
     match bls_signer::sign_vote_with_global(data) {
         Ok(envelope) => {
+            // An unjournalled vote must not leave this node (geth vote_manager.go: a
+            // WriteVote error skips PutVote + broadcast). Lost vote = rewards; double = stake.
             if let Err(e) = vote_journal::persist_vote(&envelope) {
                 if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    // Journal refused it (duplicate height or span), not a storage fault.
                     tracing::debug!(target: "bsc::vote", reason = "journal-rules-failed", target_number=target_number, "skip vote production");
                 } else {
                     tracing::error!(target: "bsc::vote", error=%e, "Failed to write vote into journal, skipping vote");
@@ -220,8 +225,10 @@ pub fn maybe_produce_and_broadcast_for_head(
                 }
                 return;
             }
+            // insert into local pool
             tracing::trace!(target: "bsc::vote", "insert self vote into local pool, target_number: {}, target_hash: {}", data.target_number, data.target_hash);
             votes::put_vote(envelope.clone());
+            // broadcast to peers
             crate::node::network::bsc_protocol::registry::broadcast_votes(vec![envelope]);
         }
         Err(e) => {
@@ -253,6 +260,10 @@ mod tests {
         Header { number, timestamp: now, ..Default::default() }
     }
 
+    /// A journal write failure has to stop the vote before it reaches the pool or the wire:
+    /// a vote that left without being journalled can be signed again at the same height after
+    /// a restart, which is slashable. Positive and negative case share one test because the
+    /// journal path is resolved once per process.
     #[tokio::test(flavor = "current_thread")]
     async fn journal_error_blocks_pool_and_broadcast() {
         let dir = std::env::temp_dir().join(format!("vote_producer_{}", uuid::Uuid::new_v4()));
@@ -288,12 +299,15 @@ mod tests {
         };
         let sp = FixedSnap(snap);
 
+        // Burn the warm-up block.
         maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &head_at(40_000_001));
 
+        // Journal writable: the vote reaches the pool.
         let ok = head_at(40_000_002);
         maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &ok);
         assert_eq!(votes::fetch_vote_by_block_hash(ok.hash_slow()).len(), 1);
 
+        // Journal directory replaced by a regular file: persist_vote fails.
         std::fs::remove_dir_all(&dir).unwrap();
         std::fs::write(&dir, b"x").unwrap();
         let bad = head_at(40_000_003);

--- a/src/node/vote_producer.rs
+++ b/src/node/vote_producer.rs
@@ -202,7 +202,7 @@ pub fn maybe_produce_and_broadcast_for_head(
         }
     }
 
-    // Check vote rules against local journal to prevent slashing and double votes.
+    // Cheap pre-filter only; `write_vote` re-runs the rules atomically under its own lock.
     if !vote_journal::under_rules(source_number, target_number) {
         tracing::debug!(target: "bsc::vote", reason = "under-rules-failed", source_number=source_number, target_number=target_number, "skip vote production");
         return;
@@ -213,11 +213,17 @@ pub fn maybe_produce_and_broadcast_for_head(
     // Sign and insert/broadcast
     match bls_signer::sign_vote_with_global(data) {
         Ok(envelope) => {
-            // Persist in journal first to avoid vote loss due to failures.
+            // An unjournalled vote must not leave this node (geth vote_manager.go: a
+            // WriteVote error skips PutVote + broadcast). Lost vote = rewards; double = stake.
             if let Err(e) = vote_journal::persist_vote(&envelope) {
-                tracing::error!(target: "bsc::vote", error=%e, "Failed to write vote into journal");
-                VOTE_METRICS.vote_journal_errors_total.increment(1);
-                // Continue despite journal error; do not halt voting pipeline.
+                if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    // Journal refused it (duplicate height or span), not a storage fault.
+                    tracing::debug!(target: "bsc::vote", reason = "journal-rules-failed", target_number=target_number, "skip vote production");
+                } else {
+                    tracing::error!(target: "bsc::vote", error=%e, "Failed to write vote into journal, skipping vote");
+                    VOTE_METRICS.vote_journal_errors_total.increment(1);
+                }
+                return;
             }
             // insert into local pool
             tracing::trace!(target: "bsc::vote", "insert self vote into local pool, target_number: {}, target_hash: {}", data.target_number, data.target_hash);

--- a/src/node/vote_producer.rs
+++ b/src/node/vote_producer.rs
@@ -202,7 +202,6 @@ pub fn maybe_produce_and_broadcast_for_head(
         }
     }
 
-    // Cheap pre-filter only; `write_vote` re-runs the rules atomically under its own lock.
     if !vote_journal::under_rules(source_number, target_number) {
         tracing::debug!(target: "bsc::vote", reason = "under-rules-failed", source_number=source_number, target_number=target_number, "skip vote production");
         return;
@@ -210,10 +209,8 @@ pub fn maybe_produce_and_broadcast_for_head(
 
     let data = VoteData { source_number, source_hash, target_number, target_hash };
 
-    // Sign and insert/broadcast
     match bls_signer::sign_vote_with_global(data) {
         Ok(envelope) => {
-            // Do not broadcast votes that failed to persist in the journal.
             if let Err(e) = vote_journal::persist_vote(&envelope) {
                 if e.kind() == std::io::ErrorKind::AlreadyExists {
                     tracing::debug!(target: "bsc::vote", reason = "journal-rules-failed", target_number=target_number, "skip vote production");
@@ -223,10 +220,8 @@ pub fn maybe_produce_and_broadcast_for_head(
                 }
                 return;
             }
-            // insert into local pool
             tracing::trace!(target: "bsc::vote", "insert self vote into local pool, target_number: {}, target_hash: {}", data.target_number, data.target_hash);
             votes::put_vote(envelope.clone());
-            // broadcast to peers
             crate::node::network::bsc_protocol::registry::broadcast_votes(vec![envelope]);
         }
         Err(e) => {
@@ -258,7 +253,6 @@ mod tests {
         Header { number, timestamp: now, ..Default::default() }
     }
 
-    /// Journal failure must stop the vote before it reaches the pool or the wire.
     #[tokio::test(flavor = "current_thread")]
     async fn journal_error_blocks_pool_and_broadcast() {
         let dir = std::env::temp_dir().join(format!("vote_producer_{}", uuid::Uuid::new_v4()));
@@ -294,15 +288,12 @@ mod tests {
         };
         let sp = FixedSnap(snap);
 
-        // Burn the warm-up block.
         maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &head_at(40_000_001));
 
-        // Journal writable: the vote reaches the pool.
         let ok = head_at(40_000_002);
         maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &ok);
         assert_eq!(votes::fetch_vote_by_block_hash(ok.hash_slow()).len(), 1);
 
-        // Journal directory replaced by a regular file: persist_vote fails.
         std::fs::remove_dir_all(&dir).unwrap();
         std::fs::write(&dir, b"x").unwrap();
         let bad = head_at(40_000_003);

--- a/src/node/vote_producer.rs
+++ b/src/node/vote_producer.rs
@@ -213,11 +213,8 @@ pub fn maybe_produce_and_broadcast_for_head(
     // Sign and insert/broadcast
     match bls_signer::sign_vote_with_global(data) {
         Ok(envelope) => {
-            // An unjournalled vote must not leave this node (geth vote_manager.go: a
-            // WriteVote error skips PutVote + broadcast). Lost vote = rewards; double = stake.
             if let Err(e) = vote_journal::persist_vote(&envelope) {
                 if e.kind() == std::io::ErrorKind::AlreadyExists {
-                    // Journal refused it (duplicate height or span), not a storage fault.
                     tracing::debug!(target: "bsc::vote", reason = "journal-rules-failed", target_number=target_number, "skip vote production");
                 } else {
                     tracing::error!(target: "bsc::vote", error=%e, "Failed to write vote into journal, skipping vote");
@@ -260,10 +257,6 @@ mod tests {
         Header { number, timestamp: now, ..Default::default() }
     }
 
-    /// A journal write failure has to stop the vote before it reaches the pool or the wire:
-    /// a vote that left without being journalled can be signed again at the same height after
-    /// a restart, which is slashable. Positive and negative case share one test because the
-    /// journal path is resolved once per process.
     #[tokio::test(flavor = "current_thread")]
     async fn journal_error_blocks_pool_and_broadcast() {
         let dir = std::env::temp_dir().join(format!("vote_producer_{}", uuid::Uuid::new_v4()));

--- a/src/node/vote_producer.rs
+++ b/src/node/vote_producer.rs
@@ -237,3 +237,87 @@ pub fn maybe_produce_and_broadcast_for_head(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consensus::parlia::snapshot::Snapshot;
+    use alloy_primitives::Address;
+
+    struct FixedSnap(Snapshot);
+    impl SnapshotProvider for FixedSnap {
+        fn snapshot_by_hash(&self, _hash: &B256) -> Option<Snapshot> {
+            Some(self.0.clone())
+        }
+        fn insert(&self, _snapshot: Snapshot) {}
+    }
+
+    fn head_at(number: u64) -> Header {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        Header { number, timestamp: now, ..Default::default() }
+    }
+
+    /// A journal write failure has to stop the vote before it reaches the pool or the wire:
+    /// a vote that left without being journalled can be signed again at the same height after
+    /// a restart, which is slashable. Positive and negative case share one test because the
+    /// journal path is resolved once per process.
+    #[tokio::test(flavor = "current_thread")]
+    async fn journal_error_blocks_pool_and_broadcast() {
+        let dir = std::env::temp_dir().join(format!("vote_producer_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("BSC_VOTE_JOURNAL_DIR", &dir);
+        std::env::set_var("BSC_VOTE_WARMUP_BLOCKS", "1");
+
+        let mut sk = [0u8; 32];
+        sk[31] = 1;
+        bls_signer::init_global_bls_signer_from_bytes(sk).unwrap();
+        let me = bls_signer::global_bls_public_key().unwrap();
+        let _ = crate::node::miner::config::set_global_mining_config(
+            crate::node::miner::config::MiningConfig {
+                enabled: true,
+                private_key_hex: Some("11".repeat(32)),
+                ..Default::default()
+            },
+        );
+
+        let spec = Arc::new(BscChainSpec::from(crate::chainspec::bsc::bsc_mainnet()));
+        let mut snap = Snapshot::new(
+            vec![Address::repeat_byte(7)],
+            40_000_000,
+            B256::repeat_byte(9),
+            200,
+            Some(vec![me]),
+        );
+        snap.vote_data = VoteData {
+            source_number: 39_999_990,
+            source_hash: B256::repeat_byte(3),
+            target_number: 39_999_990,
+            target_hash: B256::repeat_byte(3),
+        };
+        let sp = FixedSnap(snap);
+
+        // Burn the warm-up block.
+        maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &head_at(40_000_001));
+
+        // Journal writable: the vote reaches the pool.
+        let ok = head_at(40_000_002);
+        maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &ok);
+        assert_eq!(votes::fetch_vote_by_block_hash(ok.hash_slow()).len(), 1);
+
+        // Journal directory replaced by a regular file: persist_vote fails.
+        std::fs::remove_dir_all(&dir).unwrap();
+        std::fs::write(&dir, b"x").unwrap();
+        let bad = head_at(40_000_003);
+        maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &bad);
+        assert!(
+            votes::fetch_vote_by_block_hash(bad.hash_slow()).is_empty(),
+            "unjournalled vote must not reach put_vote or broadcast_votes",
+        );
+
+        let _ = votes::drain();
+        let _ = std::fs::remove_file(&dir);
+    }
+}


### PR DESCRIPTION
### Description

Fix two Parlia correctness issues:

- resolve epoch checkpoints by parent hash instead of block number
- stop votes from leaving the node when vote journal writes fail

### Rationale

Snapshot rebuilds must use the checkpoint header from the branch being rebuilt. A by-number lookup can pick the sibling fork's header.

Votes also need a durable journal write before they reach the pool or peers.

### Example

Before:
- fork rebuilds could load the sibling branch's checkpoint header
- journal write failures could still let votes reach `put_vote` or `broadcast_votes`

After:
- fork rebuilds use the correct ancestor chain
- journal write failures stop the vote before it leaves the node

### Changes

Notable changes:
- `src/consensus/parlia/*`: resolve epoch checkpoints by parent hash during snapshot rebuild
- `src/node/vote_journal.rs`: harden vote journal writes
- `src/node/vote_producer.rs`: stop vote propagation on journal write failure
- `src/consensus/parlia/tests/*`, `src/node/*`: add regressions for both paths

### Potential Impacts

- fork/reorg snapshot rebuilds become branch-correct
- vote production now fails closed on journal write errors
