### PR TITLE
ci: run Cargo Test on 16-core org runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
 
   test:
     name: Cargo Test
-    runs-on: ubuntu-latest
+    # org larger runner (16 vCPU / 64 GB). Tests run with --test-threads=1, so
+    # the cores go to building the workspace and to the tokio runtimes the node
+    # tests spin up internally, not to test-level parallelism.
+    runs-on: ${{ github.repository == 'bnb-chain/reth-bsc' && 'runner-linux-x64-16core' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     # org larger runner (16 vCPU / 64 GB). Tests run with --test-threads=1, so
     # the cores go to building the workspace and to the tokio runtimes the node
     # tests spin up internally, not to test-level parallelism.
-    runs-on: ${{ github.repository == 'bnb-chain/reth-bsc' && 'runner-linux-x64-16core' || 'ubuntu-latest' }}
+    runs-on: runner-linux-x64-16core
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies


### PR DESCRIPTION
Gives the `test` job more cores for the workspace build and for the tokio runtimes the node tests start internally. Tests run with `--test-threads=1`, so this does not buy test-level parallelism.

Requires `runner-linux-x64-16core` to exist in the org runner group with this repo granted access.