### PR TITLE
fix(parlia): authenticate vote envelopes and bound inbound vote cost

### DIFF
--- a/src/consensus/parlia/bls_signer.rs
+++ b/src/consensus/parlia/bls_signer.rs
@@ -7,7 +7,7 @@ use serde_json::Value as JsonValue;
 use std::fs;
 
 use super::vote::{VoteAddress, VoteData, VoteEnvelope, VoteSignature};
-use blst::min_pk::SecretKey;
+use blst::{min_pk::{PublicKey, SecretKey, Signature}, BLST_ERROR};
 
 /// Domain separation tag used across the codebase for BLS (POP scheme).
 const BLST_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
@@ -18,6 +18,7 @@ pub enum BlsSignerError {
     NotInitialized,
     InvalidSecret(String),
     SigningFailed(String),
+    VerificationFailed(String),
 }
 
 impl std::fmt::Display for BlsSignerError {
@@ -27,6 +28,7 @@ impl std::fmt::Display for BlsSignerError {
             Self::NotInitialized => write!(f, "Global BLS signer not initialized"),
             Self::InvalidSecret(e) => write!(f, "Invalid BLS secret: {e}"),
             Self::SigningFailed(e) => write!(f, "BLS signing failed: {e}"),
+            Self::VerificationFailed(e) => write!(f, "BLS vote verification failed: {e}"),
         }
     }
 }
@@ -69,6 +71,28 @@ impl BlsVoteSigner {
         let vote_address = self.public_key()?;
         let signature = self.sign_hash(data.hash())?;
         Ok(VoteEnvelope { vote_address, signature, data })
+    }
+}
+
+/// Verifies a vote envelope's BLS signature against the vote address it carries.
+///
+/// Mirrors go-bsc's `VoteEnvelope.Verify` (`core/types/vote.go`), which is invoked
+/// from `basicVerify` before a vote may enter the pool: the 48-byte `vote_address`
+/// must decode to a valid BLS public key, the 96-byte `signature` to a valid G2
+/// point, and the signature must cover `data.hash()`.
+///
+/// This is the authentication boundary for votes arriving from peers — nothing
+/// between the wire and the pool checks them otherwise, and pool contents feed
+/// both finality notification and vote-attestation assembly.
+pub fn verify_vote_envelope(envelope: &VoteEnvelope) -> Result<(), BlsSignerError> {
+    let pk = PublicKey::from_bytes(envelope.vote_address.as_slice())
+        .map_err(|e| BlsSignerError::VerificationFailed(format!("invalid vote address: {e:?}")))?;
+    let sig = Signature::from_bytes(envelope.signature.as_slice())
+        .map_err(|e| BlsSignerError::VerificationFailed(format!("invalid signature: {e:?}")))?;
+
+    match sig.verify(true, envelope.data.hash().as_slice(), BLST_DST, &[], &pk, true) {
+        BLST_ERROR::BLST_SUCCESS => Ok(()),
+        e => Err(BlsSignerError::VerificationFailed(format!("{e:?}"))),
     }
 }
 

--- a/src/consensus/parlia/consensus.rs
+++ b/src/consensus/parlia/consensus.rs
@@ -890,10 +890,23 @@ where
             return Ok(()); // If not enough unique votes, do not append attestation
         }
         // Aggregate signatures
+        // A malformed signature must not panic the block-production path: votes
+        // are attacker-controlled up to this point, and only validator-set
+        // membership has been checked above.
         let sigs: Vec<blst::min_pk::Signature> = ordered_unique
             .iter()
-            .map(|(_, _, sig)| blst::min_pk::Signature::from_bytes(sig.as_slice()).unwrap())
-            .collect();
+            .map(|(_, addr, sig)| {
+                blst::min_pk::Signature::from_bytes(sig.as_slice()).map_err(|e| {
+                    tracing::warn!(
+                        target: "parlia::consensus",
+                        vote_address = %addr,
+                        error = ?e,
+                        "undecodable vote signature, skipping attestation",
+                    );
+                    ParliaConsensusError::AggregateSignatureError
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         let sigs_ref: Vec<&blst::min_pk::Signature> = sigs.iter().collect();
         let aggregate = blst::min_pk::AggregateSignature::aggregate(&sigs_ref, false)
             .map_err(|_| ParliaConsensusError::AggregateSignatureError)?;

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -23,6 +23,8 @@ use crate::shared;
 use std::time::SystemTime;
 
 const LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER: u64 = 256;
+/// Envelope hashes to remember as rejected. ~32 B each, so a few hundred KB.
+const REJECTED_VOTE_CACHE_SIZE: usize = 8192;
 /// Size of the LRU cache for tracking finality notifications (matches geth's finalizedNotified)
 const FINALIZED_NOTIFIED_CACHE_SIZE: usize = 21;
 
@@ -165,6 +167,11 @@ impl VotePool {
         self.total_votes
     }
 
+    /// Whether this vote hash is already pooled.
+    fn contains(&self, vote_hash: &B256) -> bool {
+        self.received_votes.contains(vote_hash)
+    }
+
     fn len_for_block(&self, block_hash: &B256) -> usize {
         self.cur_votes.get(block_hash).map(|vm| vm.vote_messages.len()).unwrap_or(0)
     }
@@ -227,6 +234,15 @@ static VOTE_POOL: Lazy<RwLock<VotePool>> = Lazy::new(|| RwLock::new(VotePool::ne
 /// Throttles [`put_vote`]'s lazy prune to once per observed head advance.
 static LAST_PRUNED_BLOCK: AtomicU64 = AtomicU64::new(0);
 
+/// Envelope hashes that already failed verification.
+///
+/// `received_votes` only records votes that were *admitted*, so without this an
+/// attacker could replay one invalid envelope indefinitely and buy a fresh
+/// pairing with each copy. Bounded, so the cache itself cannot be grown into a
+/// memory problem; eviction only costs a repeated verification.
+static REJECTED_VOTES: Lazy<RwLock<LruCache<B256, ()>>> =
+    Lazy::new(|| RwLock::new(LruCache::new(NonZero::new(REJECTED_VOTE_CACHE_SIZE).unwrap())));
+
 /// Global metrics for vote operations.
 static VOTE_METRICS: Lazy<BscVoteMetrics> = Lazy::new(BscVoteMetrics::default);
 
@@ -251,6 +267,24 @@ fn update_vote_pool_size_metric(size: usize) {
 /// straight off the wire with nothing else checking them. Mirrors go-bsc's
 /// `basicVerify` -> `VoteEnvelope.Verify` (`core/vote/vote_pool.go`).
 pub fn put_vote(vote: VoteEnvelope) {
+    // Verification is a pairing, and votes arrive unsolicited from any peer, so
+    // do the cheap exclusions first. Votes are gossiped, meaning the same
+    // envelope reaches us from every peer that has it: verifying before
+    // deduplicating buys one pairing per copy for a single useful vote. go-bsc
+    // orders these the same way in `basicVerify`.
+    let vote_hash = vote.hash();
+    if VOTE_POOL.read().expect("vote pool poisoned").contains(&vote_hash) {
+        metrics::counter!("votes.duplicate").increment(1);
+        return;
+    }
+    // An envelope that already failed verification cannot start passing, so a
+    // replay of it need not be re-verified. Without this, one invalid envelope
+    // can be resent indefinitely to buy CPU.
+    if REJECTED_VOTES.read().expect("rejected vote cache poisoned").peek(&vote_hash).is_some() {
+        metrics::counter!("votes.rejected.replay").increment(1);
+        return;
+    }
+
     VOTE_METRICS.bls_verifications_total.increment(1);
     let started = std::time::Instant::now();
     let verified = crate::consensus::parlia::bls_signer::verify_vote_envelope(&vote);
@@ -258,6 +292,7 @@ pub fn put_vote(vote: VoteEnvelope) {
 
     if let Err(e) = verified {
         VOTE_METRICS.bls_verification_failures_total.increment(1);
+        REJECTED_VOTES.write().expect("rejected vote cache poisoned").put(vote_hash, ());
         tracing::debug!(
             target: "bsc::vote_pool",
             vote_address = %vote.vote_address,
@@ -554,6 +589,61 @@ mod tests {
             fetch_vote_by_block_hash(data.target_hash).len(),
             1,
             "vote under a mismatched vote address was admitted",
+        );
+
+        let _ = drain();
+    }
+
+
+    /// Verification is gated behind two cheap exclusions, so unsolicited traffic
+    /// cannot buy unbounded pairings.
+    ///
+    /// Votes are gossiped, so the same envelope arrives from every peer holding
+    /// it; and an envelope that failed verification can be replayed forever.
+    /// Neither should cost more than one verification in total.
+    #[test]
+    fn repeated_envelopes_are_verified_at_most_once() {
+        let _ = drain();
+
+        let mut raw = [0u8; 32];
+        raw[31] = 1;
+        let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
+        let data = VoteData {
+            source_number: 800,
+            source_hash: B256::from([0x81; 32]),
+            target_number: 801,
+            target_hash: B256::from([0x82; 32]),
+        };
+        let genuine = signer.sign_vote(data).expect("sign vote");
+
+        // A valid vote, then replays of it: deduplicated by the pool.
+        put_vote(genuine.clone());
+        assert_eq!(fetch_vote_by_block_hash(data.target_hash).len(), 1);
+        for _ in 0..10 {
+            put_vote(genuine.clone());
+        }
+        assert_eq!(
+            fetch_vote_by_block_hash(data.target_hash).len(),
+            1,
+            "re-relayed copies must not accumulate",
+        );
+
+        // An invalid envelope, then replays of it: remembered as rejected.
+        let forged =
+            VoteEnvelope { signature: VoteSignature::from([0x42u8; 96]), ..genuine.clone() };
+        let forged_hash = forged.hash();
+        put_vote(forged.clone());
+        assert!(
+            REJECTED_VOTES.read().unwrap().peek(&forged_hash).is_some(),
+            "a failed envelope is remembered so replays skip the pairing",
+        );
+        for _ in 0..10 {
+            put_vote(forged.clone());
+        }
+        assert_eq!(
+            fetch_vote_by_block_hash(data.target_hash).len(),
+            1,
+            "replayed forgeries never enter the pool",
         );
 
         let _ = drain();

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -245,7 +245,40 @@ fn update_vote_pool_size_metric(size: usize) {
 }
 
 /// Insert a single vote into the pool (deduplicated by hash).
+///
+/// The vote's BLS signature is authenticated first: pool contents drive both
+/// finality notification and vote-attestation assembly, and votes reach here
+/// straight off the wire with nothing else checking them. Mirrors go-bsc's
+/// `basicVerify` -> `VoteEnvelope.Verify` (`core/vote/vote_pool.go`).
 pub fn put_vote(vote: VoteEnvelope) {
+    VOTE_METRICS.bls_verifications_total.increment(1);
+    let started = std::time::Instant::now();
+    let verified = crate::consensus::parlia::bls_signer::verify_vote_envelope(&vote);
+    VOTE_METRICS.bls_verification_duration_seconds.record(started.elapsed().as_secs_f64());
+
+    if let Err(e) = verified {
+        VOTE_METRICS.bls_verification_failures_total.increment(1);
+        tracing::debug!(
+            target: "bsc::vote_pool",
+            vote_address = %vote.vote_address,
+            target_number = vote.data.target_number,
+            error = %e,
+            "rejecting vote with invalid BLS signature",
+        );
+        return;
+    }
+
+    put_vote_inner(vote);
+}
+
+/// Test-only ingress that skips signature verification, for tests exercising
+/// pool/finality bookkeeping with synthetic vote addresses.
+#[cfg(test)]
+pub fn put_vote_unchecked(vote: VoteEnvelope) {
+    put_vote_inner(vote);
+}
+
+fn put_vote_inner(vote: VoteEnvelope) {
     let target_hash = vote.data.target_hash;
 
     // Get pending block number for malicious vote detection scope
@@ -413,6 +446,7 @@ fn maybe_notify_finality(target_hash: B256, votes_for_block: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::consensus::parlia::bls_signer::BlsVoteSigner;
     use crate::consensus::parlia::vote::{VoteAddress, VoteData, VoteEnvelope, VoteSignature};
     use alloy_primitives::B256;
 
@@ -441,9 +475,11 @@ mod tests {
         let target_hash = B256::from([0x11; 32]);
         let other_target_hash = B256::from([0x22; 32]);
 
-        put_vote(vote_with_source(target_hash, 10, 1));
-        put_vote(vote_with_source(target_hash, 11, 2));
-        put_vote(vote_with_source(other_target_hash, 10, 3));
+        // Synthetic vote addresses/signatures: bypass BLS verification, which is
+        // covered separately by `put_vote_rejects_invalid_signature`.
+        put_vote_unchecked(vote_with_source(target_hash, 10, 1));
+        put_vote_unchecked(vote_with_source(target_hash, 11, 2));
+        put_vote_unchecked(vote_with_source(other_target_hash, 10, 3));
 
         let all_for_target = fetch_vote_by_block_hash(target_hash);
         assert_eq!(all_for_target.len(), 2);
@@ -461,4 +497,66 @@ mod tests {
 
         let _ = drain();
     }
+
+    /// A vote reaching the pool is authenticated: pool contents drive finality
+    /// notification and attestation assembly, and nothing between the wire and
+    /// here checks them. See go-bsc `basicVerify` -> `VoteEnvelope.Verify`.
+    #[test]
+    fn put_vote_rejects_unauthenticated_votes() {
+        let _ = drain();
+
+        let mut raw = [0u8; 32];
+        raw[31] = 1;
+        let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
+
+        let data = VoteData {
+            source_number: 10,
+            source_hash: B256::from([0xaa; 32]),
+            target_number: 100,
+            target_hash: B256::from([0xbb; 32]),
+        };
+        let genuine = signer.sign_vote(data).expect("sign vote");
+
+        // Baseline: a correctly signed vote is admitted.
+        put_vote(genuine.clone());
+        assert_eq!(fetch_vote_by_block_hash(data.target_hash).len(), 1, "genuine vote rejected");
+
+        // Undecodable signature under a real validator's address. Before
+        // verification existed this reached attestation assembly and panicked
+        // in `Signature::from_bytes(..).unwrap()`.
+        put_vote(VoteEnvelope {
+            signature: VoteSignature::from([0x42u8; 96]),
+            ..genuine.clone()
+        });
+        assert_eq!(
+            fetch_vote_by_block_hash(data.target_hash).len(),
+            1,
+            "vote with undecodable signature was admitted",
+        );
+
+        // Well-formed signature by the same key, but over different vote data:
+        // decodes cleanly, so only real verification catches it.
+        let other = VoteData { target_number: 101, ..data };
+        let mismatched = signer.sign_vote(other).expect("sign vote").signature;
+        put_vote(VoteEnvelope { signature: mismatched, ..genuine.clone() });
+        assert_eq!(
+            fetch_vote_by_block_hash(data.target_hash).len(),
+            1,
+            "vote signed over different data was admitted",
+        );
+
+        // Signature valid in isolation, but attributed to another validator.
+        put_vote(VoteEnvelope {
+            vote_address: VoteAddress::from([0x07u8; 48]),
+            ..genuine
+        });
+        assert_eq!(
+            fetch_vote_by_block_hash(data.target_hash).len(),
+            1,
+            "vote under a mismatched vote address was admitted",
+        );
+
+        let _ = drain();
+    }
+
 }

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -601,8 +601,8 @@ mod tests {
             data: vote_data,
         };
 
-        vote_pool::put_vote(vote1);
-        vote_pool::put_vote(vote2);
+        vote_pool::put_vote_unchecked(vote1);
+        vote_pool::put_vote_unchecked(vote2);
 
         let finalized = engine.get_finalized_number_and_hash(&head).unwrap();
         assert_eq!(finalized, (9, parent_hash));
@@ -680,7 +680,7 @@ mod tests {
             signature: VoteSignature::default(),
             data: vote_data,
         };
-        vote_pool::put_vote(vote1);
+        vote_pool::put_vote_unchecked(vote1);
 
         // Finality should NOT advance - still returns fallback
         let finalized = engine.get_finalized_number_and_hash(&head).unwrap();
@@ -762,8 +762,8 @@ mod tests {
             signature: VoteSignature::default(),
             data: wrong_vote_data,
         };
-        vote_pool::put_vote(vote1);
-        vote_pool::put_vote(vote2);
+        vote_pool::put_vote_unchecked(vote1);
+        vote_pool::put_vote_unchecked(vote2);
 
         // Finality should NOT advance - votes have wrong source
         let finalized = engine.get_finalized_number_and_hash(&head).unwrap();
@@ -845,8 +845,8 @@ mod tests {
             signature: VoteSignature::default(),
             data: wrong_vote_data,
         };
-        vote_pool::put_vote(vote1);
-        vote_pool::put_vote(vote2);
+        vote_pool::put_vote_unchecked(vote1);
+        vote_pool::put_vote_unchecked(vote2);
 
         // Finality should NOT advance - votes have wrong target
         let finalized = engine.get_finalized_number_and_hash(&head).unwrap();
@@ -920,8 +920,8 @@ mod tests {
             signature: VoteSignature::default(),
             data: vote_data,
         };
-        vote_pool::put_vote(vote1);
-        vote_pool::put_vote(vote2);
+        vote_pool::put_vote_unchecked(vote1);
+        vote_pool::put_vote_unchecked(vote2);
 
         // Finality should NOT advance because head.number - 1 (11) != current_justified_number (9)
         let finalized = engine.get_finalized_number_and_hash(&head).unwrap();
@@ -1003,7 +1003,7 @@ mod tests {
                 signature: VoteSignature::default(),
                 data: vote_data,
             };
-            vote_pool::put_vote(vote);
+            vote_pool::put_vote_unchecked(vote);
         }
 
         let finalized = engine.get_finalized_number_and_hash(&head).unwrap();
@@ -1015,7 +1015,7 @@ mod tests {
             signature: VoteSignature::default(),
             data: vote_data,
         };
-        vote_pool::put_vote(vote14);
+        vote_pool::put_vote_unchecked(vote14);
 
         let finalized = engine.get_finalized_number_and_hash(&head).unwrap();
         assert_eq!(finalized, (99, parent_hash), "14 votes should reach quorum");

--- a/src/node/network/bsc_protocol/stream.rs
+++ b/src/node/network/bsc_protocol/stream.rs
@@ -18,6 +18,59 @@ const PENDING_REQ_TTL: Duration = Duration::from_secs(15);
 /// Minimum interval between pending-request pruning passes
 const PRUNE_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Inbound votes a single peer may send us per second, mirroring go-bsc's
+/// `receiveRateLimitPerSecond` (`eth/protocols/bsc/peer.go`). 21 validators each
+/// produce one vote per block interval, so ~47/s is the natural ceiling; go-bsc
+/// sets 68 to leave headroom.
+const VOTE_RECEIVE_RATE_LIMIT_PER_SECOND: u32 = 68;
+/// Length of one vote-accounting period (go-bsc's `secondsPerPeriod`).
+const VOTE_RATE_LIMIT_PERIOD: Duration = Duration::from_secs(30);
+/// Total inbound votes a peer may send us within one period.
+const VOTE_RATE_LIMIT_PER_PERIOD: u32 =
+    VOTE_RECEIVE_RATE_LIMIT_PER_SECOND * VOTE_RATE_LIMIT_PERIOD.as_secs() as u32;
+
+/// Per-peer inbound vote budget over a tumbling window.
+///
+/// Ports go-bsc's `Peer.IsOverLimitAfterReceivingVotes`, including its two
+/// quirks: the window is tumbling rather than sliding, and the packet that rolls
+/// the window is not charged against the new period.
+#[derive(Debug)]
+struct VoteRateLimiter {
+    period_begin: std::time::Instant,
+    period_counter: u32,
+}
+
+impl VoteRateLimiter {
+    fn new() -> Self {
+        Self { period_begin: std::time::Instant::now(), period_counter: 0 }
+    }
+
+    /// Charges `n` received votes against this peer's budget and reports whether
+    /// the peer has exceeded it.
+    ///
+    /// `n` is the number of votes the peer *sent*, not the number we admit. That
+    /// matches go-bsc's `handleVotes`, which charges `len(ann.Votes)` so the
+    /// limit bounds what a peer can push at us rather than what we happen to
+    /// consume.
+    fn is_over_limit_after_receiving(&mut self, n: u32) -> bool {
+        if self.period_begin.elapsed() >= VOTE_RATE_LIMIT_PERIOD {
+            self.period_begin = std::time::Instant::now();
+            self.period_counter = 0;
+            return false;
+        }
+        self.period_counter = self.period_counter.saturating_add(n);
+        self.period_counter > VOTE_RATE_LIMIT_PER_PERIOD
+    }
+
+    /// Backdates the period so the next charge rolls the window.
+    #[cfg(test)]
+    fn force_period_expiry(&mut self) {
+        self.period_begin = std::time::Instant::now()
+            .checked_sub(VOTE_RATE_LIMIT_PERIOD)
+            .expect("machine uptime exceeds one accounting period");
+    }
+}
+
 use super::protocol::proto::BscProtoMessageId;
 use crate::node::network::blocks_by_range::{
     build_blocks_by_range_response, BlocksByRangePacket, GetBlocksByRangePacket,
@@ -60,6 +113,8 @@ pub struct BscProtocolConnection {
     _peer_id: Option<PeerId>,
     /// Last time we pruned pending requests
     last_prune: std::time::Instant,
+    /// Inbound vote budget for this peer
+    vote_rate_limiter: VoteRateLimiter,
 }
 
 impl BscProtocolConnection {
@@ -89,6 +144,7 @@ impl BscProtocolConnection {
             proto_version,
             _peer_id: peer_id,
             last_prune: std::time::Instant::now(),
+            vote_rate_limiter: VoteRateLimiter::new(),
         }
     }
 
@@ -222,7 +278,13 @@ impl BscProtocolConnection {
     /// exercised without a [`ProtocolConnection`], which has no public
     /// constructor.
     fn handle_protocol_message(&mut self, frame: &BytesMut) -> Option<BytesMut> {
-        Self::dispatch(frame, &mut self.pending_range_reqs, self._peer_id, self.proto_version)
+        Self::dispatch(
+            frame,
+            &mut self.pending_range_reqs,
+            self._peer_id,
+            self.proto_version,
+            &mut self.vote_rate_limiter,
+        )
     }
 
     /// Route one inbound frame by message id, returning a frame to send back if
@@ -240,6 +302,7 @@ impl BscProtocolConnection {
         pending_range_reqs: &mut PendingRangeReqs,
         peer_id: Option<PeerId>,
         proto_version: u64,
+        vote_rate_limiter: &mut VoteRateLimiter,
     ) -> Option<BytesMut> {
         let slice = frame.as_ref();
         let msg_id = slice[0];
@@ -258,6 +321,17 @@ impl BscProtocolConnection {
                 match VotesPacket::decode(&mut &slice[..]) {
                     Ok(packet) => {
                         let count = packet.0.len();
+                        let charged = u32::try_from(count).unwrap_or(u32::MAX);
+                        if vote_rate_limiter.is_over_limit_after_receiving(charged) {
+                            tracing::debug!(
+                                target: "bsc_protocol",
+                                peer = ?peer_id,
+                                count,
+                                period_total = vote_rate_limiter.period_counter,
+                                "peer exceeded its inbound vote budget, dropping packet",
+                            );
+                            return None;
+                        }
                         handle_votes_broadcast(packet);
                         tracing::trace!(target: "bsc_protocol", count, "Processed votes packet");
                         None
@@ -397,8 +471,12 @@ mod tests {
     /// [`BscProtocolConnection::dispatch`] directly. That is the function the
     /// deleted handshake gate used to sit in front of.
     fn dispatch(frame: &BytesMut) -> Option<BytesMut> {
+        dispatch_with_limiter(frame, &mut VoteRateLimiter::new())
+    }
+
+    fn dispatch_with_limiter(frame: &BytesMut, limiter: &mut VoteRateLimiter) -> Option<BytesMut> {
         let mut pending = HashMap::new();
-        BscProtocolConnection::dispatch(frame, &mut pending, None, 2)
+        BscProtocolConnection::dispatch(frame, &mut pending, None, 2, limiter)
     }
 
     fn frame_of(msg: impl Encodable) -> BytesMut {
@@ -505,7 +583,8 @@ mod tests {
         pending.insert(7u64, (tx, std::time::Instant::now()));
 
         let frame = frame_of(BlocksByRangePacket { request_id: 7, blocks: Vec::new() });
-        let reply = BscProtocolConnection::dispatch(&frame, &mut pending, None, 2);
+        let reply =
+            BscProtocolConnection::dispatch(&frame, &mut pending, None, 2, &mut VoteRateLimiter::new());
 
         assert!(reply.is_none(), "a range response needs no reply");
         assert!(pending.is_empty(), "the waiter must be consumed");
@@ -531,4 +610,66 @@ mod tests {
         let decoded = BscCapPacket::decode(&mut &encoded[..]).expect("must round-trip");
         assert_eq!(decoded.protocol_version, 2);
     }
+
+    // === G1: per-peer inbound vote budget (go-bsc receiveRateLimitPerSecond) ===
+
+    #[test]
+    fn vote_budget_matches_go_bsc() {
+        // 68 votes/s over a 30s period => 2040, the value go-bsc compares against.
+        assert_eq!(VOTE_RATE_LIMIT_PER_PERIOD, 2040);
+    }
+
+    #[test]
+    fn vote_rate_limiter_admits_exactly_the_budget() {
+        let mut l = VoteRateLimiter::new();
+        assert!(!l.is_over_limit_after_receiving(VOTE_RATE_LIMIT_PER_PERIOD), "budget itself must pass");
+        assert!(l.is_over_limit_after_receiving(1), "one vote past the budget must trip");
+    }
+
+    #[test]
+    fn vote_rate_limiter_accumulates_across_packets() {
+        let mut l = VoteRateLimiter::new();
+        for _ in 0..(VOTE_RATE_LIMIT_PER_PERIOD / 68) {
+            assert!(!l.is_over_limit_after_receiving(68));
+        }
+        assert!(l.is_over_limit_after_receiving(1), "budget is per period, not per packet");
+    }
+
+    /// go-bsc resets the counter and returns false when the period has elapsed,
+    /// without charging the packet that rolled the window. Ported deliberately.
+    #[test]
+    fn vote_rate_limiter_rolls_the_window_uncharged() {
+        let mut l = VoteRateLimiter::new();
+        assert!(l.is_over_limit_after_receiving(VOTE_RATE_LIMIT_PER_PERIOD + 1));
+
+        l.force_period_expiry();
+        assert!(!l.is_over_limit_after_receiving(VOTE_RATE_LIMIT_PER_PERIOD + 1), "window roll allows");
+        assert_eq!(l.period_counter, 0, "the rolling packet is not charged");
+        assert!(!l.is_over_limit_after_receiving(VOTE_RATE_LIMIT_PER_PERIOD), "fresh budget");
+    }
+
+    /// A peer over budget has its packet dropped before the vote reaches the pool.
+    #[test]
+    fn over_budget_votes_packet_never_reaches_the_pool() {
+        let target_hash = B256::repeat_byte(0x7c);
+        let mut limiter = VoteRateLimiter::new();
+        assert!(limiter.is_over_limit_after_receiving(VOTE_RATE_LIMIT_PER_PERIOD + 1));
+
+        let before = votes::len();
+        let reply = dispatch_with_limiter(
+            &frame_of(VotesPacket(vec![vote(30_000_100, target_hash)])),
+            &mut limiter,
+        );
+        assert!(reply.is_none(), "a votes frame needs no reply");
+        assert_eq!(votes::len(), before, "over-budget packet must not be ingested");
+
+        // Once the window rolls, the same peer is served again.
+        limiter.force_period_expiry();
+        let _ = dispatch_with_limiter(
+            &frame_of(VotesPacket(vec![vote(30_000_100, target_hash)])),
+            &mut limiter,
+        );
+        assert_eq!(votes::len(), before + 1, "peer must be served after the window rolls");
+    }
+
 }

--- a/src/node/network/bsc_protocol/stream.rs
+++ b/src/node/network/bsc_protocol/stream.rs
@@ -387,10 +387,11 @@ impl Stream for BscProtocolConnection {
 mod tests {
     use super::*;
     use crate::consensus::parlia::{
+        bls_signer::BlsVoteSigner,
         vote::{VoteData, VoteEnvelope},
         votes,
     };
-    use alloy_primitives::{FixedBytes, B256};
+    use alloy_primitives::B256;
 
     /// `ProtocolConnection` has no public constructor, so these tests drive
     /// [`BscProtocolConnection::dispatch`] directly. That is the function the
@@ -410,19 +411,22 @@ mod tests {
         frame_of(BscCapPacket { protocol_version, extra: Bytes::from_static(&[0x00u8]) })
     }
 
-    /// A synthetic vote. Signature/address are never verified on this path, and
-    /// `target_number` is kept high so vote-pool pruning cannot evict it.
+    /// A genuinely signed vote: the pool authenticates the BLS signature before
+    /// admitting anything, so a synthetic one would be dropped and this test
+    /// would no longer prove the frame was dispatched. `target_number` is kept
+    /// high so vote-pool pruning cannot evict it.
     fn vote(target_number: u64, target_hash: B256) -> VoteEnvelope {
-        VoteEnvelope {
-            vote_address: FixedBytes::<48>::repeat_byte(0xab),
-            signature: FixedBytes::<96>::repeat_byte(0xcd),
-            data: VoteData {
+        let mut raw = [0u8; 32];
+        raw[31] = 1;
+        let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
+        signer
+            .sign_vote(VoteData {
                 source_number: target_number - 1,
                 source_hash: B256::repeat_byte(0x11),
                 target_number,
                 target_hash,
-            },
-        }
+            })
+            .expect("sign vote")
     }
 
     // === The bsc#3737 peer generation ===


### PR DESCRIPTION
## Summary

Votes arriving on the `bsc` subprotocol were inserted into the vote pool without their BLS signature being checked. Pool contents feed both vote-attestation assembly and finality notification, so those consumers implicitly trusted input that had never been validated.

Authenticating them introduces a cost of its own — a pairing per vote, paid on unsolicited input from any peer — so this PR also bounds that cost. The two halves belong together: merging the check without the bound would put the expense on `develop` with nothing in front of it.

That is also how upstream shipped it. go-bsc's `3fd5b0c149` ("defend ddos voting attack with other mini fix according to audit", bnb-chain/bsc#1741) added the per-peer receive limit **and** the first-vote-only packet cap in a single commit. reth-bsc already had the packet cap and was missing the budget.

## What lands here

Three commits:

**1. Authenticate vote envelopes before pool admission**

`verify_vote_envelope` (`bls_signer.rs`) matches go-bsc's `VoteEnvelope.Verify`: the vote address must decode to a valid BLS public key, the signature to a valid G2 point, and the signature must cover `data.hash()`. `put_vote` calls it before insertion.

Verification lives in the pool rather than at network ingress, matching where go-bsc puts it, so any future non-broadcast path into the pool is covered too. The local vote producer re-verifies a signature it just created, which is negligible against a 750 ms slot.

Separately, attestation assembly (`consensus.rs`) now propagates an undecodable signature as `AggregateSignatureError` rather than unwrapping it. go-bsc returns an error at the equivalent step (`MultipleSignaturesFromBytes`), and the miner already handles this by logging and continuing without an attestation.

**2. Gate verification behind dedup and a rejected-replay cache**

Two ways a peer could buy unbounded pairings:

- Gossip means the same envelope reaches us from every peer holding it. Verifying before deduplicating spent one pairing per copy for a single useful vote. Deduplication now runs first, matching go-bsc's ordering in `basicVerify`.
- `received_votes` records only *admitted* votes, so a failed envelope left no trace and could be replayed indefinitely, each copy buying a fresh pairing. A bounded LRU of rejected envelope hashes closes that — an envelope that failed cannot start passing, so a replay need not be re-verified. Bounded, so the cache cannot itself be grown into a memory problem; eviction only costs a repeated verification.

**3. Per-peer inbound vote rate limit** *(previously #488, folded in)*

68 votes/sec over a 30s period — 2040 per peer per period — held per connection, ported from go-bsc's `receiveRateLimitPerSecond` (`eth/protocols/bsc/peer.go`). Two upstream quirks are reproduced deliberately and pinned by tests, since both look like bugs while porting and either would diverge from geth's admission behaviour:

- the window is **tumbling**, not sliding
- the packet that **rolls** the window is not charged against the new period

Charged by votes *sent* rather than votes admitted, matching `handleVotes`. Over-budget packets are dropped silently; the peer is not disconnected, also matching upstream.

Headroom: 21 validators produce ~28 votes/sec network-wide at 0.75s blocks, comfortably inside 68/sec per peer — which is why upstream chose 68 over the natural ~47.

## Resulting order in `put_vote`

Cheapest first, so the expensive check is reached as rarely as possible:

1. deduplication against the pool
2. rejected-envelope replay cache
3. per-peer receive budget *(network layer, `stream.rs`)*
4. BLS verification

## Test changes

Tests exercising pool and finality bookkeeping with synthetic vote addresses move to a test-only `put_vote_unchecked` ingress. The bsc#3737 first-frame regression test now builds a genuinely signed vote, so it still proves the frame was dispatched rather than silently passing on a dropped vote.

- `put_vote_rejects_unauthenticated_votes` — four cases: a genuine vote is admitted; an undecodable signature is rejected; a *well-formed* signature over different vote data is rejected (it decodes cleanly, so only real verification catches it); a valid signature attributed to another validator is rejected.
- `repeated_envelopes_are_verified_at_most_once` — replays of a valid envelope are deduplicated, and a rejected envelope is remembered so its replays skip the pairing.
- rate-limiter tests covering the budget arithmetic, accumulation across packets, the tumbling-window roll, and an over-budget packet failing to reach the pool.

## Validation

- `cargo test --all -- --test-threads=1` — 545 passed, 0 failed
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --tests --all-features` — clean
- **10-node devnet** (4 reth / 6 geth, same chain, only the reth binary swapped): finalized tracked `head-1` across 395 blocks with zero rejection of legitimate votes; block rate unchanged.

reth holds 4 of 10 validator slots and quorum is 7, so a reth node can never reach quorum on reth-origin votes alone — every assembled attestation required geth-produced votes to pass the new check. The log instrument was confirmed capable of firing before the zero was trusted (string present in the built binary, absent from the baseline).

Caveat: the devnet run predates the rate limiter being folded in and the rebase onto current `develop`. The code paths are unchanged, but the measured binary does not correspond to this SHA. Worth a re-run before merge if the evidence needs to match the commit.

## Review findings addressed

Both Hashdit reports on this PR concerned the same thing — unauthenticated peers driving BLS verification.

The first is covered by commit 2. The second correctly observed that a cache only absorbs *repeats*, and that a peer varying vote data produces unique envelopes; that is what commit 3 bounds, and why #488 was folded in rather than left as a follow-up.

Worth recording that a cheaper in-PR mitigation was looked for and does not exist. A validator-set membership pre-filter ahead of the pairing — rejecting a minted key with a hashmap lookup — fails here, because without #489's admission window the epoch-boundary guard must return "undecidable" for a far-future target (the head's validator set says nothing about a block thousands ahead), and undecidable means admit. An attacker simply picks distant target numbers. That filter only bites once targets are bounded to `head+11`.

The flagged `0000...0001` key material is a BLS scalar of integer value 1, constructed inline to get a deterministic test keypair. Not a credential, and it corresponds to no funded or privileged account.

## Rest of the stack

- **#489** — the `(head-256, head+11]` admission window
- **#491** — current/future vote pool split, origin checks at admission and promotion, per-target caps, oversize shedding
- **#492** — pins first-vote-only packet admission, which matches current go-bsc and is easy to "fix" in the wrong direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
