### PR TITLE
fix(forkchoice): recover from forks whose base is below the persisted tip (v2.5)

### DIFF
--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -46,7 +46,7 @@ fn apply_mining_delay_with_leftover(
     mut delay_ms: u64,
     period_ms: u64,
     last_block_in_turn: bool,
-    first_block_in_turn: bool,
+    enforce_min_delay: bool,
     left_over_ms: u64,
 ) -> u64 {
     if left_over_ms >= period_ms {
@@ -68,10 +68,15 @@ fn apply_mining_delay_with_leftover(
         delay_ms = time_for_mining_ms;
     }
 
-    // For the first block in a turn, a minimum 50ms delay is enforced so the block
-    // is not empty — validator switches require re-execution and root recomputation,
-    // leaving very little time for transaction inclusion.
-    if delay_ms == 0 && first_block_in_turn {
+    // A zero window makes the payload job return immediately with an empty candidate, and on
+    // BSC an empty block carries no system transaction, so peers reject it
+    // (`BscBlockValidationError::UnexpectedSystemTx`). This is not limited to validator
+    // switches: after any stall the parent timestamp is old enough that `delay_ms` collapses
+    // to 0 for ORDINARY in-turn blocks too, and the validator then seals invalid empty blocks
+    // that the network refuses — with `turn_length = 16` that is 15 blocks in 16, and the chain
+    // cannot restart on its own. Every locally built block therefore gets a floor; bid
+    // simulation passes `false` because it only re-executes an already-built bid.
+    if delay_ms == 0 && enforce_min_delay {
         delay_ms = 50;
     }
 
@@ -602,17 +607,18 @@ where
     /// - Applies `left_over_ms` reservation for finalization work.
     /// - Caps blocking time to `period / 5` when last block in turn to reserve
     ///   time for trie root computation; otherwise a full period.
-    /// - Ensures first block in turn gets at least 50ms for transaction inclusion.
+    /// - Ensures every locally built block gets at least 50ms for transaction inclusion, so a
+    ///   stale parent can never produce an empty (and therefore invalid) block.
     pub fn delay_for_mining(&self, snap: &Snapshot, header: &Header, left_over_ms: u64) -> u64 {
         let period_ms = snap.block_interval;
         let last_block_in_turn = snap.last_block_in_one_turn(header.number);
-        let first_block_in_turn = snap.first_block_in_one_turn(header.number);
         let delay_ms = self.delay_for_ramanujan_fork(snap, header);
         apply_mining_delay_with_leftover(
             delay_ms,
             period_ms,
             last_block_in_turn,
-            first_block_in_turn,
+            // Locally built blocks always need a non-zero window, not just the first of a turn.
+            true,
             left_over_ms,
         )
     }
@@ -1027,20 +1033,33 @@ mod tests {
     }
 
     #[test]
-    fn mining_delay_first_block_in_turn_gets_minimum_50ms() {
-        // first_block_in_turn: left_over (600) >= delay (500), so delay = 0,
-        // then first_block_in_turn minimum kicks in: result is 50.
+    fn mining_delay_floor_applies_when_the_window_is_fully_consumed() {
+        // left_over (600) >= delay (500), so delay = 0, then the floor kicks in: result is 50.
         assert_eq!(apply_mining_delay_with_leftover(500, 3000, false, true, 600), 50);
     }
 
     #[test]
+    fn mining_delay_floor_covers_ordinary_in_turn_blocks_not_just_the_first() {
+        // Regression, observed 2026-08-26 on a 3-validator net with turn_length=16: after a
+        // stall the parent timestamp is old, so the raw delay is already 0. The floor used to
+        // be gated on `first_block_in_turn`, leaving 15 blocks in 16 with a ZERO build window;
+        // the payload job then returned an empty candidate, and an empty BSC block carries no
+        // system transaction, so peers rejected it with `UnexpectedSystemTx`. The validator
+        // re-entered the same path every ~3s, signing a different block for the same height.
+        assert_eq!(apply_mining_delay_with_leftover(0, 450, false, true, 0), 50);
+        // Same for the last block of a turn, where the period/5 cap also applies.
+        assert_eq!(apply_mining_delay_with_leftover(0, 450, true, true, 0), 50);
+    }
+
+    #[test]
     fn bid_simulation_delay_ignores_turn_position() {
-        // Bid simulation passes last/first_block_in_turn as false regardless of
+        // Bid simulation passes last_block_in_turn/enforce_min_delay as false regardless of
         // the actual turn position (go-bsc PR #3669): a last-in-turn block gets
         // the full period cap (2500 - 100 = 2400, under the 3000 cap) instead of
         // being squeezed to period/5 = 600 like local mining.
         assert_eq!(apply_mining_delay_with_leftover(2500, 3000, false, false, 100), 2400);
-        // And no 50ms floor: fully consumed delay stays 0.
+        // And no floor: bid simulation only re-executes an already-built bid, so a fully
+        // consumed delay legitimately stays 0.
         assert_eq!(apply_mining_delay_with_leftover(500, 3000, false, false, 600), 0);
     }
 }

--- a/src/consensus/parlia/forkchoice_rule.rs
+++ b/src/consensus/parlia/forkchoice_rule.rs
@@ -1,7 +1,11 @@
-use crate::{chainspec::BscChainSpec, hardforks::BscHardforks};
+use crate::{chainspec::BscChainSpec, hardforks::BscHardforks, metrics::BscConsensusMetrics};
 use alloy_consensus::Header;
 use alloy_primitives::U256;
+use once_cell::sync::Lazy;
 use std::{sync::Arc, cmp::Ordering};
+
+/// Metrics for fork-choice decisions taken without a resolvable total difficulty.
+static FORKCHOICE_METRICS: Lazy<BscConsensusMetrics> = Lazy::new(BscConsensusMetrics::default);
 
 /// Header with additional fork choice metadata.
 ///
@@ -145,12 +149,35 @@ impl BscForkChoiceRule {
         incoming: &HeaderForForkchoice,
         current: &HeaderForForkchoice,
     ) -> Result<bool, crate::consensus::ParliaConsensusErr> {
-        let current_td = current.td.ok_or(
-            crate::consensus::ParliaConsensusErr::UnknownTotalDifficulty(current.header.hash_slow(), current.header.number)
-        )?;
-        let incoming_td = incoming.td.ok_or(
-            crate::consensus::ParliaConsensusErr::UnknownTotalDifficulty(incoming.header.hash_slow(), incoming.header.number)
-        )?;
+        // An unresolvable TD must never abort the decision. Erroring here returns `Err` all the
+        // way out of `update_forkchoice`, so no forkchoice update is ever sent; the canonical
+        // head then stays pinned to `current`, which is precisely what makes the TD
+        // unresolvable in the first place (the persisted chain keeps the losing branch). That
+        // feedback loop is unrecoverable — see `td_unknown_prefers_higher_descendant` and the
+        // upstream `query_header_with_td` deep-fork gap.
+        //
+        // Fall back to height instead: only a STRICTLY higher block may win. That is
+        // conservative in the direction that matters — we never reorg to a sibling or to a
+        // lower block on the strength of missing information, and every candidate reaching
+        // here has already passed full payload validation (the block-import path only calls
+        // fork choice after `PayloadStatusEnum::Valid`), so it is a real, executed chain.
+        let (Some(current_td), Some(incoming_td)) = (current.td, incoming.td) else {
+            let reorg = incoming.header.number > current.header.number;
+            FORKCHOICE_METRICS.td_unknown_fallbacks_total.increment(1);
+            tracing::warn!(
+                target: "bsc::forkchoice",
+                incoming_number = incoming.header.number,
+                incoming_hash = ?incoming.header.hash_slow(),
+                incoming_td = ?incoming.td,
+                current_number = current.header.number,
+                current_hash = ?current.header.hash_slow(),
+                current_td = ?current.td,
+                reorg,
+                "Total difficulty unresolvable; deciding fork choice by height. Persistent \
+                 occurrences mean this node's persisted tip is on a branch below the fork point"
+            );
+            return Ok(reorg);
+        };
 
         tracing::debug!(
             target: "bsc::forkchoice",
@@ -347,5 +374,113 @@ mod tests {
                 curr_num, curr_tgt, inc_num, inc_tgt, should_reorg, result
             );
         }
+    }
+
+    /// Control case: when the incoming TD is known, fork choice decides normally.
+    ///
+    /// Numbers mirror the 2026-07-28 QA-net incident so this sits directly alongside
+    /// `unknown_incoming_td_must_not_wedge_forkchoice` below: stale local head 63 at
+    /// TD 106, incoming majority-chain block 653. This passes on current code.
+    #[test]
+    fn known_incoming_td_decides_normally() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        let current_header = Header { number: 63, ..Default::default() };
+        let incoming_header = Header { number: 653, ..Default::default() };
+
+        let current = HeaderForForkchoice::new(&current_header, Some(U256::from(106)), 0);
+        let incoming = HeaderForForkchoice::new(&incoming_header, Some(U256::from(1200)), 0);
+
+        assert!(
+            rule.is_need_reorg(&incoming, &current).unwrap(),
+            "higher known TD must win"
+        );
+    }
+
+    /// Reproduces the 2026-07-28 QA-net validator wedge.
+    ///
+    /// Background: four reth-bsc validators lost an equal-TD tie at block 61 and
+    /// persisted their own branch to block 63. Because the fork point (61) sits more
+    /// than one block below the persisted tip (63), upstream `query_header_with_td`
+    /// walks the in-memory fork, fails to reach a canonical ancestor, and returns
+    /// `Ok((header, None))` — "TD unknown" — for every incoming majority-chain block.
+    ///
+    /// `head_choice_with_td` then hard-errors `UnknownTotalDifficulty`, so
+    /// `update_forkchoice` returns `Err` and never issues a forkchoice update. The
+    /// provider's canonical head stays at 63 forever, which means the DB can never
+    /// reorg off the losing branch, which means the TD stays unresolvable. The node
+    /// keeps validating the majority chain in memory and reports itself healthy while
+    /// being permanently unable to rejoin — and its miner idles, because it evaluates
+    /// `sign_recently` against the frozen tip where it had already signed.
+    ///
+    /// The primary assertion is that fork choice must not *abort* on an unresolvable
+    /// TD. The second assertion encodes the proposed policy (a strictly
+    /// higher-numbered block wins when its TD cannot be resolved); reviewers may want
+    /// to debate that policy without weakening the first assertion.
+    ///
+    #[test]
+    fn unknown_incoming_td_must_not_wedge_forkchoice() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        // Local head: the losing branch's persisted tip, TD as observed in the incident.
+        let current_header = Header { number: 63, ..Default::default() };
+        // Incoming: a majority-chain block whose TD the engine could not resolve.
+        let incoming_header = Header { number: 653, ..Default::default() };
+
+        let current = HeaderForForkchoice::new(&current_header, Some(U256::from(106)), 0);
+        let incoming = HeaderForForkchoice::new(&incoming_header, None, 0);
+
+        let decision = rule.is_need_reorg(&incoming, &current);
+
+        assert!(
+            decision.is_ok(),
+            "unresolvable incoming TD must not abort fork choice — aborting pins the \
+             canonical head to the stale tip and the node can never rejoin; got {:?}",
+            decision.err()
+        );
+        assert!(
+            decision.unwrap(),
+            "a strictly higher-numbered block must win when its TD cannot be resolved"
+        );
+    }
+
+    /// The height fallback must stay conservative: unresolvable TD is not a licence to reorg
+    /// onto a sibling or a shorter branch.
+    #[test]
+    fn td_unknown_never_reorgs_to_equal_or_lower_height() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        let current_header = Header { number: 100, ..Default::default() };
+        let current = HeaderForForkchoice::new(&current_header, Some(U256::from(200)), 0);
+
+        for incoming_number in [99u64, 100] {
+            let incoming_header = Header { number: incoming_number, ..Default::default() };
+            let incoming = HeaderForForkchoice::new(&incoming_header, None, 0);
+            assert!(
+                !rule.is_need_reorg(&incoming, &current).unwrap(),
+                "must not reorg to height {incoming_number} against current height 100 with TD unknown"
+            );
+        }
+    }
+
+    /// The fallback applies whichever side is unresolvable — a stale local head whose own TD
+    /// cannot be read must not abort the decision either.
+    #[test]
+    fn td_unknown_on_current_side_also_falls_back() {
+        let chain_spec = Arc::new(crate::chainspec::BscChainSpec::from(bsc_qanet()));
+        let rule = BscForkChoiceRule::new(chain_spec);
+
+        let current_header = Header { number: 63, ..Default::default() };
+        let incoming_header = Header { number: 653, ..Default::default() };
+
+        let current = HeaderForForkchoice::new(&current_header, None, 0);
+        let incoming = HeaderForForkchoice::new(&incoming_header, Some(U256::from(1200)), 0);
+
+        let decision = rule.is_need_reorg(&incoming, &current);
+        assert!(decision.is_ok(), "unresolvable current TD must not abort; got {:?}", decision.err());
+        assert!(decision.unwrap(), "higher incoming block must win");
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -59,6 +59,21 @@ pub struct BscConsensusMetrics {
 
     /// Total number of bad blocks detected (equivalent to chain/insert/badBlock)
     pub bad_blocks_total: Counter,
+
+    /// Total number of fork-choice decisions made by height because total difficulty could not
+    /// be resolved.
+    ///
+    /// A sustained nonzero rate means this node's persisted tip sits on a branch below the fork
+    /// point, so the engine cannot derive TD for incoming blocks. Worth alerting on: before the
+    /// height fallback existed, this condition froze the canonical head permanently while the
+    /// node kept reporting itself healthy.
+    pub td_unknown_fallbacks_total: Counter,
+
+    /// Total number of failed forkchoice updates, any cause.
+    ///
+    /// Repeated failures mean the canonical head is not advancing even though blocks are still
+    /// being validated — a state no other metric distinguishes from normal operation.
+    pub forkchoice_update_errors_total: Counter,
 }
 
 /// Metrics for BSC reward distribution

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -1175,6 +1175,8 @@ pub struct BscForkChoiceEngine<P> {
     finality_metrics: BscFinalityMetrics,
     /// Blockchain metrics (including reorg metrics)
     blockchain_metrics: BscBlockchainMetrics,
+    /// Consensus metrics (forkchoice failures)
+    consensus_metrics: crate::metrics::BscConsensusMetrics,
 }
 
 impl<P> BscForkChoiceEngine<P>
@@ -1197,6 +1199,7 @@ where
             ))),
             finality_metrics: BscFinalityMetrics::default(),
             blockchain_metrics: BscBlockchainMetrics::default(),
+            consensus_metrics: crate::metrics::BscConsensusMetrics::default(),
         }
     }
 
@@ -1237,7 +1240,15 @@ where
             .ok_or(ParliaConsensusErr::HeadHashNotFound)?;
 
         // Determine if we need to reorg using fork choice rules
-        let need_reorg = self.is_need_reorg(incoming_header, &current_head).await?;
+        let need_reorg = match self.is_need_reorg(incoming_header, &current_head).await {
+            Ok(need_reorg) => need_reorg,
+            Err(e) => {
+                // Bailing here means no forkchoice update is sent and the canonical head stays
+                // put, so this must be visible in metrics — callers only log it at warn.
+                self.consensus_metrics.forkchoice_update_errors_total.increment(1);
+                return Err(e);
+            }
+        };
 
         // Only count as reorg if:
         // 1. Fork choice says we need to reorg AND
@@ -1492,6 +1503,9 @@ where
             return Ok(*td);
         }
         let td = self.provider.header_td(&hash).map_err(ParliaConsensusErr::internal)?;
+        // Only memoize resolved values. Caching a `None` makes a transient failure permanent for
+        // that hash: TD becomes resolvable once the block is persisted or a common ancestor
+        // appears, but a cached `None` means we would never ask again.
         if td.is_some() {
             self.header_td_cache.write().insert(hash, td);
         }

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -1929,6 +1929,9 @@ mod tests {
         let mut provider = MockProvider::new();
         let header = Header { number: local_tip, ..Default::default() };
         provider.insert(header, U256::from(1));
+        // "TD unknown" is produced by the provider, not the engine: since v2.5 fork choice resolves
+        // TD through `header_td`, and this mock holds only `local_tip`, both the incoming fork
+        // block's hash and its parent's answer `Ok(None)` — the case that used to wedge the head.
         let chain_spec =
             Arc::new(crate::chainspec::BscChainSpec::from(crate::chainspec::bsc::bsc_mainnet()));
 
@@ -1988,9 +1991,9 @@ mod tests {
         tokio::time::timeout(timeout, fcu_rx.recv()).await.ok().flatten()
     }
 
-    /// Like [`spawn_service_with_tip`], but the engine answers `QueryTd` with `Ok(None)` —
-    /// "TD unknown" — which is what the real engine-tree returns for a fork whose divergence
-    /// point lies below the persisted tip (its parent walk stops at `last_block_number`).
+    /// Like [`spawn_service_with_tip`], but the provider cannot resolve the incoming block's TD.
+    /// Since v2.5 fork choice reads TD via `header_td` rather than asking the engine, "TD unknown"
+    /// is what a real node sees for a fork whose divergence point lies below the persisted tip.
     async fn spawn_service_with_td_unknown(
         local_tip: u64,
     ) -> (ImportHandle, mpsc::UnboundedReceiver<ForkchoiceState>, mpsc::UnboundedReceiver<()>) {
@@ -2018,10 +2021,6 @@ mod tests {
                             PayloadStatusEnum::Valid,
                             None,
                         ))));
-                    }
-                    BeaconEngineMessage::QueryTd { number: _, hash: _, tx } => {
-                        // The distinguishing behavior: query succeeds, answer is "unknown".
-                        let _ = tx.send(Ok(None));
                     }
                     _ => {}
                 }
@@ -2067,7 +2066,7 @@ mod tests {
         };
         let new_block = BscNewBlock(NewBlock { block, td: U128::from(1) });
         let hash = new_block.0.block.header.hash_slow();
-        NewBlockMessage { hash, block: Arc::new(new_block), td: Some(U256::from(1)) }
+        NewBlockMessage { hash, block: Arc::new(new_block) }
     }
 
     /// Regression test for the unrecoverable-fork wedge (QA net, 2026-07-28).

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -1988,6 +1988,120 @@ mod tests {
         tokio::time::timeout(timeout, fcu_rx.recv()).await.ok().flatten()
     }
 
+    /// Like [`spawn_service_with_tip`], but the engine answers `QueryTd` with `Ok(None)` —
+    /// "TD unknown" — which is what the real engine-tree returns for a fork whose divergence
+    /// point lies below the persisted tip (its parent walk stops at `last_block_number`).
+    async fn spawn_service_with_td_unknown(
+        local_tip: u64,
+    ) -> (ImportHandle, mpsc::UnboundedReceiver<ForkchoiceState>, mpsc::UnboundedReceiver<()>) {
+        let mut provider = MockProvider::new();
+        let header = Header { number: local_tip, ..Default::default() };
+        provider.insert(header, U256::from(1));
+        let chain_spec =
+            Arc::new(crate::chainspec::BscChainSpec::from(crate::chainspec::bsc::bsc_mainnet()));
+
+        let (to_engine, mut from_engine) = mpsc::unbounded_channel();
+        let engine_handle = ConsensusEngineHandle::new(to_engine);
+
+        let (fcu_tx, fcu_rx) = mpsc::unbounded_channel();
+        let (np_tx, np_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(message) = from_engine.recv().await {
+                match message {
+                    BeaconEngineMessage::NewPayload { payload: _, tx } => {
+                        let _ = np_tx.send(());
+                        let _ = tx.send(Ok(PayloadStatus::new(PayloadStatusEnum::Valid, None)));
+                    }
+                    BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs: _, tx } => {
+                        let _ = fcu_tx.send(state);
+                        let _ = tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::new(
+                            PayloadStatusEnum::Valid,
+                            None,
+                        ))));
+                    }
+                    BeaconEngineMessage::QueryTd { number: _, hash: _, tx } => {
+                        // The distinguishing behavior: query succeeds, answer is "unknown".
+                        let _ = tx.send(Ok(None));
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let (to_import, from_network) = mpsc::unbounded_channel();
+        let (_to_import_mined, from_builder) = mpsc::unbounded_channel();
+        let (_to_import_bid, from_bid_block) = mpsc::unbounded_channel();
+        let (to_hashes, from_hashes) = mpsc::unbounded_channel();
+        let (to_network, import_outcome) = mpsc::unbounded_channel();
+        let handle = ImportHandle::new(to_import, to_hashes, import_outcome);
+
+        let service = ImportService::new(
+            provider,
+            chain_spec,
+            engine_handle,
+            from_network,
+            from_builder,
+            from_bid_block,
+            from_hashes,
+            to_network,
+        );
+        tokio::spawn(Box::pin(async move {
+            service.await.unwrap();
+        }));
+
+        (handle, fcu_rx, np_rx)
+    }
+
+    /// Builds a test block message at `number`.
+    fn create_test_block_at(number: u64) -> NewBlockMessage<BscNewBlock> {
+        let block = BscBlock {
+            header: Header { number, ..Default::default() },
+            body: BscBlockBody {
+                inner: BlockBody {
+                    transactions: Vec::new(),
+                    ommers: Vec::new(),
+                    withdrawals: None,
+                },
+                sidecars: None,
+            },
+        };
+        let new_block = BscNewBlock(NewBlock { block, td: U128::from(1) });
+        let hash = new_block.0.block.header.hash_slow();
+        NewBlockMessage { hash, block: Arc::new(new_block), td: Some(U256::from(1)) }
+    }
+
+    /// Regression test for the unrecoverable-fork wedge (QA net, 2026-07-28).
+    ///
+    /// A node whose persisted tip sits on a branch below the fork point cannot resolve the TD of
+    /// any incoming majority-chain block. Before the fix, `head_choice_with_td` turned that into
+    /// `UnknownTotalDifficulty`, `update_forkchoice` returned `Err`, and **no forkchoice update
+    /// was ever sent** — freezing the canonical head, which kept the DB on the losing branch,
+    /// which kept the TD unresolvable. Four validators stayed dead for an entire run while
+    /// reporting themselves healthy.
+    ///
+    /// This asserts the loop-level property the unit tests cannot: an FCU is actually emitted,
+    /// and it targets the incoming block rather than the stale local tip.
+    #[tokio::test]
+    async fn unresolvable_td_still_emits_forkchoice_update() {
+        // Local tip 63 and incoming 653 mirror the production incident.
+        let (handle, mut fcu_rx, _np_rx) = spawn_service_with_td_unknown(63).await;
+
+        let block = create_test_block_at(653);
+        let expected_head = block.hash;
+        handle.send_block(block, PeerId::random()).unwrap();
+
+        let state = recv_fcu_within(&mut fcu_rx, tokio::time::Duration::from_secs(5))
+            .await
+            .expect(
+                "a forkchoice update must be emitted even when the incoming TD is unresolvable; \
+                 without one the canonical head can never advance and the node is wedged",
+            );
+        assert_eq!(
+            state.head_block_hash, expected_head,
+            "the forkchoice update must target the incoming block, not the stale local tip"
+        );
+    }
+
     #[tokio::test]
     async fn routes_far_behind_announcement_to_pipeline_fcu() {
         // Local tip = 100. Announce a head whose gap exceeds the threshold by

--- a/src/node/network/bsc_protocol/stream.rs
+++ b/src/node/network/bsc_protocol/stream.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::bytes::BytesMut;
 use alloy_rlp::{Decodable, Encodable};
 use bytes::Bytes;
-use futures::Future;
 use futures::{Stream, StreamExt};
 use reth_eth_wire::multiplex::ProtocolConnection;
 use reth_network_api::PeerId;
@@ -11,11 +10,9 @@ use std::{
     task::{ready, Context, Poll},
 };
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
-use tokio::time::{Duration, Sleep};
+use tokio::time::Duration;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-/// Handshake timeout, mirroring the Go implementation.
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 /// TTL for pending range requests before being pruned
 const PENDING_REQ_TTL: Duration = Duration::from_secs(15);
 /// Minimum interval between pending-request pruning passes
@@ -44,17 +41,19 @@ pub enum BscCommand {
     BlocksByRange(BlocksByRangePacket),
 }
 
+/// In-flight `GetBlocksByRange` requests, keyed by request id, each with the
+/// waiter to resolve and the instant it was issued (for TTL pruning).
+type PendingRangeReqs =
+    HashMap<u64, (oneshot::Sender<Result<BlocksByRangePacket, String>>, std::time::Instant)>;
+
 /// Stream that handles incoming BSC protocol messages and returns outgoing messages to send.
 pub struct BscProtocolConnection {
     conn: ProtocolConnection,
     commands: UnboundedReceiverStream<BscCommand>,
-    handshake_deadline: Option<std::pin::Pin<Box<Sleep>>>,
-    handshake_completed: bool,
     is_dialer: bool,
     initial_capability: Option<BscCommand>,
     /// Pending in-flight GetBlocksByRange requests mapped by request_id
-    pending_range_reqs:
-        HashMap<u64, (oneshot::Sender<Result<BlocksByRangePacket, String>>, std::time::Instant)>,
+    pending_range_reqs: PendingRangeReqs,
     /// Protocol version negotiated for this connection (1 or 2)
     proto_version: u64,
     /// PeerId for this connection, if known
@@ -71,8 +70,10 @@ impl BscProtocolConnection {
         proto_version: u64,
         peer_id: Option<PeerId>,
     ) -> Self {
-        let handshake_deadline = Some(Box::pin(tokio::time::sleep(HANDSHAKE_TIMEOUT)));
-        // Both sides should send initial capability in BSC protocol
+        // We still send the capability packet as our first frame: nodes older than
+        // bsc#3483 block on reading it before they will talk to us. Peers on
+        // bsc#3737 and later no longer send one, and drop ours in their no-op
+        // `handleBscCap`, so sending it stays safe across every peer generation.
         // BSC sends []byte{00} which in RLP is encoded as a single byte 0x00
         let initial_capability = Some(BscCommand::Capability {
             protocol_version: proto_version,
@@ -82,8 +83,6 @@ impl BscProtocolConnection {
         Self {
             conn,
             commands: UnboundedReceiverStream::new(commands),
-            handshake_deadline,
-            handshake_completed: false,
             is_dialer,
             initial_capability,
             pending_range_reqs: HashMap::new(),
@@ -217,73 +216,43 @@ impl BscProtocolConnection {
         Poll::Ready(Some(Some(raw)))
     }
 
-    /// Handle handshake-related frames
-    fn handle_handshake_frame(
-        &mut self,
-        frame: &BytesMut,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Option<BytesMut>>> {
-        tracing::debug!(target: "bsc_protocol", "Handshake not completed, processing handshake frame");
-        // Check for handshake timeout
-        if let Some(deadline) = self.handshake_deadline.as_mut() {
-            if Future::poll(deadline.as_mut(), cx).is_ready() {
-                tracing::warn!(target: "bsc_protocol", "BSC handshake timed out");
-                return Poll::Ready(None);
-            }
-        }
-
-        let slice = frame.as_ref();
-        let msg_id = slice[0];
-
-        tracing::debug!(target: "bsc_protocol", "Handshake not completed, processing handshake frame, msg_id: {:?}", msg_id);
-        if msg_id != BscProtoMessageId::Capability as u8 {
-            tracing::warn!(target: "bsc_protocol", got = format_args!("{:#04x}", msg_id), "Expected capability during handshake");
-            return Poll::Ready(None);
-        }
-
-        // Debug: Show what we received
-        tracing::trace!(
-            target: "bsc_protocol",
-            frame_len = slice.len(),
-            frame_bytes = format!("{:02x?}", &slice[..slice.len().min(16)]),
-            "Raw received frame in handshake"
-        );
-
-        match BscCapPacket::decode(&mut &slice[..]) {
-            Ok(pkt) => {
-                if pkt.protocol_version != self.proto_version {
-                    tracing::warn!(target: "bsc_protocol", "Protocol version mismatch: {} != {}", pkt.protocol_version, self.proto_version);
-                    return Poll::Ready(None);
-                }
-
-                tracing::trace!(target: "bsc_protocol", version = pkt.protocol_version, "Received peer capability");
-
-                tracing::trace!(
-                    target: "bsc_protocol",
-                    is_dialer = self.is_dialer,
-                    "BSC handshake completed successfully"
-                );
-
-                self.handshake_completed = true;
-                self.handshake_deadline = None;
-                tracing::trace!(target: "bsc_protocol", "BSC handshake completed");
-                Poll::Ready(Some(None))
-            }
-            Err(e) => {
-                tracing::warn!(target: "bsc_protocol", error = %e, "Failed to decode BSC capability during handshake");
-                Poll::Ready(None)
-            }
-        }
+    /// Handle an inbound protocol message.
+    ///
+    /// Thin wrapper over [`Self::dispatch`] so the dispatch path can be
+    /// exercised without a [`ProtocolConnection`], which has no public
+    /// constructor.
+    fn handle_protocol_message(&mut self, frame: &BytesMut) -> Option<BytesMut> {
+        Self::dispatch(frame, &mut self.pending_range_reqs, self._peer_id, self.proto_version)
     }
 
-    /// Handle normal protocol messages after handshake
-    fn handle_protocol_message(&mut self, frame: &BytesMut) -> Option<BytesMut> {
-        tracing::trace!(target: "bsc_protocol", "Handshake completed, processing normal message");
+    /// Route one inbound frame by message id, returning a frame to send back if
+    /// the message requires a reply.
+    ///
+    /// There is deliberately no handshake gate here. The `bsc` subprotocol used
+    /// to require `Capability` (0x00) as the first inbound frame, but bsc#3483
+    /// removed the blocking read and bsc#3737 stops sending the packet
+    /// altogether, so a peer's first frame is normally `Votes`. Rejecting that
+    /// tore down the whole RLPx session — a satellite stream ending drops the
+    /// `eth` primary with it — so 0x00 is now ignored exactly like geth's
+    /// no-op `handleBscCap`.
+    fn dispatch(
+        frame: &BytesMut,
+        pending_range_reqs: &mut PendingRangeReqs,
+        peer_id: Option<PeerId>,
+        proto_version: u64,
+    ) -> Option<BytesMut> {
         let slice = frame.as_ref();
         let msg_id = slice[0];
 
-        tracing::trace!(target: "bsc_protocol", "Handshake completed, processing normal message, msg_id: {:?}", msg_id);
+        tracing::trace!(target: "bsc_protocol", msg_id = format_args!("{msg_id:#04x}"), "Processing message");
         match msg_id {
+            x if x == BscProtoMessageId::Capability as u8 => {
+                // Legacy handshake packet. Peers older than bsc#3737 still send
+                // it; the version it carries was only ever a restatement of the
+                // devp2p-negotiated version we already hold, so drop it.
+                tracing::trace!(target: "bsc_protocol", peer = ?peer_id, "Ignoring legacy BSC capability message");
+                None
+            }
             x if x == BscProtoMessageId::Votes as u8 => {
                 tracing::trace!(target: "bsc_protocol", "Processing votes message");
                 match VotesPacket::decode(&mut &slice[..]) {
@@ -335,7 +304,7 @@ impl BscProtocolConnection {
                             blocks = res.blocks.len(),
                             "Received BlocksByRange"
                         );
-                        if let Some((waiter, _)) = self.pending_range_reqs.remove(&res.request_id) {
+                        if let Some((waiter, _)) = pending_range_reqs.remove(&res.request_id) {
                             let _ = waiter.send(Ok(res));
                         } else {
                             tracing::trace!(target: "bsc_protocol", "No waiter for request_id; dropping BlocksByRange");
@@ -350,14 +319,14 @@ impl BscProtocolConnection {
                         tracing::warn!(
                             target: "bsc_protocol",
                             error = %err.error,
-                            peer = ?self._peer_id,
-                            proto_version = self.proto_version,
+                            peer = ?peer_id,
+                            proto_version,
                             frame_len = slice.len(),
                             request_id = ?err.request_id,
                             "Failed to decode BlocksByRangePacket"
                         );
                         if let Some(req_id) = err.request_id {
-                            if let Some((waiter, _)) = self.pending_range_reqs.remove(&req_id) {
+                            if let Some((waiter, _)) = pending_range_reqs.remove(&req_id) {
                                 let _ = waiter.send(Err(format!(
                                     "failed to decode BlocksByRangePacket: {}",
                                     err.error
@@ -406,21 +375,156 @@ impl Stream for BscProtocolConnection {
                 Poll::Pending => return Poll::Pending,
             };
 
-            // Process the frame based on handshake state
-            if !this.handshake_completed {
-                match this.handle_handshake_frame(&raw_frame, cx) {
-                    Poll::Ready(Some(Some(response))) => return Poll::Ready(Some(response)),
-                    Poll::Ready(Some(None)) => continue, // Handshake complete, no response needed
-                    Poll::Ready(None) => return Poll::Ready(None), // Handshake failed
-                    Poll::Pending => return Poll::Pending,
-                }
-            } else if let Some(response) = this.handle_protocol_message(&raw_frame) {
+            if let Some(response) = this.handle_protocol_message(&raw_frame) {
                 return Poll::Ready(Some(response));
-            } else {
-                // After handshake, check if there are more messages to process
-                // If not, we'll loop back and check for commands/incoming frames
-                continue;
             }
+            // No reply needed; loop back for more commands/incoming frames.
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consensus::parlia::{
+        vote::{VoteData, VoteEnvelope},
+        votes,
+    };
+    use alloy_primitives::{FixedBytes, B256};
+
+    /// `ProtocolConnection` has no public constructor, so these tests drive
+    /// [`BscProtocolConnection::dispatch`] directly. That is the function the
+    /// deleted handshake gate used to sit in front of.
+    fn dispatch(frame: &BytesMut) -> Option<BytesMut> {
+        let mut pending = HashMap::new();
+        BscProtocolConnection::dispatch(frame, &mut pending, None, 2)
+    }
+
+    fn frame_of(msg: impl Encodable) -> BytesMut {
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf);
+        buf
+    }
+
+    fn cap_frame(protocol_version: u64) -> BytesMut {
+        frame_of(BscCapPacket { protocol_version, extra: Bytes::from_static(&[0x00u8]) })
+    }
+
+    /// A synthetic vote. Signature/address are never verified on this path, and
+    /// `target_number` is kept high so vote-pool pruning cannot evict it.
+    fn vote(target_number: u64, target_hash: B256) -> VoteEnvelope {
+        VoteEnvelope {
+            vote_address: FixedBytes::<48>::repeat_byte(0xab),
+            signature: FixedBytes::<96>::repeat_byte(0xcd),
+            data: VoteData {
+                source_number: target_number - 1,
+                source_hash: B256::repeat_byte(0x11),
+                target_number,
+                target_hash,
+            },
+        }
+    }
+
+    // === The bsc#3737 peer generation ===
+
+    /// A peer on bsc#3737 sends no capability packet at all, so its first frame
+    /// is a vote. The old handshake gate answered that with `Poll::Ready(None)`,
+    /// which ended the satellite stream and took the whole RLPx session (`eth`
+    /// included) down with it. It must now be processed normally.
+    #[test]
+    fn votes_as_very_first_frame_are_processed() {
+        let target_hash = B256::repeat_byte(0x5a);
+        let before = votes::len();
+
+        let reply = dispatch(&frame_of(VotesPacket(vec![vote(30_000_000, target_hash)])));
+
+        assert!(reply.is_none(), "a votes frame needs no reply");
+        assert_eq!(votes::len(), before + 1, "the vote must reach the pool");
+    }
+
+    /// Same peer generation, but the first frame is a range request. The old
+    /// gate dropped the session here too, which is what broke fork recovery.
+    #[test]
+    fn get_blocks_by_range_as_very_first_frame_is_answered() {
+        let req = GetBlocksByRangePacket {
+            request_id: 0xfeed,
+            start_block_height: 1,
+            start_block_hash: B256::repeat_byte(0x22),
+            count: 1,
+        };
+
+        let reply = dispatch(&frame_of(req)).expect("a range request must be answered");
+
+        assert_eq!(reply[0], BscProtoMessageId::BlocksByRange as u8);
+        let decoded =
+            crate::node::network::blocks_by_range::decode_blocks_by_range(&mut &reply[..])
+                .expect("reply must decode");
+        assert_eq!(decoded.request_id, 0xfeed, "reply must echo the request id");
+    }
+
+    // === Legacy capability packet: tolerated, never fatal ===
+
+    /// Peers older than bsc#3737 still send the packet. Ignore it, as geth's
+    /// no-op `handleBscCap` does.
+    #[test]
+    fn legacy_capability_frame_is_ignored() {
+        assert!(dispatch(&cap_frame(2)).is_none());
+    }
+
+    /// The old gate tore the session down on a version mismatch. The devp2p
+    /// `Hello` exchange already fixed the version, so this packet's copy of it
+    /// carries no authority and a disagreement must not be fatal.
+    #[test]
+    fn capability_frame_with_mismatched_version_is_ignored() {
+        assert!(dispatch(&cap_frame(1)).is_none(), "version 1 cap on a v2 conn");
+        assert!(dispatch(&cap_frame(99)).is_none(), "nonsense version");
+    }
+
+    /// The old gate also tore the session down when the packet failed to decode.
+    /// We no longer decode it at all, so a truncated or garbage body is inert.
+    #[test]
+    fn malformed_capability_frame_is_ignored() {
+        let mut truncated = cap_frame(2);
+        truncated.truncate(2);
+        assert!(dispatch(&truncated).is_none(), "truncated cap payload");
+
+        let bare_id = BytesMut::from(&[BscProtoMessageId::Capability as u8][..]);
+        assert!(dispatch(&bare_id).is_none(), "message id with no payload");
+    }
+
+    // === Unchanged behaviour, guarded against the refactor ===
+
+    #[test]
+    fn blocks_by_range_resolves_the_pending_waiter() {
+        let (tx, rx) = oneshot::channel();
+        let mut pending = HashMap::new();
+        pending.insert(7u64, (tx, std::time::Instant::now()));
+
+        let frame = frame_of(BlocksByRangePacket { request_id: 7, blocks: Vec::new() });
+        let reply = BscProtocolConnection::dispatch(&frame, &mut pending, None, 2);
+
+        assert!(reply.is_none(), "a range response needs no reply");
+        assert!(pending.is_empty(), "the waiter must be consumed");
+        let resolved = rx.blocking_recv().expect("waiter must be resolved");
+        assert_eq!(resolved.expect("response must be Ok").request_id, 7);
+    }
+
+    #[test]
+    fn unknown_message_id_is_ignored() {
+        assert!(dispatch(&BytesMut::from(&[0x7fu8, 0xc0][..])).is_none());
+    }
+
+    /// We must keep *sending* the capability packet: nodes older than bsc#3483
+    /// block on reading it. Guards the frame we put on the wire first.
+    #[test]
+    fn outbound_capability_frame_is_still_well_formed() {
+        let encoded = BscProtocolConnection::encode_command(BscCommand::Capability {
+            protocol_version: 2,
+            extra: Bytes::from_static(&[0x00u8]),
+        });
+
+        assert_eq!(encoded[0], BscProtoMessageId::Capability as u8);
+        let decoded = BscCapPacket::decode(&mut &encoded[..]).expect("must round-trip");
+        assert_eq!(decoded.protocol_version, 2);
     }
 }


### PR DESCRIPTION
# fix(forkchoice): recover from forks whose base is below the persisted tip (v2.5)

## Symptom

On `qa_new_ten_validators`, all four reth-bsc validators froze while the six geth
validators kept producing. The frozen nodes looked healthy: 9 peers, `bad_blocks_total 0`,
and `reth_bsc_consensus_current_block_height` climbing (991) — but `eth_blockNumber` was
pinned hundreds of blocks back (691), and `eth_getBlockByNumber` for the majority head
returned `null`. Each node sat on its own out-of-turn branch (difficulty `0x1`) while the
canonical chain carried in-turn blocks (`0x2`) at the same heights.

Reproduces after `bsc_cluster.sh remote_reset` with reth v2.5.1.

## Root cause

`update_forkchoice` -> `is_need_reorg` -> `head_choice_with_td` hard-errored
`UnknownTotalDifficulty` whenever a TD could not be resolved. The `Err` propagated out, so
**no forkchoice update was ever sent**, so the canonical head stayed pinned to the losing
branch, so the persisted chain kept that branch, so the TD stayed unresolvable. A closed
loop with no exit.

TD is unresolvable exactly when a fork's divergence point lies *below* the node's persisted
tip. `remote_reset` arms that condition deterministically: it runs `remote_upgrade` ~100s
after genesis, gracefully restarting every node mid-chain, and reth's shutdown flushes its
in-memory chain to disk. Any node then sitting on a minority branch has its *persisted* tip
moved onto that branch, above the fork point.

`b13e12d82` fixed this in July on the pre-v2.5 line and was never merged into
`feat/upgrade-reth-v2.5`, so v2.5.1 shipped without it.

## Relationship to #452

#452 ("fix(forkchoice): recover from forks whose base is below the persisted tip", opened
2026-07-29) carries the same fix for the pre-v2.5 line and is still open. `b13e12d82` is on no
other published branch — not `develop`, not `main` — so no release line has ever had it.

This PR is that fix rebased onto the v2.5 line, minus the parts `03fc2399d` has since
reimplemented independently. #452 as written does **not** compile on `feat/upgrade-reth-v2.5`:
its harness uses `BeaconEngineMessage::QueryTd` and `NewBlockMessage.td`, both removed in v2.5.
Suggest closing #452 as superseded once this lands, and landing an equivalent on `develop`,
which is still exposed (the original July incident happened on that line).

## Why this got worse in v2.5 specifically

The hard error predates v2.5; what changed is where TD comes from.

```
pre-v2.5:  header_td() -> engine.query_td(number, hash)   + NewBlockMessage carried `td` on the wire
v2.5:      header_td() -> self.provider.header_td(&hash)  (both of the above removed upstream)
```

With the peer supplying TD and the engine answering queries, `Some(td)` was almost guaranteed
and the `ok_or(...)?` lines were near-unreachable — the July incident was one rare geometry.
v2.5 must derive TD locally, and local derivation fails precisely when a fork's base sits below
the persisted tip, so the same latent bug became routine. v2.5 didn't introduce it; it removed
what was masking it.

## What this changes

Production (small, deliberately):

- `forkchoice_rule.rs` — when either side's TD is unresolvable, decide by **height** instead
  of erroring. Only a *strictly higher* block may win.
- `metrics.rs` / `consensus.rs` — `td_unknown_fallbacks_total` (fallback taken) and
  `forkchoice_update_errors_total` (a bail-out that leaves the head unadvanced). Neither state
  was distinguishable from normal operation before.

Deliberately **not** taken from `b13e12d82`: its TD-resolution rework and `parent_derived_td`
helper. `03fc2399d` already implements that half on this branch, and better — it derives the
incoming block's TD from its parent *first* (correct, since an incoming block is not yet
imported, so its own hash cannot resolve), where the July version tried the own-hash lookup
first and fell back. It also already avoids memoizing `None`.

After this change no production path constructs `UnknownTotalDifficulty`.

## Trade-off, stated explicitly

Height-wins is weaker than TD-wins. With a TD unknown the decision ignores difficulty, so a
longer-but-lighter chain wins. Every candidate has already passed full payload validation and
Parlia signature checks, so producing one requires validator keys — but this is a real
semantic loosening, accepted against the alternative of a permanent freeze. It is conservative
in the direction that matters: never reorg to a sibling or to a lower block on missing
information.

Not fixed: a provider `Err` (as opposed to `Ok(None)`) still aborts `is_need_reorg` and emits
no FCU. That is now visible via `forkchoice_update_errors_total` rather than silent.

## Evidence

Unit, on this branch's base (`feat/upgrade-reth-v2.5`), same test either side of the fix:

| build | `unresolvable_td_still_emits_forkchoice_update` |
|---|---|
| base + test only | **FAILS** — 5.03s timeout, no FCU ever emitted |
| base + this fix   | **PASSES** in 0.01s |

Full set: 7 passed / 0 failed, including the two pre-existing fork-choice tests (normal TD
path unregressed).

Live, ten-node local cluster under partition/heal stress on the unfixed binary: 24
`Failed to update fork choice` and 25 `Unknown total difficulty`. The defect fires outside a
mock. A live wedge-and-recover demo was NOT obtained locally: a partition leaves the reth
group *behind*, so the majority's blocks arrive disconnected and backfill unwinds the DB
without ever consulting TD. The wedge needs the node to be *ahead* at heal.

## How to verify on the QA net

Deploy, then `remote_reset`. Healthy result is all ten in lockstep past a few hundred blocks
with `reth_bsc_consensus_td_unknown_fallbacks_total` incrementing. The counter mattering is the
point: if it stays at 0, no fork occurred and the run proves nothing. `forkchoice_update_errors_total`
should stay at 0.

Also required on that net, unrelated to this PR: `osakaTime`/`--override.osaka` on
`PassedForkTime` for both clients (reth's fork-ID hash is wrong when `osakaTime` exceeds
pascal/lorentz/maxwell/fermi — `parser.rs` inserts Osaka before them and `fork_id`'s dedup
assumes ascending order), and `EnableSentryNode=false` unless the sentry tier is running.

---

# Second fix in this PR: every locally built block gets a non-zero build window

`1b9e9c54b`. Separate bug, same v2.5 line, found while validating this branch on a 3-validator
benchmark net.

`apply_mining_delay_with_leftover` enforced its 50ms floor only when `first_block_in_turn`. With
`turn_length = 16` that leaves 15 blocks in 16 unprotected, and after any stall the parent
timestamp is old enough that the raw delay is already 0 for those blocks. The payload job then
returns immediately with an empty candidate — and an empty BSC block carries no system
transaction, so peers reject it with `BscBlockValidationError::UnexpectedSystemTx`. The miner
re-enters the same path every ~3s, signing a *different* block for the same height, i.e.
double-signing.

Observed 2026-08-26, chain id 714, 3 validators, `turn_length=16`, 140M gas, pool at its 100k cap:

```
Outer loop: Job already timeout, returning best payload block_number=25344109 job_elapsed_ms=0 timeout_ms=0
Succeed to pick and finalize the best payload  tx_count=0 gas_used=0 pick_index=1 total_len=1
ERROR Reject Double Sign!! block: 25344109, hash: 0xf7699442…   (6 distinct hashes, same height, same ms)
```
and the resulting block, against its parent:
```
25,344,420  1678 txs; idx=1677 to=0x…1000 from=<miner> input=0xf340fa01…   <- deposit(), block reward
25,344,421  0 transactions                                                 <- rejected by the other reth validator AND geth
```

The floor's own comment already stated its purpose — "so the block is not empty" — the condition
was simply too narrow. The parameter is renamed `enforce_min_delay` and `delay_for_mining` passes
`true`; `delay_for_bid_simulation` keeps passing `false`, since it only re-executes an
already-built bid and a fully consumed window there is legitimate (its existing test asserting
`0` is unchanged and still passes).

Consequence of the bug worth noting: a network that stalls cannot restart on its own. The node
holding the tip refuses to mine (its sync gate holds) while any node that will mine can only
produce invalid empty blocks.

Two further defects observed alongside it, NOT fixed here:
- The miner is not gated on pipeline/backfill sync — it mines on a head hundreds of blocks stale.
- `Reject Double Sign!!` logs at ERROR but does not stop submission, and
  `reth_bsc_consensus_double_signs_detected_total` stays 0 while it fires.
