### PR TITLE
fix(parlia): split the vote pool and complete vote admission checks

### DIFF
--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -31,11 +31,33 @@ const REJECTED_VOTE_CACHE_SIZE: usize = 8192;
 /// Votes retained per target hash once we hold the target block, matching
 /// go-bsc's `maxCurVoteAmountPerBlock`. One per validator suffices.
 const MAX_CUR_VOTE_AMOUNT_PER_BLOCK: usize = 21;
-/// Votes retained per target hash while the target block is still unknown
-/// (`maxFutureVoteAmountPerBlock`). Higher than the current-vote cap because we
-/// cannot yet resolve the target's validator set, so non-validator votes cannot
-/// be filtered out until promotion.
-const MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK: usize = 50;
+// Deliberately no per-target cap on future votes.
+//
+// go-bsc has one (`maxFutureVoteAmountPerBlock = 50`), but capping a bucket
+// whose contents cannot be authenticated turns the cap into a censorship tool.
+// A future vote is only signature-checked, and a signature proves the signer
+// holds the key in the envelope — not that the key belongs to a validator. So
+// any peer can mint keys, self-sign 50 envelopes for a target hash it has seen
+// and we have not, and fill the bucket. Genuine validator votes for that target
+// are then refused, and nothing re-sends them: votes are broadcast once. When
+// the block finally arrives the junk is discarded at promotion, but the real
+// votes are already lost, so that target can never reach local quorum.
+//
+// Leaving the future bucket uncapped trades that for bounded waste. Memory is
+// still held by three other limits: the `(head-256, head+11]` admission window
+// bounds how many distinct targets can be addressed, `MAX_VOTES_IN_POOL` bounds
+// the pool overall, and the per-peer receive budget bounds the rate. Junk is
+// reclaimed by promotion and by pruning. Losing good votes is not recoverable;
+// holding useless ones briefly is.
+//
+// NOTE: go-bsc appears to share this weakness. `basicVerify` applies the 50-cap
+// to future votes with only `vote.Verify()` behind it, `VerifyVote` runs solely
+// for current votes, and there is no per-peer accounting for future votes
+// anywhere in `core/vote/vote_pool.go`. Worth reporting upstream rather than
+// assuming reth-bsc is the only client affected.
+//
+// The real fix, ahead of both clients, is per-peer fairness for unauthenticated
+// votes, which needs peer identity plumbed into the ingest path.
 /// Size of the LRU cache for tracking finality notifications (matches geth's finalizedNotified)
 const FINALIZED_NOTIFIED_CACHE_SIZE: usize = 21;
 
@@ -122,17 +144,20 @@ impl VotePool {
         }
     }
 
-    /// Whether this target hash already holds its per-pool maximum.
+    /// Whether this target hash already holds its maximum current votes.
     ///
-    /// go-bsc applies the same cap in `basicVerify`, bounding how much one block
-    /// hash can cost us regardless of how many peers relay votes for it.
+    /// Applies to current votes only. Those have passed the origin check, so the
+    /// cap can only ever refuse a vote we know to be surplus — one validator's
+    /// vote per target is all that counts, and the cap sits at the validator
+    /// count. Future votes are intentionally uncapped; see the note above the
+    /// absent `MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK`.
     fn is_at_capacity(&self, block_hash: &B256, is_future: bool) -> bool {
-        let (votes, cap) = if is_future {
-            (&self.future_votes, MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK)
-        } else {
-            (&self.cur_votes, MAX_CUR_VOTE_AMOUNT_PER_BLOCK)
-        };
-        votes.get(block_hash).is_some_and(|vm| vm.vote_messages.len() >= cap)
+        if is_future {
+            return false;
+        }
+        self.cur_votes
+            .get(block_hash)
+            .is_some_and(|vm| vm.vote_messages.len() >= MAX_CUR_VOTE_AMOUNT_PER_BLOCK)
     }
 
     /// Insert a vote and return the new *current* vote count for its target
@@ -1017,6 +1042,63 @@ mod tests {
         let _ = drain();
     }
 
+
+
+
+    // === D1: per-target vote caps ===
+
+    /// Future votes carry no per-target cap; current votes do.
+    ///
+    /// A future vote is only signature-checked, and a signature does not show
+    /// the signer is a validator — so a cap there refuses genuine votes as
+    /// readily as forged ones, and whichever arrives second loses. Current votes
+    /// have passed the origin check, so their cap only ever refuses surplus.
+    #[test]
+    fn future_votes_are_uncapped_and_current_votes_are_capped() {
+        let mut pool = VotePool::new();
+
+        let envelope = |target: B256, i: usize| {
+            let mut address = VoteAddress::default();
+            address[0] = (i & 0xff) as u8;
+            address[1] = ((i >> 8) & 0xff) as u8;
+            VoteEnvelope {
+                vote_address: address,
+                signature: VoteSignature::default(),
+                data: VoteData {
+                    source_number: 10,
+                    source_hash: B256::from([0x71; 32]),
+                    target_number: 11,
+                    target_hash: target,
+                },
+            }
+        };
+
+        // Well past go-bsc's former future cap of 50.
+        let future_target = B256::from([0x77; 32]);
+        for i in 0..200 {
+            assert!(
+                !pool.is_at_capacity(&future_target, true),
+                "a future target must never refuse a vote for capacity (i={i})",
+            );
+            pool.insert(envelope(future_target, i), 0, true);
+        }
+        assert_eq!(
+            pool.future_votes.get(&future_target).map(|vm| vm.vote_messages.len()),
+            Some(200),
+            "every future vote is retained",
+        );
+
+        // Current votes still stop at the validator-count cap.
+        let cur_target = B256::from([0x78; 32]);
+        for i in 0..MAX_CUR_VOTE_AMOUNT_PER_BLOCK {
+            assert!(!pool.is_at_capacity(&cur_target, false), "below the cap (i={i})");
+            pool.insert(envelope(cur_target, 1_000 + i), 0, false);
+        }
+        assert!(
+            pool.is_at_capacity(&cur_target, false),
+            "current votes must stop at MAX_CUR_VOTE_AMOUNT_PER_BLOCK",
+        );
+    }
 
     /// One target hash cannot be made to hold unbounded votes, however many
     /// distinct validators sign for it. Mirrors go-bsc's cap in `basicVerify`.

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -31,33 +31,27 @@ const REJECTED_VOTE_CACHE_SIZE: usize = 8192;
 /// Votes retained per target hash once we hold the target block, matching
 /// go-bsc's `maxCurVoteAmountPerBlock`. One per validator suffices.
 const MAX_CUR_VOTE_AMOUNT_PER_BLOCK: usize = 21;
-// Deliberately no per-target cap on future votes.
-//
-// go-bsc has one (`maxFutureVoteAmountPerBlock = 50`), but capping a bucket
-// whose contents cannot be authenticated turns the cap into a censorship tool.
-// A future vote is only signature-checked, and a signature proves the signer
-// holds the key in the envelope — not that the key belongs to a validator. So
-// any peer can mint keys, self-sign 50 envelopes for a target hash it has seen
-// and we have not, and fill the bucket. Genuine validator votes for that target
-// are then refused, and nothing re-sends them: votes are broadcast once. When
-// the block finally arrives the junk is discarded at promotion, but the real
-// votes are already lost, so that target can never reach local quorum.
-//
-// Leaving the future bucket uncapped trades that for bounded waste. Memory is
-// still held by three other limits: the `(head-256, head+11]` admission window
-// bounds how many distinct targets can be addressed, `MAX_VOTES_IN_POOL` bounds
-// the pool overall, and the per-peer receive budget bounds the rate. Junk is
-// reclaimed by promotion and by pruning. Losing good votes is not recoverable;
-// holding useless ones briefly is.
-//
-// NOTE: go-bsc appears to share this weakness. `basicVerify` applies the 50-cap
-// to future votes with only `vote.Verify()` behind it, `VerifyVote` runs solely
-// for current votes, and there is no per-peer accounting for future votes
-// anywhere in `core/vote/vote_pool.go`. Worth reporting upstream rather than
-// assuming reth-bsc is the only client affected.
-//
-// The real fix, ahead of both clients, is per-peer fairness for unauthenticated
-// votes, which needs peer identity plumbed into the ingest path.
+/// Votes retained per target hash for future targets whose sender we managed to
+/// authenticate, matching go-bsc's `maxFutureVoteAmountPerBlock`.
+///
+/// Applied *only* when `future_vote_sender_is_validator` returned `Some(true)`.
+/// A cap over unauthenticatable contents is a censorship tool, not a safety
+/// limit: a future vote is signature-checked and nothing more, and a signature
+/// proves the signer holds the key in the envelope, not that the key belongs to
+/// a validator. Capping such a bucket lets any peer mint keys, self-sign enough
+/// envelopes to fill it, and have genuine validator votes refused —
+/// permanently, since votes are broadcast once and never re-sent. Reported by
+/// Hashdit Bot on #491.
+///
+/// NOTE: go-bsc applies its cap unconditionally. `basicVerify` uses
+/// `maxFutureVoteAmountPerBlock` with only `vote.Verify()` behind it,
+/// `VerifyVote` runs solely for current votes, and there is no per-peer
+/// accounting for future votes in `core/vote/vote_pool.go`. Worth raising
+/// upstream rather than assuming reth-bsc is the only client affected.
+const MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK: usize = 50;
+/// Hard ceiling on pooled votes. Exceeding it triggers a prune and, failing
+/// that, shedding of future votes.
+const MAX_VOTES_IN_POOL: usize = 32 * 1024 * 2;
 /// Size of the LRU cache for tracking finality notifications (matches geth's finalizedNotified)
 const FINALIZED_NOTIFIED_CACHE_SIZE: usize = 21;
 
@@ -151,9 +145,15 @@ impl VotePool {
     /// vote per target is all that counts, and the cap sits at the validator
     /// count. Future votes are intentionally uncapped; see the note above the
     /// absent `MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK`.
-    fn is_at_capacity(&self, block_hash: &B256, is_future: bool) -> bool {
+    fn is_at_capacity(&self, block_hash: &B256, is_future: bool, authenticated: bool) -> bool {
         if is_future {
-            return false;
+            // Only cap a future bucket whose sender we authenticated; see the
+            // note on MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK.
+            return authenticated
+                && self
+                    .future_votes
+                    .get(block_hash)
+                    .is_some_and(|vm| vm.vote_messages.len() >= MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK);
         }
         self.cur_votes
             .get(block_hash)
@@ -356,6 +356,43 @@ impl VotePool {
         true
     }
 
+    /// Drops future votes, furthest-ahead target first, until at least `target`
+    /// entries have been released. Returns how many votes were dropped.
+    ///
+    /// The escape hatch for a flood that pruning cannot reach because every
+    /// entry is still inside the admission window. Furthest-ahead first because
+    /// those are the least likely to be promoted soon.
+    fn shed_future_votes(&mut self, target: usize) -> usize {
+        let mut order: Vec<VoteData> = self.future_votes_pq.heap.iter().map(|r| r.0).collect();
+        order.sort_by_key(|vd| std::cmp::Reverse(vd.target_number));
+
+        let mut shed = 0usize;
+        for vd in order {
+            if shed >= target {
+                break;
+            }
+            if let Some(box_) = self.future_votes.remove(&vd.target_hash) {
+                shed += box_.vote_messages.len();
+                self.total_votes = self.total_votes.saturating_sub(box_.vote_messages.len());
+                for entry in box_.vote_messages {
+                    self.received_votes.remove(&entry.hash);
+                }
+            }
+        }
+        // Rebuild the queue over what survived.
+        self.future_votes_pq = VotesPriorityQueue::new();
+        let surviving: Vec<VoteData> = self
+            .future_votes
+            .values()
+            .filter_map(|vm| vm.vote_messages.first().map(|e| e.envelope.data))
+            .collect();
+        for vd in surviving {
+            self.future_votes_pq.push(vd);
+        }
+        metrics::gauge!("futureVotesPq.local").set(self.future_votes_pq.heap.len() as f64);
+        shed
+    }
+
     /// Prune old votes based on the latest block number.
     /// Removes votes where targetNumber + LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER - 1 < latestBlockNumber
     fn prune(&mut self, latest_block_number: BlockNumber) {
@@ -443,6 +480,39 @@ pub fn justified_pair_for_hash(header_hash: &B256) -> Option<(BlockNumber, B256)
     let sp = shared::get_snapshot_provider()?;
     let snap = sp.snapshot_by_hash(header_hash)?;
     Some((snap.vote_data.target_number, snap.vote_data.target_hash))
+}
+
+/// Whether a *future* vote's sender is a validator, judged against the snapshot
+/// at our own head.
+///
+/// `verify_vote_origin` cannot run on a future vote: it resolves membership from
+/// the target's parent snapshot, and we do not hold the target. But the
+/// validator set only changes on epoch boundaries, and the admission window caps
+/// a future target at `head + 11`, so the set at our head is the set that will
+/// govern the target — unless an epoch boundary falls in between.
+///
+/// Returns:
+/// - `Some(true)`  sender is a validator in the current set
+/// - `Some(false)` sender is not, and cannot become one inside the window
+/// - `None` undecidable: no snapshot, or an epoch boundary lies in
+///   `(head, target]` so the governing set may differ. Callers admit these
+///   uncapped rather than guess.
+fn future_vote_sender_is_validator(vote: &VoteEnvelope) -> Option<bool> {
+    let head_number = shared::get_best_canonical_block_number()?;
+    let head = shared::get_canonical_header_by_number(head_number)?;
+    let snap = shared::get_snapshot_provider()?.snapshot_by_hash(&head.hash_slow())?;
+    if snap.validators_map.is_empty() {
+        return None;
+    }
+
+    // An epoch boundary between head and target can swap the set out from under
+    // us; decline to judge rather than risk rejecting an incoming validator.
+    let epoch = snap.epoch_num.max(1);
+    if vote.data.target_number / epoch > head_number / epoch {
+        return None;
+    }
+
+    Some(snap.validators_map.values().any(|v| v.vote_addr == vote.vote_address))
 }
 
 /// Whether a vote plausibly originates from a validator of its target block and
@@ -620,6 +690,30 @@ fn put_vote_inner(vote: VoteEnvelope) {
     let is_future = can_classify
         && shared::get_canonical_header_by_hash_from_provider(&target_hash).is_none();
 
+    // Future votes cannot be origin-checked (membership lives in the target's
+    // parent snapshot, which we do not hold), but we can still ask whether the
+    // sender is a validator *at all*, against our own head. An attacker's minted
+    // key is in no validator set, so this refuses the junk before a bucket is
+    // ever created. `None` means undecidable — admitted, but left uncapped.
+    let future_sender_authenticated = if is_future {
+        match future_vote_sender_is_validator(&vote) {
+            Some(false) => {
+                metrics::counter!("votes.rejected.future_not_a_validator").increment(1);
+                tracing::debug!(
+                    target: "bsc::vote_pool",
+                    vote_address = %vote.vote_address,
+                    target_number,
+                    "rejecting future vote from a non-validator",
+                );
+                return;
+            }
+            Some(true) => true,
+            None => false,
+        }
+    } else {
+        false
+    };
+
     // Current votes are origin-checked at admission; future votes at promotion.
     if can_classify && !is_future && !verify_vote_origin(&vote) {
         tracing::debug!(
@@ -638,7 +732,7 @@ fn put_vote_inner(vote: VoteEnvelope) {
 
     let mut pool = VOTE_POOL.write().expect("vote pool poisoned");
 
-    if pool.is_at_capacity(&target_hash, is_future) {
+    if pool.is_at_capacity(&target_hash, is_future, future_sender_authenticated) {
         drop(pool);
         metrics::counter!("votes.rejected.block_at_capacity").increment(1);
         tracing::debug!(
@@ -659,17 +753,38 @@ fn put_vote_inner(vote: VoteEnvelope) {
         LAST_PRUNED_BLOCK.fetch_max(pending_block_number, Ordering::Relaxed);
     }
 
-    // Force prune if pool is too large, prevents memory issues during stage sync.
-    const MAX_VOTES_IN_POOL: usize = 32 * 1024 * 2;
+    // Force prune if the pool is oversized.
+    //
+    // This used to prune relative to the *incoming* vote's target, which frees
+    // nothing when the flood targets recent heights: pruning below
+    // `target - 256` only evicts votes already far behind the window. Prune
+    // relative to our head instead, and if that reclaims too little, shed
+    // future votes.
+    //
+    // Shedding future votes is the right response because current votes cannot
+    // be the cause: they are origin-checked and capped per target, so with the
+    // 267-block admission window they are bounded at roughly
+    // `267 * MAX_CUR_VOTE_AMOUNT_PER_BLOCK` entries. Any overflow is future
+    // votes, which are the less trustworthy half by construction.
     if pool.len() > MAX_VOTES_IN_POOL {
-        let force_prune = target_number.saturating_sub(LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER);
-        pool.prune(force_prune);
-        tracing::debug!(
-            target: "bsc::vote_pool",
-            pool_size = pool.len(),
-            force_prune_block_number = force_prune,
-            "Vote pool oversized, force pruned"
-        );
+        pool.prune(pending_block_number);
+        let after_prune = pool.len();
+        if after_prune > MAX_VOTES_IN_POOL {
+            let shed = pool.shed_future_votes(after_prune - MAX_VOTES_IN_POOL);
+            metrics::counter!("votes.shed.future_oversized").increment(shed as u64);
+            tracing::warn!(
+                target: "bsc::vote_pool",
+                pool_size = pool.len(),
+                shed,
+                "vote pool oversized after pruning; shed future votes",
+            );
+        } else {
+            tracing::debug!(
+                target: "bsc::vote_pool",
+                pool_size = after_prune,
+                "vote pool oversized, pruned to head",
+            );
+        }
     }
 
     let size = pool.len();
@@ -1047,14 +1162,15 @@ mod tests {
 
     // === D1: per-target vote caps ===
 
-    /// Future votes carry no per-target cap; current votes do.
+    /// The future-vote cap applies only once the sender is authenticated.
     ///
-    /// A future vote is only signature-checked, and a signature does not show
-    /// the signer is a validator — so a cap there refuses genuine votes as
-    /// readily as forged ones, and whichever arrives second loses. Current votes
-    /// have passed the origin check, so their cap only ever refuses surplus.
+    /// Unauthenticated future votes are uncapped, because a cap over contents we
+    /// cannot vouch for refuses genuine votes as readily as forged ones and
+    /// whichever arrives second loses. Authenticated ones are capped, because
+    /// then it can only ever refuse surplus from real validators. Current votes
+    /// are always capped, having passed the origin check.
     #[test]
-    fn future_votes_are_uncapped_and_current_votes_are_capped() {
+    fn future_cap_applies_only_to_authenticated_senders() {
         let mut pool = VotePool::new();
 
         let envelope = |target: B256, i: usize| {
@@ -1073,31 +1189,91 @@ mod tests {
             }
         };
 
-        // Well past go-bsc's former future cap of 50.
-        let future_target = B256::from([0x77; 32]);
-        for i in 0..200 {
+        // Unauthenticated future sender: well past the cap, never refused.
+        let unauth = B256::from([0x77; 32]);
+        for i in 0..(MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK * 4) {
             assert!(
-                !pool.is_at_capacity(&future_target, true),
-                "a future target must never refuse a vote for capacity (i={i})",
+                !pool.is_at_capacity(&unauth, true, false),
+                "an unauthenticated future bucket must never refuse (i={i})",
             );
-            pool.insert(envelope(future_target, i), 0, true);
+            pool.insert(envelope(unauth, i), 0, true);
         }
         assert_eq!(
-            pool.future_votes.get(&future_target).map(|vm| vm.vote_messages.len()),
-            Some(200),
-            "every future vote is retained",
+            pool.future_votes.get(&unauth).map(|vm| vm.vote_messages.len()),
+            Some(MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK * 4),
+            "every unauthenticated future vote is retained",
         );
 
-        // Current votes still stop at the validator-count cap.
+        // Authenticated future sender: capped.
+        let auth = B256::from([0x79; 32]);
+        for i in 0..MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK {
+            assert!(!pool.is_at_capacity(&auth, true, true), "below the future cap (i={i})");
+            pool.insert(envelope(auth, 5_000 + i), 0, true);
+        }
+        assert!(
+            pool.is_at_capacity(&auth, true, true),
+            "an authenticated future bucket stops at MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK",
+        );
+
+        // Current votes stop at the validator-count cap.
         let cur_target = B256::from([0x78; 32]);
         for i in 0..MAX_CUR_VOTE_AMOUNT_PER_BLOCK {
-            assert!(!pool.is_at_capacity(&cur_target, false), "below the cap (i={i})");
+            assert!(!pool.is_at_capacity(&cur_target, false, false), "below the cap (i={i})");
             pool.insert(envelope(cur_target, 1_000 + i), 0, false);
         }
         assert!(
-            pool.is_at_capacity(&cur_target, false),
+            pool.is_at_capacity(&cur_target, false, false),
             "current votes must stop at MAX_CUR_VOTE_AMOUNT_PER_BLOCK",
         );
+    }
+
+    /// Shedding releases future votes when pruning cannot, furthest-ahead first.
+    ///
+    /// Answers the "what if there are too many bad votes" case: a flood that
+    /// targets recent heights sits entirely inside the admission window, so
+    /// pruning by head frees nothing and the pool needs another way down.
+    #[test]
+    fn shedding_releases_future_votes_furthest_ahead_first() {
+        let mut pool = VotePool::new();
+
+        // Three future targets at increasing heights, two votes each.
+        for (n, byte) in [(100u64, 0xb1u8), (200, 0xb2), (300, 0xb3)] {
+            let target = B256::from([byte; 32]);
+            for i in 0..2usize {
+                let mut address = VoteAddress::default();
+                address[0] = byte;
+                address[1] = i as u8;
+                pool.insert(
+                    VoteEnvelope {
+                        vote_address: address,
+                        signature: VoteSignature::default(),
+                        data: VoteData {
+                            source_number: n - 1,
+                            source_hash: B256::from([0x01; 32]),
+                            target_number: n,
+                            target_hash: target,
+                        },
+                    },
+                    0,
+                    true,
+                );
+            }
+        }
+        assert_eq!(pool.len(), 6);
+
+        // Ask for 1; the furthest-ahead bucket (300) goes, releasing both of its
+        // votes. Buckets are released whole, so shedding can overshoot.
+        let shed = pool.shed_future_votes(1);
+        assert_eq!(shed, 2, "the whole furthest-ahead bucket is released");
+        assert!(
+            !pool.future_votes.contains_key(&B256::from([0xb3; 32])),
+            "height 300 shed first",
+        );
+        assert!(
+            pool.future_votes.contains_key(&B256::from([0xb1; 32])),
+            "height 100 retained: nearest to promotion",
+        );
+        assert_eq!(pool.len(), 4, "accounting follows the shed votes");
     }
 
     /// One target hash cannot be made to hold unbounded votes, however many

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -1328,12 +1328,9 @@ mod tests {
 
         // Distinct signers so nothing is rejected as a duplicate.
         let over = MAX_CUR_VOTE_AMOUNT_PER_BLOCK + 8;
-        for i in 1..=over {
-            let mut raw = [0u8; 32];
-            raw[30] = (i >> 8) as u8;
-            raw[31] = (i & 0xff) as u8;
-            let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
-            put_vote_unchecked(signer.sign_vote(data).expect("sign vote"));
+        for _ in 1..=over {
+            // A fresh signer each time, so nothing is rejected as a duplicate.
+            put_vote_unchecked(random_test_signer().sign_vote(data).expect("sign vote"));
         }
 
         assert_eq!(
@@ -1440,9 +1437,7 @@ mod tests {
             "precondition: unit tests have no header provider",
         );
 
-        let mut raw = [0u8; 32];
-        raw[31] = 1;
-        let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
+        let signer = random_test_signer();
         let data = VoteData {
             source_number: 7_000,
             source_hash: B256::from([0xe1; 32]),

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -28,6 +28,14 @@ const LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER: u64 = 256;
 pub(crate) const UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER: u64 = 11;
 /// Envelope hashes to remember as rejected. ~32 B each, so a few hundred KB.
 const REJECTED_VOTE_CACHE_SIZE: usize = 8192;
+/// Votes retained per target hash once we hold the target block, matching
+/// go-bsc's `maxCurVoteAmountPerBlock`. One per validator suffices.
+const MAX_CUR_VOTE_AMOUNT_PER_BLOCK: usize = 21;
+/// Votes retained per target hash while the target block is still unknown
+/// (`maxFutureVoteAmountPerBlock`). Higher than the current-vote cap because we
+/// cannot yet resolve the target's validator set, so non-validator votes cannot
+/// be filtered out until promotion.
+const MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK: usize = 50;
 /// Size of the LRU cache for tracking finality notifications (matches geth's finalizedNotified)
 const FINALIZED_NOTIFIED_CACHE_SIZE: usize = 21;
 
@@ -91,6 +99,10 @@ struct VotePool {
     cur_votes: HashMap<B256, VoteMessages>,
     /// Priority queue for efficiently finding votes to prune.
     cur_votes_pq: VotesPriorityQueue,
+    /// Votes whose target block we do not hold yet, keyed by target hash.
+    future_votes: HashMap<B256, VoteMessages>,
+    /// Priority queue over `future_votes`, ordered by target number.
+    future_votes_pq: VotesPriorityQueue,
     /// Total number of votes stored in the pool.
     total_votes: usize,
     /// Malicious vote monitor for detecting rule violations.
@@ -103,50 +115,84 @@ impl VotePool {
             received_votes: HashSet::new(),
             cur_votes: HashMap::new(),
             cur_votes_pq: VotesPriorityQueue::new(),
+            future_votes: HashMap::new(),
+            future_votes_pq: VotesPriorityQueue::new(),
             total_votes: 0,
             malicious_vote_monitor: MaliciousVoteMonitor::new(),
         }
     }
 
-    /// Insert a vote and return the new vote count for its target block (0 if duplicate).
-    fn insert(&mut self, vote: VoteEnvelope, pending_block_number: BlockNumber) -> usize {
+    /// Whether this target hash already holds its per-pool maximum.
+    ///
+    /// go-bsc applies the same cap in `basicVerify`, bounding how much one block
+    /// hash can cost us regardless of how many peers relay votes for it.
+    fn is_at_capacity(&self, block_hash: &B256, is_future: bool) -> bool {
+        let (votes, cap) = if is_future {
+            (&self.future_votes, MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK)
+        } else {
+            (&self.cur_votes, MAX_CUR_VOTE_AMOUNT_PER_BLOCK)
+        };
+        votes.get(block_hash).is_some_and(|vm| vm.vote_messages.len() >= cap)
+    }
+
+    /// Insert a vote and return the new *current* vote count for its target
+    /// block. Returns 0 for duplicates and for future votes, which must not
+    /// drive finality notification until they are promoted.
+    fn insert(
+        &mut self,
+        vote: VoteEnvelope,
+        pending_block_number: BlockNumber,
+        is_future: bool,
+    ) -> usize {
         let vote_hash = vote.hash();
-        if self.received_votes.insert(vote_hash) {
-            // Track received votes count (geth-compatible)
-            VOTE_METRICS.received_votes_total.increment(1);
-            metrics::counter!("curVotes.local").increment(1);
+        if !self.received_votes.insert(vote_hash) {
+            return 0; // duplicate vote
+        }
 
-            // Check for malicious votes
-            self.malicious_vote_monitor.conflict_detect(&vote, pending_block_number);
+        VOTE_METRICS.received_votes_total.increment(1);
+        metrics::counter!(if is_future { "futureVotes.local" } else { "curVotes.local" })
+            .increment(1);
 
-            // Use target_hash as the key for organizing votes
-            let block_hash = vote.data.target_hash;
+        // Check for malicious votes
+        self.malicious_vote_monitor.conflict_detect(&vote, pending_block_number);
 
-            // Add to priority queue if this is a new block
-            if !self.cur_votes.contains_key(&block_hash) {
-                self.cur_votes_pq.push(vote.data);
+        let block_hash = vote.data.target_hash;
+        let vote_data = vote.data;
+        {
+            let (votes, pq) = if is_future {
+                (&mut self.future_votes, &mut self.future_votes_pq)
+            } else {
+                (&mut self.cur_votes, &mut self.cur_votes_pq)
+            };
+            // Only push to the queue for a hash we are not already tracking, so
+            // the queue holds one entry per target rather than one per vote.
+            if !votes.contains_key(&block_hash) {
+                pq.push(vote_data);
             }
-            self.cur_votes
+            votes
                 .entry(block_hash)
                 .or_default()
                 .vote_messages
                 .push(VoteEntry { hash: vote_hash, envelope: vote });
-            self.total_votes += 1;
+        }
+        self.total_votes += 1;
 
-            // Update geth-compatible gauges
-            metrics::gauge!("curVotesPq.local").set(self.cur_votes_pq.heap.len() as f64);
-            metrics::gauge!("receivedVotes.local").set(self.received_votes.len() as f64);
+        metrics::gauge!("curVotesPq.local").set(self.cur_votes_pq.heap.len() as f64);
+        metrics::gauge!("futureVotesPq.local").set(self.future_votes_pq.heap.len() as f64);
+        metrics::gauge!("receivedVotes.local").set(self.received_votes.len() as f64);
 
-            // Return the new vote count for this block
-            self.len_for_block(&block_hash)
+        if is_future {
+            0
         } else {
-            0 // duplicate vote
+            self.len_for_block(&block_hash)
         }
     }
 
     fn drain(&mut self) -> Vec<VoteEnvelope> {
         self.received_votes.clear();
         self.cur_votes_pq = VotesPriorityQueue::new();
+        self.future_votes_pq = VotesPriorityQueue::new();
+        self.future_votes.clear();
         self.total_votes = 0;
         let mut all_votes = Vec::new();
         for (_, vote_messages) in self.cur_votes.drain() {
@@ -202,6 +248,89 @@ impl VotePool {
             .collect()
     }
 
+    /// Promotes future votes whose target we now hold, mirroring go-bsc's
+    /// `transferVotesFromFutureToCur`.
+    ///
+    /// Two phases, as upstream: entries older than `latest - 11` are promoted
+    /// unconditionally (they can no longer be "future"), then entries at or
+    /// below `latest` are promoted only once their target block is actually
+    /// known, with the rest pushed back for a later pass.
+    ///
+    /// Returns the target hashes that gained current votes, so the caller can
+    /// run finality notification after releasing the pool lock.
+    fn transfer_future_votes(&mut self, latest: BlockNumber) -> Vec<B256> {
+        let mut promoted = Vec::new();
+
+        // Phase 1: too old to still be considered future.
+        while let Some(vd) = self.future_votes_pq.peek() {
+            if vd.target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) >= latest {
+                break;
+            }
+            let hash = vd.target_hash;
+            self.future_votes_pq.pop();
+            if self.promote(hash) {
+                promoted.push(hash);
+            }
+        }
+
+        // Phase 2: promote only what we can now resolve; retain the rest.
+        let mut deferred = Vec::new();
+        while let Some(vd) = self.future_votes_pq.peek() {
+            if vd.target_number > latest {
+                break;
+            }
+            let vd = *vd;
+            self.future_votes_pq.pop();
+            if shared::get_canonical_header_by_hash_from_provider(&vd.target_hash).is_none() {
+                deferred.push(vd);
+                continue;
+            }
+            if self.promote(vd.target_hash) {
+                promoted.push(vd.target_hash);
+            }
+        }
+        for vd in deferred {
+            self.future_votes_pq.push(vd);
+        }
+
+        metrics::gauge!("futureVotesPq.local").set(self.future_votes_pq.heap.len() as f64);
+        promoted
+    }
+
+    /// Moves one target's future votes into the current pool, dropping any that
+    /// fail the origin check. Returns whether any vote survived.
+    ///
+    /// The caller has already popped this hash from the future queue.
+    fn promote(&mut self, block_hash: B256) -> bool {
+        let Some(box_) = self.future_votes.remove(&block_hash) else {
+            return false;
+        };
+
+        let mut valid = Vec::with_capacity(box_.vote_messages.len());
+        for entry in box_.vote_messages {
+            if verify_vote_origin(&entry.envelope) {
+                valid.push(entry);
+            } else {
+                // Drop from the dedup set too, so a later legitimate copy is not
+                // mistaken for a duplicate.
+                self.received_votes.remove(&entry.hash);
+                self.total_votes = self.total_votes.saturating_sub(1);
+                metrics::counter!("votes.rejected.origin_on_promote").increment(1);
+            }
+        }
+        if valid.is_empty() {
+            return false;
+        }
+
+        let data = valid[0].envelope.data;
+        if !self.cur_votes.contains_key(&block_hash) {
+            self.cur_votes_pq.push(data);
+        }
+        self.cur_votes.entry(block_hash).or_default().vote_messages.extend(valid);
+        metrics::gauge!("curVotesPq.local").set(self.cur_votes_pq.heap.len() as f64);
+        true
+    }
+
     /// Prune old votes based on the latest block number.
     /// Removes votes where targetNumber + LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER - 1 < latestBlockNumber
     fn prune(&mut self, latest_block_number: BlockNumber) {
@@ -224,6 +353,24 @@ impl VotePool {
                 break;
             }
         }
+        // Future entries below the lower bound can never be promoted usefully.
+        while let Some(vd) = self.future_votes_pq.peek() {
+            if vd.target_number.saturating_add(LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER)
+                > latest_block_number
+            {
+                break;
+            }
+            let hash = vd.target_hash;
+            self.future_votes_pq.pop();
+            if let Some(box_) = self.future_votes.remove(&hash) {
+                self.total_votes = self.total_votes.saturating_sub(box_.vote_messages.len());
+                for entry in box_.vote_messages {
+                    self.received_votes.remove(&entry.hash);
+                }
+            }
+        }
+        metrics::gauge!("futureVotesPq.local").set(self.future_votes_pq.heap.len() as f64);
+
         // Update geth-compatible gauges after pruning
         metrics::gauge!("curVotesPq.local").set(self.cur_votes_pq.heap.len() as f64);
         metrics::gauge!("receivedVotes.local").set(self.received_votes.len() as f64);
@@ -261,6 +408,78 @@ static FINALIZED_NOTIFIED: Lazy<RwLock<LruCache<B256, ()>>> =
 fn update_vote_pool_size_metric(size: usize) {
     VOTE_METRICS.vote_pool_size.set(size as f64);
     VOTE_METRICS.current_votes_count.set(size as f64);
+}
+
+/// Justified (source) pair recorded in a header's snapshot.
+///
+/// Shared so the vote pool and `BscForkChoiceEngine` derive it one way. The
+/// Luban gate stays with the caller, which is where the chain spec lives.
+pub fn justified_pair_for_hash(header_hash: &B256) -> Option<(BlockNumber, B256)> {
+    let sp = shared::get_snapshot_provider()?;
+    let snap = sp.snapshot_by_hash(header_hash)?;
+    Some((snap.vote_data.target_number, snap.vote_data.target_hash))
+}
+
+/// Whether a vote plausibly originates from a validator of its target block and
+/// cites the correct source, mirroring go-bsc's `Parlia.VerifyVote`.
+///
+/// Only meaningful once the target block is known; callers apply it to current
+/// votes at admission and to future votes at promotion, exactly as upstream
+/// does. Returns false when the target header or either snapshot is missing —
+/// the same outcome go-bsc reaches by returning an error — but logs the two
+/// cases separately, because "snapshot not available yet" and "vote is not from
+/// a validator" have very different operational meanings.
+fn verify_vote_origin(vote: &VoteEnvelope) -> bool {
+    let Some(header) = shared::get_canonical_header_by_hash_from_provider(&vote.data.target_hash)
+    else {
+        tracing::debug!(
+            target: "bsc::vote_pool",
+            target_number = vote.data.target_number,
+            "vote origin unverifiable: target header not found",
+        );
+        return false;
+    };
+    if header.number != vote.data.target_number {
+        return false;
+    }
+
+    match justified_pair_for_hash(&vote.data.target_hash) {
+        Some((justified_number, justified_hash)) => {
+            if vote.data.source_number != justified_number
+                || vote.data.source_hash != justified_hash
+            {
+                metrics::counter!("votes.rejected.source_mismatch").increment(1);
+                return false;
+            }
+        }
+        None => {
+            tracing::debug!(
+                target: "bsc::vote_pool",
+                target_number = vote.data.target_number,
+                "vote origin unverifiable: no snapshot for target",
+            );
+            return false;
+        }
+    }
+
+    let Some(sp) = shared::get_snapshot_provider() else {
+        return false;
+    };
+    let Some(parent_snap) = sp.snapshot_by_hash(&header.parent_hash) else {
+        tracing::debug!(
+            target: "bsc::vote_pool",
+            target_number = vote.data.target_number,
+            "vote origin unverifiable: no snapshot for target's parent",
+        );
+        return false;
+    };
+
+    let is_validator =
+        parent_snap.validators_map.values().any(|v| v.vote_addr == vote.vote_address);
+    if !is_validator {
+        metrics::counter!("votes.rejected.not_a_validator").increment(1);
+    }
+    is_validator
 }
 
 /// Whether a vote targeting `target_number` falls inside the admission window
@@ -355,22 +574,62 @@ pub fn put_vote_unchecked(vote: VoteEnvelope) {
 
 fn put_vote_inner(vote: VoteEnvelope) {
     let target_hash = vote.data.target_hash;
-
-    // Get pending block number for malicious vote detection scope
+    let target_number = vote.data.target_number;
     let pending_block_number = shared::get_best_canonical_block_number().unwrap_or(0);
 
-    // Lazy prune: evict votes below `head - LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER`
-    // once per observed head advance. Replaces geth-bsc's chain-head event
-    // subscription by piggybacking on the vote ingest path (same cadence).
-    // `fetch_max` keeps the watermark monotonic across racing writers; the
-    // inner prune is O(0) when nothing is stale.
-    let need_prune = pending_block_number > LAST_PRUNED_BLOCK.load(Ordering::Relaxed);
+    // Classify: a vote for a block we do not hold cannot have its origin checked
+    // yet, because membership is resolved against the target's parent snapshot.
+    // go-bsc splits `curVotes`/`futureVotes` on exactly this condition.
+    //
+    // We test canonical presence where go-bsc tests *verified* presence, which is
+    // the stricter reading: a valid but not-yet-canonical target is treated as
+    // future here. That defers its origin check to promotion rather than skipping
+    // it, so the effect is conservative.
+    //
+    // Before the header provider is registered every lookup misses, which would
+    // classify *everything* as future — and promotion needs the same provider,
+    // so those votes could never be promoted and finality would stall. Treat an
+    // unregistered provider as "cannot classify" and admit as current without an
+    // origin check, matching the fail-open stance the height window takes.
+    let can_classify = shared::has_header_by_hash_provider();
+    let is_future = can_classify
+        && shared::get_canonical_header_by_hash_from_provider(&target_hash).is_none();
 
-    let target_number = vote.data.target_number;
+    // Current votes are origin-checked at admission; future votes at promotion.
+    if can_classify && !is_future && !verify_vote_origin(&vote) {
+        tracing::debug!(
+            target: "bsc::vote_pool",
+            vote_address = %vote.vote_address,
+            target_number,
+            "rejecting vote that failed the origin check",
+        );
+        return;
+    }
+
+    // Lazy prune and promotion: run once per observed head advance. Replaces
+    // geth-bsc's chain-head subscription by piggybacking on the vote ingest
+    // path, which is the same cadence in practice since votes arrive per block.
+    let need_head_work = pending_block_number > LAST_PRUNED_BLOCK.load(Ordering::Relaxed);
 
     let mut pool = VOTE_POOL.write().expect("vote pool poisoned");
-    let votes_for_block = pool.insert(vote, pending_block_number);
-    if need_prune {
+
+    if pool.is_at_capacity(&target_hash, is_future) {
+        drop(pool);
+        metrics::counter!("votes.rejected.block_at_capacity").increment(1);
+        tracing::debug!(
+            target: "bsc::vote_pool",
+            target_number,
+            is_future,
+            "rejecting vote: target already at its per-block vote cap",
+        );
+        return;
+    }
+
+    let votes_for_block = pool.insert(vote, pending_block_number, is_future);
+
+    let mut promoted = Vec::new();
+    if need_head_work {
+        promoted = pool.transfer_future_votes(pending_block_number);
         pool.prune(pending_block_number);
         LAST_PRUNED_BLOCK.fetch_max(pending_block_number, Ordering::Relaxed);
     }
@@ -389,6 +648,8 @@ fn put_vote_inner(vote: VoteEnvelope) {
     }
 
     let size = pool.len();
+    let promoted_counts: Vec<(B256, usize)> =
+        promoted.iter().map(|h| (*h, pool.len_for_block(h))).collect();
     drop(pool);
     update_vote_pool_size_metric(size);
 
@@ -396,6 +657,12 @@ fn put_vote_inner(vote: VoteEnvelope) {
     if votes_for_block > 0 {
         block_stats::on_vote_received(target_hash, votes_for_block);
         maybe_notify_finality(target_hash, votes_for_block);
+    }
+    // Promoted targets may have crossed quorum while sitting in the future pool.
+    for (hash, count) in promoted_counts {
+        if count > 0 {
+            maybe_notify_finality(hash, count);
+        }
     }
 }
 
@@ -745,6 +1012,39 @@ mod tests {
             fetch_vote_by_block_hash(data.target_hash).len(),
             1,
             "an unknown head must not cause votes to be discarded",
+        );
+
+        let _ = drain();
+    }
+
+
+    /// One target hash cannot be made to hold unbounded votes, however many
+    /// distinct validators sign for it. Mirrors go-bsc's cap in `basicVerify`.
+    #[test]
+    fn put_vote_caps_votes_per_target() {
+        let _ = drain();
+
+        let data = VoteData {
+            source_number: 900,
+            source_hash: B256::from([0x91; 32]),
+            target_number: 901,
+            target_hash: B256::from([0x92; 32]),
+        };
+
+        // Distinct signers so nothing is rejected as a duplicate.
+        let over = MAX_CUR_VOTE_AMOUNT_PER_BLOCK + 8;
+        for i in 1..=over {
+            let mut raw = [0u8; 32];
+            raw[30] = (i >> 8) as u8;
+            raw[31] = (i & 0xff) as u8;
+            let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
+            put_vote(signer.sign_vote(data).expect("sign vote"));
+        }
+
+        assert_eq!(
+            fetch_vote_by_block_hash(data.target_hash).len(),
+            MAX_CUR_VOTE_AMOUNT_PER_BLOCK,
+            "votes for one target must stop at the cap",
         );
 
         let _ = drain();

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -398,7 +398,12 @@ impl VotePool {
     fn prune(&mut self, latest_block_number: BlockNumber) {
         // Remove votes in the range [, latestBlockNumber - LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER]
         while let Some(vote_data) = self.cur_votes_pq.peek() {
-            if vote_data.target_number + LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER - 1 < latest_block_number
+            // Saturating: the admission window bounds `target_number` to
+            // `head + 11`, but it fails open while the head is unknown at
+            // startup, so an extreme value can still reach the pool. A plain add
+            // would then wrap in release and trap in debug.
+            if vote_data.target_number.saturating_add(LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER)
+                <= latest_block_number
             {
                 // Remove from priority queue
                 let vote_data = self.cur_votes_pq.pop().unwrap();
@@ -1304,6 +1309,78 @@ mod tests {
             MAX_CUR_VOTE_AMOUNT_PER_BLOCK,
             "votes for one target must stop at the cap",
         );
+
+        let _ = drain();
+    }
+
+
+    /// An extreme `target_number` must not be able to empty the pool.
+    ///
+    /// The oversize path used to derive its prune height from the *incoming*
+    /// vote's target: `prune(target_number - 256)`. `target_number` is supplied
+    /// by whoever sent the vote, and before the admission window existed it was
+    /// unbounded — so one vote claiming a target near `u64::MAX` produced an
+    /// astronomically large prune height, and `prune` then evicted every vote
+    /// below it, which is all of them. Votes are never re-sent, so the node lost
+    /// local quorum until fresh ones accumulated.
+    ///
+    /// No panic accompanied it: `[profile.release]` sets no `overflow-checks`,
+    /// so `target_number + 255` inside `prune` wraps rather than trapping.
+    ///
+    /// The height now comes from our own head, so the sender cannot steer it.
+    /// Uses `put_vote_unchecked` to reach the oversize path without paying a
+    /// pairing per vote.
+    #[test]
+    fn extreme_target_number_cannot_wipe_the_pool() {
+        let _ = drain();
+
+        let survivor_target = B256::from([0xd1; 32]);
+        let vote = |target: B256, number: u64, i: usize| {
+            let mut address = VoteAddress::default();
+            address[0] = (i & 0xff) as u8;
+            address[1] = ((i >> 8) & 0xff) as u8;
+            address[2] = ((i >> 16) & 0xff) as u8;
+            VoteEnvelope {
+                vote_address: address,
+                signature: VoteSignature::default(),
+                data: VoteData {
+                    source_number: number.saturating_sub(1),
+                    source_hash: B256::from([0xd0; 32]),
+                    target_number: number,
+                    target_hash: target,
+                },
+            }
+        };
+
+        // One vote we will look for afterwards, at an ordinary height.
+        put_vote_unchecked(vote(survivor_target, 5_000, 0));
+        assert_eq!(fetch_vote_by_block_hash(survivor_target).len(), 1);
+
+        // Push past MAX_VOTES_IN_POOL so the oversize path engages. Spread over
+        // many targets because the per-target cap bounds each one.
+        let mut i = 1usize;
+        let mut target_seed = 0u64;
+        while len() <= MAX_VOTES_IN_POOL {
+            target_seed += 1;
+            let mut bytes = [0u8; 32];
+            bytes[..8].copy_from_slice(&target_seed.to_le_bytes());
+            let filler = B256::from(bytes);
+            for _ in 0..MAX_CUR_VOTE_AMOUNT_PER_BLOCK {
+                put_vote_unchecked(vote(filler, 5_000, i));
+                i += 1;
+            }
+        }
+        assert!(len() > MAX_VOTES_IN_POOL, "precondition: pool is oversized");
+
+        // The payload: a target claiming to be near the end of the number space.
+        put_vote_unchecked(vote(B256::from([0xff; 32]), u64::MAX - 300, i));
+
+        assert_eq!(
+            fetch_vote_by_block_hash(survivor_target).len(),
+            1,
+            "a vote at an ordinary height must survive an extreme target_number",
+        );
+        assert!(len() > MAX_CUR_VOTE_AMOUNT_PER_BLOCK, "the pool must not have been emptied");
 
         let _ = drain();
     }

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -665,11 +665,24 @@ pub fn put_vote(vote: VoteEnvelope) {
     put_vote_inner(vote);
 }
 
-/// Test-only ingress that skips signature verification, for tests exercising
-/// pool/finality bookkeeping with synthetic vote addresses.
+/// Test-only ingress that skips signature verification and places the vote
+/// directly into the current pool, for tests exercising pool and finality
+/// bookkeeping with synthetic vote addresses.
+///
+/// Bypasses classification deliberately: no unit test can register the header
+/// provider, so the real path would route everything to the future pool.
 #[cfg(test)]
 pub fn put_vote_unchecked(vote: VoteEnvelope) {
-    put_vote_inner(vote);
+    let target_hash = vote.data.target_hash;
+    let mut pool = VOTE_POOL.write().expect("vote pool poisoned");
+    if pool.is_at_capacity(&target_hash, false, false) {
+        return;
+    }
+    let votes_for_block = pool.insert(vote, 0, false);
+    drop(pool);
+    if votes_for_block > 0 {
+        maybe_notify_finality(target_hash, votes_for_block);
+    }
 }
 
 fn put_vote_inner(vote: VoteEnvelope) {
@@ -686,14 +699,17 @@ fn put_vote_inner(vote: VoteEnvelope) {
     // future here. That defers its origin check to promotion rather than skipping
     // it, so the effect is conservative.
     //
-    // Before the header provider is registered every lookup misses, which would
-    // classify *everything* as future — and promotion needs the same provider,
-    // so those votes could never be promoted and finality would stall. Treat an
-    // unregistered provider as "cannot classify" and admit as current without an
-    // origin check, matching the fail-open stance the height window takes.
+    // Until the header provider is registered we cannot classify at all. The
+    // network starts accepting peers in `build_network` while the provider is
+    // registered later, in `build_consensus`, so that window is reachable by a
+    // connected peer. Treat unclassifiable votes as future: they are then
+    // uncapped (so they cannot crowd out validator votes), they do not reach
+    // `maybe_notify_finality` (so they cannot manufacture quorum), and they are
+    // fully origin-checked at promotion once the provider appears. Reported by
+    // Hashdit Bot on #491.
     let can_classify = shared::has_header_by_hash_provider();
-    let is_future = can_classify
-        && shared::get_canonical_header_by_hash_from_provider(&target_hash).is_none();
+    let is_future = !can_classify
+        || shared::get_canonical_header_by_hash_from_provider(&target_hash).is_none();
 
     // Future votes cannot be origin-checked (membership lives in the target's
     // parent snapshot, which we do not hold), but we can still ask whether the
@@ -720,7 +736,7 @@ fn put_vote_inner(vote: VoteEnvelope) {
     };
 
     // Current votes are origin-checked at admission; future votes at promotion.
-    if can_classify && !is_future && !verify_vote_origin(&vote) {
+    if !is_future && !verify_vote_origin(&vote) {
         tracing::debug!(
             target: "bsc::vote_pool",
             vote_address = %vote.vote_address,
@@ -836,6 +852,22 @@ pub fn is_empty() -> bool {
 /// Fetch votes by block hash.
 pub fn fetch_vote_by_block_hash(block_hash: B256) -> Vec<VoteEnvelope> {
     VOTE_POOL.read().expect("vote pool poisoned").fetch_vote_by_block_hash(block_hash)
+}
+
+/// Test-only: votes for a target in either pool.
+///
+/// No unit test can register the header provider, so the real ingest path
+/// classifies everything as future. Tests whose subject is admission — dedup,
+/// signature rejection, the height window — need to see both pools; production
+/// callers deliberately see only current votes, which are origin-checked.
+#[cfg(test)]
+pub fn fetch_any_vote_by_block_hash(block_hash: B256) -> Vec<VoteEnvelope> {
+    let pool = VOTE_POOL.read().expect("vote pool poisoned");
+    let mut out = pool.fetch_vote_by_block_hash(block_hash);
+    if let Some(vm) = pool.future_votes.get(&block_hash) {
+        out.extend(vm.vote_messages.iter().map(|e| e.envelope.clone()));
+    }
+    out
 }
 
 /// Fetch votes by block hash and source block number.
@@ -1004,7 +1036,7 @@ mod tests {
 
         // Baseline: a correctly signed vote is admitted.
         put_vote(genuine.clone());
-        assert_eq!(fetch_vote_by_block_hash(data.target_hash).len(), 1, "genuine vote rejected");
+        assert_eq!(fetch_any_vote_by_block_hash(data.target_hash).len(), 1, "genuine vote rejected");
 
         // Undecodable signature under a real validator's address. Before
         // verification existed this reached attestation assembly and panicked
@@ -1014,7 +1046,7 @@ mod tests {
             ..genuine.clone()
         });
         assert_eq!(
-            fetch_vote_by_block_hash(data.target_hash).len(),
+            fetch_any_vote_by_block_hash(data.target_hash).len(),
             1,
             "vote with undecodable signature was admitted",
         );
@@ -1025,7 +1057,7 @@ mod tests {
         let mismatched = signer.sign_vote(other).expect("sign vote").signature;
         put_vote(VoteEnvelope { signature: mismatched, ..genuine.clone() });
         assert_eq!(
-            fetch_vote_by_block_hash(data.target_hash).len(),
+            fetch_any_vote_by_block_hash(data.target_hash).len(),
             1,
             "vote signed over different data was admitted",
         );
@@ -1036,7 +1068,7 @@ mod tests {
             ..genuine
         });
         assert_eq!(
-            fetch_vote_by_block_hash(data.target_hash).len(),
+            fetch_any_vote_by_block_hash(data.target_hash).len(),
             1,
             "vote under a mismatched vote address was admitted",
         );
@@ -1066,12 +1098,12 @@ mod tests {
 
         // A valid vote, then replays of it: deduplicated by the pool.
         put_vote(genuine.clone());
-        assert_eq!(fetch_vote_by_block_hash(data.target_hash).len(), 1);
+        assert_eq!(fetch_any_vote_by_block_hash(data.target_hash).len(), 1);
         for _ in 0..10 {
             put_vote(genuine.clone());
         }
         assert_eq!(
-            fetch_vote_by_block_hash(data.target_hash).len(),
+            fetch_any_vote_by_block_hash(data.target_hash).len(),
             1,
             "re-relayed copies must not accumulate",
         );
@@ -1089,7 +1121,7 @@ mod tests {
             put_vote(forged.clone());
         }
         assert_eq!(
-            fetch_vote_by_block_hash(data.target_hash).len(),
+            fetch_any_vote_by_block_hash(data.target_hash).len(),
             1,
             "replayed forgeries never enter the pool",
         );
@@ -1154,7 +1186,7 @@ mod tests {
         put_vote(signer.sign_vote(data).expect("sign vote"));
 
         assert_eq!(
-            fetch_vote_by_block_hash(data.target_hash).len(),
+            fetch_any_vote_by_block_hash(data.target_hash).len(),
             1,
             "an unknown head must not cause votes to be discarded",
         );
@@ -1301,7 +1333,7 @@ mod tests {
             raw[30] = (i >> 8) as u8;
             raw[31] = (i & 0xff) as u8;
             let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
-            put_vote(signer.sign_vote(data).expect("sign vote"));
+            put_vote_unchecked(signer.sign_vote(data).expect("sign vote"));
         }
 
         assert_eq!(
@@ -1381,6 +1413,60 @@ mod tests {
             "a vote at an ordinary height must survive an extreme target_number",
         );
         assert!(len() > MAX_CUR_VOTE_AMOUNT_PER_BLOCK, "the pool must not have been emptied");
+
+        let _ = drain();
+    }
+
+
+    /// A vote that cannot be classified must not be treated as current.
+    ///
+    /// The network begins accepting peers in `build_network`, while the header
+    /// provider is registered later in `build_consensus`, so votes can arrive
+    /// while classification is impossible. Treating them as current would put
+    /// un-origin-checked votes where attestation assembly and finality
+    /// notification read from, let them consume the 21-per-target cap and so
+    /// crowd out real validator votes, and never revalidate them afterwards.
+    ///
+    /// Routing them to the future pool instead means they are uncapped, invisible
+    /// to finality counting, and fully origin-checked at promotion once the
+    /// provider appears. Reported by Hashdit Bot on #491.
+    ///
+    /// Unit tests cannot register the provider, so this is the state under test.
+    #[test]
+    fn unclassifiable_votes_are_held_as_future_not_current() {
+        let _ = drain();
+        assert!(
+            !shared::has_header_by_hash_provider(),
+            "precondition: unit tests have no header provider",
+        );
+
+        let mut raw = [0u8; 32];
+        raw[31] = 1;
+        let signer = BlsVoteSigner::new_from_bytes(raw).expect("create bls signer");
+        let data = VoteData {
+            source_number: 7_000,
+            source_hash: B256::from([0xe1; 32]),
+            target_number: 7_001,
+            target_hash: B256::from([0xe2; 32]),
+        };
+        put_vote(signer.sign_vote(data).expect("sign vote"));
+
+        assert!(
+            fetch_vote_by_block_hash(data.target_hash).is_empty(),
+            "an unclassifiable vote must not enter the current pool, which feeds \
+             attestation assembly and finality counting",
+        );
+        assert_eq!(
+            fetch_any_vote_by_block_hash(data.target_hash).len(),
+            1,
+            "it is retained as a future vote, to be origin-checked at promotion",
+        );
+
+        // Uncapped, so it cannot be used to crowd out validator votes.
+        {
+            let pool = VOTE_POOL.read().expect("vote pool poisoned");
+            assert!(!pool.is_at_capacity(&data.target_hash, true, false));
+        }
 
         let _ = drain();
     }

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -492,14 +492,14 @@ pub fn justified_pair_for_hash(header_hash: &B256) -> Option<(BlockNumber, B256)
 ///
 /// `verify_vote_origin` cannot run on a future vote: it resolves membership from
 /// the target's parent snapshot, and we do not hold the target. But the
-/// validator set only changes on epoch boundaries, and the admission window caps
-/// a future target at `head + 11`, so the set at our head is the set that will
-/// govern the target — unless an epoch boundary falls in between.
+/// validator set only changes at one block per epoch, and the admission window
+/// caps a future target at `head + 11`, so the set at our head is the set that
+/// will govern the target — unless that block falls in between.
 ///
 /// Returns:
 /// - `Some(true)`  sender is a validator in the current set
 /// - `Some(false)` sender is not, and cannot become one inside the window
-/// - `None` undecidable: no snapshot, or an epoch boundary lies in
+/// - `None` undecidable: no snapshot, or a validator-set swap lies in
 ///   `(head, target]` so the governing set may differ. Callers admit these
 ///   uncapped rather than guess.
 fn future_vote_sender_is_validator(vote: &VoteEnvelope) -> Option<bool> {
@@ -510,14 +510,42 @@ fn future_vote_sender_is_validator(vote: &VoteEnvelope) -> Option<bool> {
         return None;
     }
 
-    // An epoch boundary between head and target can swap the set out from under
-    // us; decline to judge rather than risk rejecting an incoming validator.
-    let epoch = snap.epoch_num.max(1);
-    if vote.data.target_number / epoch > head_number / epoch {
+    // A validator-set swap between head and target changes the set out from
+    // under us; decline to judge rather than risk rejecting an incoming
+    // validator.
+    if validator_set_swaps_within(
+        head_number,
+        vote.data.target_number,
+        snap.epoch_num,
+        snap.miner_history_check_len(),
+    ) {
         return None;
     }
 
     Some(snap.validators_map.values().any(|v| v.vote_addr == vote.vote_address))
+}
+
+/// Whether a validator-set swap falls in `(head, target]`.
+///
+/// The set does **not** change at the epoch multiple: it changes `offset`
+/// blocks later, where `offset` is `Snapshot::miner_history_check_len()`. That
+/// is the `header.number % epoch_num == miner_check_len` test in
+/// `SnapshotProvider::try_rebuild`, and it is the only place the set is
+/// swapped. With 21 validators at `turn_length` 4 the offset is 43, so on a
+/// 1000-block epoch the set turns over at `…043`, not `…000`.
+///
+/// Counting the swap points at or below each height and comparing the counts
+/// catches a boundary wherever it sits in the window, and needs no special case
+/// for a window that spans an epoch multiple.
+fn validator_set_swaps_within(head: u64, target: u64, epoch: u64, offset: u64) -> bool {
+    let epoch = epoch.max(1);
+    // `n % epoch == offset` is unsatisfiable here, so the provider never treats
+    // any block as a boundary. Mirror it rather than invent one.
+    if offset >= epoch {
+        return false;
+    }
+    let swaps_upto = |n: u64| if n >= offset { (n - offset) / epoch + 1 } else { 0 };
+    swaps_upto(target) > swaps_upto(head)
 }
 
 /// Whether a vote plausibly originates from a validator of its target block and
@@ -1466,4 +1494,69 @@ mod tests {
         let _ = drain();
     }
 
+    /// The validator set swaps `miner_history_check_len()` blocks *after* the
+    /// epoch multiple, not at it. Judging a future vote against our own head is
+    /// only sound when no swap sits in `(head, target]`, and watching the
+    /// multiple instead misses the real boundary by that offset — which rejects
+    /// a joining validator's votes outright, since `Some(false)` drops them and
+    /// votes are never re-sent. Raised by will-2012 on #491.
+    #[test]
+    fn validator_set_swap_window_tracks_the_real_boundary() {
+        // Mainnet post-Maxwell: 1000-block epoch, 21 validators, turn_length 4.
+        const EPOCH: u64 = 1000;
+        const OFFSET: u64 = 43; // (21 / 2 + 1) * 4 - 1
+
+        // The swap at 43_043 lies in the window, so membership is undecidable...
+        assert!(validator_set_swaps_within(43_035, 43_043, EPOCH, OFFSET));
+        // ...and both heights share an epoch multiple, so the multiple-based
+        // test saw no boundary at all and judged against the outgoing set.
+        assert_eq!(43_035 / EPOCH, 43_043 / EPOCH);
+
+        // Crossing the multiple without reaching the swap: the set is unchanged...
+        assert!(!validator_set_swaps_within(42_995, 43_000, EPOCH, OFFSET));
+        // ...where the multiple-based test declined to judge. Harmless, but it
+        // gave up the per-block cap for no reason.
+        assert_ne!(42_995 / EPOCH, 43_000 / EPOCH);
+
+        // Half-open window: a swap at `head` is behind us, one at `target` is not.
+        assert!(!validator_set_swaps_within(43_043, 43_050, EPOCH, OFFSET));
+        assert!(validator_set_swaps_within(43_042, 43_043, EPOCH, OFFSET));
+        // Mid-epoch window, nothing near a boundary.
+        assert!(!validator_set_swaps_within(43_100, 43_111, EPOCH, OFFSET));
+    }
+
+    /// Differential check against the predicate that actually swaps the set in
+    /// `SnapshotProvider::try_rebuild`, over every window the admission bound
+    /// permits.
+    #[test]
+    fn validator_set_swap_window_matches_the_provider_predicate() {
+        const EPOCH: u64 = 200;
+        const OFFSET: u64 = 10;
+
+        for head in 0..(EPOCH * 3) {
+            for target in head..=(head + UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) {
+                // `is_epoch_boundary` in provider.rs, applied block by block.
+                let expected = ((head + 1)..=target).any(|n| n > 0 && n % EPOCH == OFFSET);
+                assert_eq!(
+                    validator_set_swaps_within(head, target, EPOCH, OFFSET),
+                    expected,
+                    "head {head}, target {target}",
+                );
+            }
+        }
+    }
+
+    /// Degenerate configurations must not invent a boundary the provider can
+    /// never reach, and must not divide by zero.
+    #[test]
+    fn validator_set_swap_window_handles_degenerate_epochs() {
+        // offset >= epoch: `n % epoch == offset` never holds, so the provider
+        // never swaps the set and neither may we.
+        assert!(!validator_set_swaps_within(0, 10_000, 200, 200));
+        // A zero epoch is coerced to 1 rather than panicking.
+        assert!(validator_set_swaps_within(5, 6, 0, 0));
+        // Single-validator devnet: offset 0, so the swap sits on the multiple.
+        assert!(validator_set_swaps_within(199, 200, 200, 0));
+        assert!(!validator_set_swaps_within(200, 205, 200, 0));
+    }
 }

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -481,10 +481,44 @@ fn update_vote_pool_size_metric(size: usize) {
 ///
 /// Shared so the vote pool and `BscForkChoiceEngine` derive it one way. The
 /// Luban gate stays with the caller, which is where the chain spec lives.
+///
+/// Before the chain justifies anything the recorded pair is all zeroes, which
+/// resolves to genesis — see `justified_pair_of`.
 pub fn justified_pair_for_hash(header_hash: &B256) -> Option<(BlockNumber, B256)> {
     let sp = shared::get_snapshot_provider()?;
     let snap = sp.snapshot_by_hash(header_hash)?;
-    Some((snap.vote_data.target_number, snap.vote_data.target_hash))
+    justified_pair_of(&snap.vote_data, || {
+        let genesis = shared::get_canonical_header_by_number(0)?;
+        Some((genesis.number, genesis.hash_slow()))
+    })
+}
+
+/// Which block a vote must cite as its source, given the attestation recorded in
+/// a header's snapshot.
+///
+/// A zero target hash is the *absence* of an attestation, not a justified block
+/// living at the zero hash. Nothing can ever cite that hash: our own producers
+/// substitute genesis in this state (`vote_producer.rs`, and `Parlia::assemble_
+/// vote_attestation`), and go-bsc's `GetJustifiedNumberAndHash` returns
+/// `chain.GetHeaderByNumber(0).Hash()` whenever `snap.Attestation == nil`.
+///
+/// Reporting the zero hash here rejects every vote for source mismatch, and the
+/// rejection is self-locking: leaving the state needs an attestation, and an
+/// attestation can only be assembled from the votes being rejected. A fresh
+/// all-reth network therefore never reaches finality at all. Raised by
+/// will-2012 on #491.
+///
+/// `genesis` is lazy so a chain that has justified something never pays for the
+/// lookup, and so the branch is unit-testable without a registered header
+/// provider.
+fn justified_pair_of(
+    vote_data: &VoteData,
+    genesis: impl FnOnce() -> Option<(BlockNumber, B256)>,
+) -> Option<(BlockNumber, B256)> {
+    if vote_data.target_hash == B256::ZERO {
+        return genesis();
+    }
+    Some((vote_data.target_number, vote_data.target_hash))
 }
 
 /// Whether a *future* vote's sender is a validator, judged against the snapshot
@@ -1492,6 +1526,109 @@ mod tests {
         }
 
         let _ = drain();
+    }
+
+    /// A recorded attestation is reported as-is, and the genesis lookup is never
+    /// performed — a chain that has justified something must not pay for it.
+    #[test]
+    fn justified_pair_uses_the_recorded_attestation() {
+        let vote_data = VoteData {
+            source_number: 8,
+            source_hash: B256::from([0x08; 32]),
+            target_number: 9,
+            target_hash: B256::from([0x09; 32]),
+        };
+        let pair = justified_pair_of(&vote_data, || panic!("genesis must not be consulted"));
+        assert_eq!(pair, Some((9, B256::from([0x09; 32]))));
+    }
+
+    /// No attestation resolves to genesis, matching go-bsc's
+    /// `GetJustifiedNumberAndHash` and the substitution our own vote producers
+    /// already make. Reported by will-2012 on #491; verified on a fresh 10-node
+    /// all-reth devnet, where every vote was rejected for source mismatch and
+    /// `finalized` never left genesis.
+    #[test]
+    fn justified_pair_without_an_attestation_resolves_to_genesis() {
+        let genesis_hash = B256::from([0x9e; 32]);
+        let vote_data = VoteData {
+            source_number: 0,
+            source_hash: B256::ZERO,
+            target_number: 0,
+            target_hash: B256::ZERO,
+        };
+        let pair = justified_pair_of(&vote_data, || Some((0, genesis_hash)));
+        assert_eq!(pair, Some((0, genesis_hash)));
+    }
+
+    /// Registers a snapshot provider for tests, reusing whichever one another
+    /// test already installed — `SNAPSHOT_PROVIDER` is a `OnceLock`.
+    fn test_snapshot_provider() -> &'static std::sync::Arc<
+        dyn crate::consensus::parlia::provider::SnapshotProvider + Send + Sync,
+    > {
+        #[derive(Default)]
+        struct MapProvider {
+            snaps: std::sync::RwLock<
+                std::collections::HashMap<B256, crate::consensus::parlia::snapshot::Snapshot>,
+            >,
+        }
+        impl crate::consensus::parlia::provider::SnapshotProvider for MapProvider {
+            fn snapshot_by_hash(
+                &self,
+                block_hash: &B256,
+            ) -> Option<crate::consensus::parlia::snapshot::Snapshot> {
+                self.snaps.read().ok().and_then(|m| m.get(block_hash).cloned())
+            }
+            fn insert(&self, snapshot: crate::consensus::parlia::snapshot::Snapshot) {
+                if let Ok(mut m) = self.snaps.write() {
+                    m.insert(snapshot.block_hash, snapshot);
+                }
+            }
+        }
+
+        if shared::get_snapshot_provider().is_none() {
+            let p: std::sync::Arc<
+                dyn crate::consensus::parlia::provider::SnapshotProvider + Send + Sync,
+            > = std::sync::Arc::new(MapProvider::default());
+            let _ = shared::set_snapshot_provider(p);
+        }
+        shared::get_snapshot_provider().expect("snapshot provider registered")
+    }
+
+    /// Before the chain has justified anything, `vote_data` is all zeroes — the
+    /// *absence* of a justified block, not a justified block whose hash is zero.
+    /// Vote producers know this and substitute genesis (`vote_producer.rs:192`,
+    /// `consensus.rs:785`), and go-bsc's `GetJustifiedNumberAndHash` returns
+    /// `chain.GetHeaderByNumber(0).Hash()` when `snap.Attestation == nil`.
+    ///
+    /// Reporting the zero hash here makes `verify_vote_origin` reject every vote
+    /// on such a chain for source mismatch, and the rejection is self-locking:
+    /// leaving the state needs an attestation, which can only be assembled from
+    /// the votes being rejected. Raised by will-2012 on #491.
+    #[test]
+    fn justified_pair_never_reports_the_zero_hash() {
+        use crate::consensus::parlia::snapshot::{Snapshot, DEFAULT_EPOCH_LENGTH};
+
+        let head_hash = B256::from([0x5a; 32]);
+        let snap = Snapshot::new(
+            vec![alloy_primitives::Address::ZERO],
+            10,
+            head_hash,
+            DEFAULT_EPOCH_LENGTH,
+            None,
+        );
+        assert_eq!(
+            snap.vote_data.target_hash,
+            B256::ZERO,
+            "a snapshot with no attestation records the zero hash",
+        );
+        test_snapshot_provider().insert(snap);
+
+        let pair = justified_pair_for_hash(&head_hash);
+        assert!(
+            !matches!(pair, Some((_, B256::ZERO))),
+            "no attestation must not be reported as a justified block at the zero hash, \
+             which no vote can ever cite; got {pair:?}",
+        );
     }
 
     /// The validator set swaps `miner_history_check_len()` blocks *after* the

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -1089,7 +1089,13 @@ pub fn promote_future_votes(head_number: BlockNumber) {
         if !candidate.expired
             && shared::get_canonical_header_by_hash_from_provider(&target_hash).is_none()
         {
-            continue; // still future
+            // Still future: we do not hold the target yet.
+            tracing::trace!(
+                target: "bsc::vote_pool",
+                target_number = candidate.target_number,
+                "promotion deferred: target block not held",
+            );
+            continue;
         }
         resolved.insert(
             target_hash,
@@ -1108,6 +1114,10 @@ pub fn promote_future_votes(head_number: BlockNumber) {
     let promoted_counts: Vec<(B256, usize)> = {
         let mut pool = VOTE_POOL.write().expect("vote pool poisoned");
         let applied = pool.apply_promotion(head_number, &resolved);
+        // How much of the per-pass budget a pass consumed. Sitting at the cap
+        // means a backlog is draining across passes — or that someone is filling
+        // the future pool faster than promotion can retire it.
+        metrics::histogram!("votes.promotion.targets_examined").record(applied.examined as f64);
         applied.promoted.into_iter().map(|hash| (hash, pool.len_for_block(&hash))).collect()
     };
 

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -83,8 +83,16 @@ struct VoteEntry {
 struct PromotionCandidate {
     data: VoteData,
     votes: Vec<VoteEntry>,
-    /// Past the `head + 11` window, so it can never become promotable later:
+    /// Below the `head - 256` retention bound, where `prune` would drop it anyway:
     /// judge it now and drop what fails rather than holding it forever.
+    ///
+    /// The bound is the *lower* admission limit, not `head + 11`. A target we do
+    /// not hold is not necessarily invalid — it can be a valid block on a branch
+    /// we have not seen — and go-bsc keeps such votes for the full 256-block
+    /// window rather than discarding them 11 blocks after the head passes them.
+    /// Discarding early loses the evidence if the node later reorgs onto that
+    /// branch. This stays a live check rather than being left to `prune`, since
+    /// `prune` runs on the vote path and promotion now runs on every import.
     expired: bool,
 }
 
@@ -340,7 +348,7 @@ impl VotePool {
                 .unwrap_or_default();
             vote_budget -= votes.len();
             candidates.push(PromotionCandidate {
-                expired: vd.target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
+                expired: vd.target_number.saturating_add(LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
                 votes,
                 data: *vd,
             });
@@ -1065,9 +1073,14 @@ pub fn promote_future_votes(head_number: BlockNumber) {
         promoted.into_iter().map(|hash| (hash, pool.len_for_block(&hash))).collect()
     };
 
-    // A target may have crossed quorum while it sat in the future pool.
+    // A target may have crossed quorum while it sat in the future pool. Report the
+    // delay stats too: `on_vote_received` is keyed on the current total for a
+    // block, and promotion is the only path by which a future vote reaches that
+    // total, so skipping it under-reports first- and majority-vote delay on
+    // exactly the nodes that classify the most votes as future.
     for (hash, count) in promoted_counts {
         if count > 0 {
+            block_stats::on_vote_received(hash, count);
             maybe_notify_finality(hash, count);
         }
     }
@@ -1823,21 +1836,24 @@ mod tests {
     }
 
     /// Candidate selection is the read-lock half: everything at or below the head
-    /// is a candidate, anything past `head + 11` is flagged so promotion judges it
-    /// now instead of holding it forever, and targets above the head are left
-    /// alone.
+    /// is a candidate, anything below the `head - 256` retention bound is flagged
+    /// so promotion judges it instead of holding it forever, and targets above the
+    /// head are left alone.
     #[test]
     fn promotion_candidates_selects_reached_targets_and_flags_expired() {
+        const HEAD: u64 = 400;
         let stale = B256::from([0xa1; 32]);
-        let current = B256::from([0xa2; 32]);
-        let ahead = B256::from([0xa3; 32]);
+        let recent = B256::from([0xa2; 32]);
+        let current = B256::from([0xa3; 32]);
+        let ahead = B256::from([0xa4; 32]);
         let mut pool = VotePool::new();
-        pool.insert(future_vote(stale, 50, 5), 0, true);
-        pool.insert(future_vote(current, 100, 6), 0, true);
-        pool.insert(future_vote(ahead, 105, 7), 0, true);
+        pool.insert(future_vote(stale, 100, 5), 0, true);
+        pool.insert(future_vote(recent, 380, 6), 0, true);
+        pool.insert(future_vote(current, HEAD, 7), 0, true);
+        pool.insert(future_vote(ahead, HEAD + 5, 8), 0, true);
 
         let mut got: Vec<(u64, bool, usize)> = pool
-            .promotion_candidates(100)
+            .promotion_candidates(HEAD)
             .into_iter()
             .map(|c| (c.data.target_number, c.expired, c.votes.len()))
             .collect();
@@ -1845,8 +1861,9 @@ mod tests {
 
         assert_eq!(
             got,
-            vec![(50, true, 1), (100, false, 1)],
-            "target 105 is still ahead of the head; 50 is past head-11 so it expires",
+            vec![(100, true, 1), (380, false, 1), (400, false, 1)],
+            "405 is still ahead of the head; only 100 is past head-256, and 380 is \
+             held rather than discarded, matching go-bsc's retention",
         );
     }
 

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -694,10 +694,10 @@ fn future_vote_sender_is_validator(vote: &VoteEnvelope) -> Option<bool> {
         return None;
     }
 
-    // A validator-set swap between head and target changes the set out from
-    // under us; decline to judge rather than risk rejecting an incoming
-    // validator.
-    if validator_set_swaps_within(
+    // If our head's set is not the set that governs the target, we cannot judge
+    // membership from it; decline rather than risk rejecting a validator that is
+    // legitimate for that target.
+    if governing_sets_differ(
         head_number,
         vote.data.target_number,
         snap.epoch_num,
@@ -709,19 +709,30 @@ fn future_vote_sender_is_validator(vote: &VoteEnvelope) -> Option<bool> {
     Some(snap.validators_map.values().any(|v| v.vote_addr == vote.vote_address))
 }
 
-/// Whether a validator-set swap falls in `(head, target]`.
+/// Whether the validator set at `head` differs from the set that governs `target`.
 ///
-/// The set does **not** change at the epoch multiple: it changes `offset`
-/// blocks later, where `offset` is `Snapshot::miner_history_check_len()`. That
-/// is the `header.number % epoch_num == miner_check_len` test in
-/// `SnapshotProvider::try_rebuild`, and it is the only place the set is
-/// swapped. With 21 validators at `turn_length` 4 the offset is 43, so on a
-/// 1000-block epoch the set turns over at `…043`, not `…000`.
+/// Membership for a vote targeting `T` is resolved from **`T`'s parent** snapshot
+/// — that is what `verify_vote_origin` uses, and go-bsc's `VerifyVote` too — so
+/// the comparison is between `head` and `target - 1`, and it must hold in both
+/// directions. A future vote is one whose block we do not hold, which says
+/// nothing about its height: the admission window reaches back to `head - 255`,
+/// so a vote for a valid block on a branch we have not seen is routinely *behind*
+/// the head, with a set change in between. Testing only "did a swap happen after
+/// the head" answers false for every such vote and judges it against the wrong
+/// set — rejecting a validator that legitimately governs that target, and, since
+/// those rejections are cached, keeping the vote out for good if the branch later
+/// becomes canonical. Reported by Hashdit Bot on #491.
 ///
-/// Counting the swap points at or below each height and comparing the counts
-/// catches a boundary wherever it sits in the window, and needs no special case
-/// for a window that spans an epoch multiple.
-fn validator_set_swaps_within(head: u64, target: u64, epoch: u64, offset: u64) -> bool {
+/// The set does **not** change at the epoch multiple: it changes `offset` blocks
+/// later, where `offset` is `Snapshot::miner_history_check_len()`. That is the
+/// `header.number % epoch_num == miner_check_len` test in
+/// `SnapshotProvider::try_rebuild`, and it is the only place the set is swapped.
+/// With 21 validators at `turn_length` 4 the offset is 43, so on a 1000-block
+/// epoch the set turns over at `…043`, not `…000`.
+///
+/// Counting the swap points at or below each height and comparing the two counts
+/// answers this for any pair of heights, in either order.
+fn governing_sets_differ(head: u64, target: u64, epoch: u64, offset: u64) -> bool {
     let epoch = epoch.max(1);
     // `n % epoch == offset` is unsatisfiable here, so the provider never treats
     // any block as a boundary. Mirror it rather than invent one.
@@ -729,7 +740,7 @@ fn validator_set_swaps_within(head: u64, target: u64, epoch: u64, offset: u64) -
         return false;
     }
     let swaps_upto = |n: u64| if n >= offset { (n - offset) / epoch + 1 } else { 0 };
-    swaps_upto(target) > swaps_upto(head)
+    swaps_upto(head) != swaps_upto(target.saturating_sub(1))
 }
 
 /// Whether a vote plausibly originates from a validator of its target block and
@@ -2145,50 +2156,79 @@ mod tests {
     }
 
     /// The validator set swaps `miner_history_check_len()` blocks *after* the
-    /// epoch multiple, not at it. Judging a future vote against our own head is
-    /// only sound when no swap sits in `(head, target]`, and watching the
-    /// multiple instead misses the real boundary by that offset — which rejects
-    /// a joining validator's votes outright, since `Some(false)` drops them and
-    /// votes are never re-sent. Raised by will-2012 on #491.
+    /// epoch multiple, not at it, and membership for a target comes from the
+    /// target's *parent*. Watching the multiple instead misses the real boundary
+    /// by that offset — which rejects a joining validator's votes outright, since
+    /// `Some(false)` drops them and votes are never re-sent. Raised by will-2012
+    /// on #491.
     #[test]
-    fn validator_set_swap_window_tracks_the_real_boundary() {
+    fn governing_sets_differ_tracks_the_real_boundary() {
         // Mainnet post-Maxwell: 1000-block epoch, 21 validators, turn_length 4.
         const EPOCH: u64 = 1000;
         const OFFSET: u64 = 43; // (21 / 2 + 1) * 4 - 1
 
-        // The swap at 43_043 lies in the window, so membership is undecidable...
-        assert!(validator_set_swaps_within(43_035, 43_043, EPOCH, OFFSET));
-        // ...and both heights share an epoch multiple, so the multiple-based
-        // test saw no boundary at all and judged against the outgoing set.
-        assert_eq!(43_035 / EPOCH, 43_043 / EPOCH);
+        // The swap at 43_043 governs 43_044 onward, so our head at 43_035 holds a
+        // different set...
+        assert!(governing_sets_differ(43_035, 43_044, EPOCH, OFFSET));
+        // ...and both heights share an epoch multiple, so a multiple-based test
+        // saw no boundary at all and judged against the outgoing set.
+        assert_eq!(43_035 / EPOCH, 43_044 / EPOCH);
 
-        // Crossing the multiple without reaching the swap: the set is unchanged...
-        assert!(!validator_set_swaps_within(42_995, 43_000, EPOCH, OFFSET));
-        // ...where the multiple-based test declined to judge. Harmless, but it
-        // gave up the per-block cap for no reason.
+        // Crossing the multiple without reaching the swap: the set is unchanged.
+        assert!(!governing_sets_differ(42_995, 43_000, EPOCH, OFFSET));
         assert_ne!(42_995 / EPOCH, 43_000 / EPOCH);
 
-        // Half-open window: a swap at `head` is behind us, one at `target` is not.
-        assert!(!validator_set_swaps_within(43_043, 43_050, EPOCH, OFFSET));
-        assert!(validator_set_swaps_within(43_042, 43_043, EPOCH, OFFSET));
+        // The swap block itself is still governed by the outgoing set, because
+        // membership comes from its parent.
+        assert!(!governing_sets_differ(43_042, 43_043, EPOCH, OFFSET));
+        // Its successor is not.
+        assert!(governing_sets_differ(43_042, 43_044, EPOCH, OFFSET));
         // Mid-epoch window, nothing near a boundary.
-        assert!(!validator_set_swaps_within(43_100, 43_111, EPOCH, OFFSET));
+        assert!(!governing_sets_differ(43_100, 43_111, EPOCH, OFFSET));
+    }
+
+    /// The comparison must hold in both directions. A future vote is one whose
+    /// block we do not hold, which says nothing about its height: the admission
+    /// window reaches back to `head - 255`, so a vote for a valid block on an
+    /// unseen branch is routinely behind the head with a swap in between. Judging
+    /// it against our head's set rejects a validator that legitimately governs
+    /// that target, and the rejection is cached, so the vote stays out even if the
+    /// branch later becomes canonical. Reported by Hashdit Bot on #491.
+    #[test]
+    fn governing_sets_differ_detects_a_swap_behind_the_head() {
+        const EPOCH: u64 = 1000;
+        const OFFSET: u64 = 43;
+
+        // Target 100 blocks behind the head, with the swap at 43_043 between them.
+        assert!(governing_sets_differ(43_100, 43_000, EPOCH, OFFSET));
+        // Both behind the swap: same set, safe to judge.
+        assert!(!governing_sets_differ(43_040, 43_000, EPOCH, OFFSET));
+        // Both after it: likewise.
+        assert!(!governing_sets_differ(43_200, 43_100, EPOCH, OFFSET));
+        // The full admission window can span a swap in either direction.
+        let oldest_admissible = 43_050 - LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER + 1;
+        assert!(governing_sets_differ(43_050, oldest_admissible, EPOCH, OFFSET));
     }
 
     /// Differential check against the predicate that actually swaps the set in
-    /// `SnapshotProvider::try_rebuild`, over every window the admission bound
-    /// permits.
+    /// `SnapshotProvider::try_rebuild`, over every ordered pair the admission
+    /// window permits — behind the head as well as ahead of it.
     #[test]
-    fn validator_set_swap_window_matches_the_provider_predicate() {
+    fn governing_sets_differ_matches_the_provider_predicate() {
         const EPOCH: u64 = 200;
         const OFFSET: u64 = 10;
 
-        for head in 0..(EPOCH * 3) {
-            for target in head..=(head + UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) {
+        for head in 300..(300 + EPOCH * 2) {
+            let lowest = head - LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER + 1;
+            for target in lowest..=(head + UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) {
+                // Membership comes from the target's parent.
+                let governing = target.saturating_sub(1);
+                let (lo, hi) =
+                    if governing < head { (governing, head) } else { (head, governing) };
                 // `is_epoch_boundary` in provider.rs, applied block by block.
-                let expected = ((head + 1)..=target).any(|n| n > 0 && n % EPOCH == OFFSET);
+                let expected = ((lo + 1)..=hi).any(|n| n > 0 && n % EPOCH == OFFSET);
                 assert_eq!(
-                    validator_set_swaps_within(head, target, EPOCH, OFFSET),
+                    governing_sets_differ(head, target, EPOCH, OFFSET),
                     expected,
                     "head {head}, target {target}",
                 );
@@ -2199,14 +2239,14 @@ mod tests {
     /// Degenerate configurations must not invent a boundary the provider can
     /// never reach, and must not divide by zero.
     #[test]
-    fn validator_set_swap_window_handles_degenerate_epochs() {
+    fn governing_sets_differ_handles_degenerate_epochs() {
         // offset >= epoch: `n % epoch == offset` never holds, so the provider
         // never swaps the set and neither may we.
-        assert!(!validator_set_swaps_within(0, 10_000, 200, 200));
+        assert!(!governing_sets_differ(0, 10_000, 200, 200));
         // A zero epoch is coerced to 1 rather than panicking.
-        assert!(validator_set_swaps_within(5, 6, 0, 0));
+        assert!(governing_sets_differ(5, 7, 0, 0));
         // Single-validator devnet: offset 0, so the swap sits on the multiple.
-        assert!(validator_set_swaps_within(199, 200, 200, 0));
-        assert!(!validator_set_swaps_within(200, 205, 200, 0));
+        assert!(governing_sets_differ(199, 201, 200, 0));
+        assert!(!governing_sets_differ(200, 205, 200, 0));
     }
 }

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -64,6 +64,14 @@ const MAX_PROMOTION_TARGETS_PER_PASS: usize = 64;
 /// snapshot reads to judge. `promote_judged` leaves the unjudged remainder future
 /// and re-queues the target, so a large bucket drains across passes.
 const MAX_PROMOTION_VOTES_PER_PASS: usize = 512;
+/// Votes of headroom to reclaim when the pool overflows.
+///
+/// Shedding walks and rebuilds the whole future queue, so releasing exactly the
+/// overflow makes the *next* admitted vote overflow again — turning an O(n log n)
+/// pass under the write lock into a per-vote cost. Reclaiming a block of headroom
+/// instead amortises it to roughly one pass per `SHED_HEADROOM` admissions.
+/// Reported by Hashdit Bot on #491.
+const SHED_HEADROOM: usize = 4096;
 /// Hard ceiling on pooled votes. Exceeding it triggers a prune and, failing
 /// that, shedding of future votes.
 const MAX_VOTES_IN_POOL: usize = 32 * 1024 * 2;
@@ -94,6 +102,16 @@ struct PromotionCandidate {
     /// Upstream never prunes `futureVotes` by the 256-block bound — this sweep is
     /// what clears them.
     expired: bool,
+}
+
+/// How many votes to release when the pool is over its ceiling, or `None` when it
+/// is not. Sheds down to `MAX_VOTES_IN_POOL - SHED_HEADROOM` so the cost is paid
+/// once per block of admissions rather than on every vote.
+fn overflow_shed_target(pool_len: usize) -> Option<usize> {
+    if pool_len <= MAX_VOTES_IN_POOL {
+        return None;
+    }
+    Some(pool_len - MAX_VOTES_IN_POOL.saturating_sub(SHED_HEADROOM))
 }
 
 /// What one promotion pass did, so the per-pass bound is observable in tests.
@@ -424,6 +442,9 @@ impl VotePool {
                         deferred.push(vd);
                     }
                 }
+                // A target whose bucket is gone — shed, or pruned — leaves a
+                // stale queue entry. Drop it rather than deferring it forever.
+                None if !self.future_votes.contains_key(&vd.target_hash) => {}
                 None => deferred.push(vd),
             }
         }
@@ -1024,8 +1045,8 @@ fn put_vote_inner(vote: VoteEnvelope, vote_hash: B256) {
     if pool.len() > MAX_VOTES_IN_POOL {
         pool.prune(pending_block_number);
         let after_prune = pool.len();
-        if after_prune > MAX_VOTES_IN_POOL {
-            let shed = pool.shed_future_votes(after_prune - MAX_VOTES_IN_POOL);
+        if let Some(to_shed) = overflow_shed_target(after_prune) {
+            let shed = pool.shed_future_votes(to_shed);
             metrics::counter!("votes.shed.future_oversized").increment(shed as u64);
             tracing::warn!(
                 target: "bsc::vote_pool",
@@ -2013,6 +2034,43 @@ mod tests {
             .collect();
         let applied = pool.apply_promotion(1000, &resolved);
         assert_eq!(applied.promoted.len(), MAX_PROMOTION_TARGETS_PER_PASS, "all judged promoted");
+    }
+
+    /// Overflow must reclaim a block of headroom, not just the excess. Shedding
+    /// walks and rebuilds the whole future queue, so releasing exactly the
+    /// overflow would make the next admitted vote overflow again and pay that
+    /// cost per vote, under the write lock. Reported by Hashdit Bot on #491.
+    #[test]
+    fn overflow_sheds_a_block_of_headroom() {
+        assert_eq!(overflow_shed_target(MAX_VOTES_IN_POOL), None, "at the ceiling, nothing to do");
+        assert_eq!(overflow_shed_target(MAX_VOTES_IN_POOL - 1), None);
+
+        // One vote over: still reclaim headroom, so the next admissions are free.
+        let one_over = overflow_shed_target(MAX_VOTES_IN_POOL + 1).expect("over the ceiling");
+        assert_eq!(one_over, SHED_HEADROOM + 1);
+
+        // After shedding, the pool sits a full block below the ceiling.
+        let remaining = (MAX_VOTES_IN_POOL + 1) - one_over;
+        assert_eq!(remaining, MAX_VOTES_IN_POOL - SHED_HEADROOM);
+        assert_eq!(overflow_shed_target(remaining), None, "and does not re-trigger");
+    }
+
+    /// A queue entry whose bucket was shed or pruned must be discarded, not
+    /// deferred: deferring re-queues it every pass, forever.
+    #[test]
+    fn apply_promotion_drops_queue_entries_whose_bucket_is_gone() {
+        let target = B256::from([0xd1; 32]);
+        let mut pool = VotePool::new();
+        pool.insert(future_vote(target, 100, 1), 0, true);
+        assert_eq!(pool.future_votes_pq.heap.len(), 1);
+
+        // Simulate shedding having removed the bucket while its queue entry stays.
+        pool.future_votes.remove(&target);
+
+        let applied = pool.apply_promotion(100, &HashMap::new());
+        assert!(applied.promoted.is_empty());
+        assert_eq!(applied.examined, 1);
+        assert_eq!(pool.future_votes_pq.heap.len(), 0, "the stale entry is discarded");
     }
 
     /// Registers a snapshot provider for tests, reusing whichever one another

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -83,16 +83,15 @@ struct VoteEntry {
 struct PromotionCandidate {
     data: VoteData,
     votes: Vec<VoteEntry>,
-    /// Below the `head - 256` retention bound, where `prune` would drop it anyway:
-    /// judge it now and drop what fails rather than holding it forever.
+    /// More than `head - 11` behind, so judge it now and drop what fails rather
+    /// than holding it forever.
     ///
-    /// The bound is the *lower* admission limit, not `head + 11`. A target we do
-    /// not hold is not necessarily invalid — it can be a valid block on a branch
-    /// we have not seen — and go-bsc keeps such votes for the full 256-block
-    /// window rather than discarding them 11 blocks after the head passes them.
-    /// Discarding early loses the evidence if the node later reorgs onto that
-    /// branch. This stays a live check rather than being left to `prune`, since
-    /// `prune` runs on the vote path and promotion now runs on every import.
+    /// The bound is the *upper* admission limit, matching go-bsc's
+    /// `transferVotesFromFutureToCur`, which sweeps
+    /// `TargetNumber + upperLimitOfVoteBlockNumber < latestBlockNumber`
+    /// unconditionally and lets `VerifyVote` drop what cannot be verified.
+    /// Upstream never prunes `futureVotes` by the 256-block bound — this sweep is
+    /// what clears them.
     expired: bool,
 }
 
@@ -348,7 +347,7 @@ impl VotePool {
                 .unwrap_or_default();
             vote_budget -= votes.len();
             candidates.push(PromotionCandidate {
-                expired: vd.target_number.saturating_add(LOWER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
+                expired: vd.target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
                 votes,
                 data: *vd,
             });
@@ -1836,24 +1835,22 @@ mod tests {
     }
 
     /// Candidate selection is the read-lock half: everything at or below the head
-    /// is a candidate, anything below the `head - 256` retention bound is flagged
-    /// so promotion judges it instead of holding it forever, and targets above the
-    /// head are left alone.
+    /// is a candidate, anything more than `head - 11` behind is flagged so
+    /// promotion judges it instead of holding it forever — the same sweep go-bsc
+    /// runs in `transferVotesFromFutureToCur` — and targets above the head are
+    /// left alone.
     #[test]
     fn promotion_candidates_selects_reached_targets_and_flags_expired() {
-        const HEAD: u64 = 400;
         let stale = B256::from([0xa1; 32]);
-        let recent = B256::from([0xa2; 32]);
-        let current = B256::from([0xa3; 32]);
-        let ahead = B256::from([0xa4; 32]);
+        let current = B256::from([0xa2; 32]);
+        let ahead = B256::from([0xa3; 32]);
         let mut pool = VotePool::new();
-        pool.insert(future_vote(stale, 100, 5), 0, true);
-        pool.insert(future_vote(recent, 380, 6), 0, true);
-        pool.insert(future_vote(current, HEAD, 7), 0, true);
-        pool.insert(future_vote(ahead, HEAD + 5, 8), 0, true);
+        pool.insert(future_vote(stale, 50, 5), 0, true);
+        pool.insert(future_vote(current, 100, 6), 0, true);
+        pool.insert(future_vote(ahead, 105, 7), 0, true);
 
         let mut got: Vec<(u64, bool, usize)> = pool
-            .promotion_candidates(HEAD)
+            .promotion_candidates(100)
             .into_iter()
             .map(|c| (c.data.target_number, c.expired, c.votes.len()))
             .collect();
@@ -1861,9 +1858,8 @@ mod tests {
 
         assert_eq!(
             got,
-            vec![(100, true, 1), (380, false, 1), (400, false, 1)],
-            "405 is still ahead of the head; only 100 is past head-256, and 380 is \
-             held rather than discarded, matching go-bsc's retention",
+            vec![(50, true, 1), (100, false, 1)],
+            "target 105 is still ahead of the head; 50 is past head-11 so it expires",
         );
     }
 

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -49,6 +49,21 @@ const MAX_CUR_VOTE_AMOUNT_PER_BLOCK: usize = 21;
 /// accounting for future votes in `core/vote/vote_pool.go`. Worth raising
 /// upstream rather than assuming reth-bsc is the only client affected.
 const MAX_FUTURE_VOTE_AMOUNT_PER_BLOCK: usize = 50;
+/// Targets examined by one promotion pass.
+///
+/// Promotion runs on every import, so a bounded slice per pass still drains a
+/// backlog quickly, while a flood cannot put unbounded work on the critical path
+/// between importing a block and the next one. Whatever is left over is picked up
+/// by the next pass.
+const MAX_PROMOTION_TARGETS_PER_PASS: usize = 64;
+/// Votes origin-checked by one promotion pass.
+///
+/// The per-target budget matters more than the per-pass one: future buckets whose
+/// sender could not be authenticated are deliberately uncapped, so a single target
+/// can hold tens of thousands of votes, each costing a provider read and two
+/// snapshot reads to judge. `promote_judged` leaves the unjudged remainder future
+/// and re-queues the target, so a large bucket drains across passes.
+const MAX_PROMOTION_VOTES_PER_PASS: usize = 512;
 /// Hard ceiling on pooled votes. Exceeding it triggers a prune and, failing
 /// that, shedding of future votes.
 const MAX_VOTES_IN_POOL: usize = 32 * 1024 * 2;
@@ -62,6 +77,9 @@ struct VoteEntry {
 }
 
 /// One future target considered for promotion, captured under the read lock.
+///
+/// `votes` may be a prefix of the target's bucket when the pass runs out of
+/// budget; the remainder stays future and is judged by a later pass.
 struct PromotionCandidate {
     data: VoteData,
     votes: Vec<VoteEntry>,
@@ -305,21 +323,30 @@ impl VotePool {
     ///
     /// Read-only: nothing moves until `apply_promotion` runs with the verdicts.
     fn promotion_candidates(&self, latest: BlockNumber) -> Vec<PromotionCandidate> {
-        self.future_votes_pq
-            .heap
-            .iter()
-            .map(|Reverse(vd)| *vd)
-            .filter(|vd| vd.target_number <= latest)
-            .map(|vd| PromotionCandidate {
+        let mut candidates = Vec::new();
+        let mut vote_budget = MAX_PROMOTION_VOTES_PER_PASS;
+
+        for Reverse(vd) in self.future_votes_pq.heap.iter() {
+            if candidates.len() >= MAX_PROMOTION_TARGETS_PER_PASS || vote_budget == 0 {
+                break;
+            }
+            if vd.target_number > latest {
+                continue;
+            }
+            let votes: Vec<VoteEntry> = self
+                .future_votes
+                .get(&vd.target_hash)
+                .map(|vm| vm.vote_messages.iter().take(vote_budget).cloned().collect())
+                .unwrap_or_default();
+            vote_budget -= votes.len();
+            candidates.push(PromotionCandidate {
                 expired: vd.target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
-                votes: self
-                    .future_votes
-                    .get(&vd.target_hash)
-                    .map(|vm| vm.vote_messages.clone())
-                    .unwrap_or_default(),
-                data: vd,
-            })
-            .collect()
+                votes,
+                data: *vd,
+            });
+        }
+
+        candidates
     }
 
     /// Moves the targets in `resolved` into the current pool, using verdicts
@@ -647,7 +674,7 @@ fn validator_set_swaps_within(head: u64, target: u64, epoch: u64, offset: u64) -
 /// the same outcome go-bsc reaches by returning an error — but logs the two
 /// cases separately, because "snapshot not available yet" and "vote is not from
 /// a validator" have very different operational meanings.
-fn verify_vote_origin(vote: &VoteEnvelope) -> bool {
+fn verify_vote_origin(vote: &VoteEnvelope) -> OriginVerdict {
     let Some(header) = shared::get_canonical_header_by_hash_from_provider(&vote.data.target_hash)
     else {
         tracing::debug!(
@@ -655,10 +682,10 @@ fn verify_vote_origin(vote: &VoteEnvelope) -> bool {
             target_number = vote.data.target_number,
             "vote origin unverifiable: target header not found",
         );
-        return false;
+        return OriginVerdict::Unverifiable;
     };
     if header.number != vote.data.target_number {
-        return false;
+        return OriginVerdict::Rejected;
     }
 
     match justified_pair_for_hash(&vote.data.target_hash) {
@@ -667,7 +694,7 @@ fn verify_vote_origin(vote: &VoteEnvelope) -> bool {
                 || vote.data.source_hash != justified_hash
             {
                 metrics::counter!("votes.rejected.source_mismatch").increment(1);
-                return false;
+                return OriginVerdict::Rejected;
             }
         }
         None => {
@@ -676,12 +703,12 @@ fn verify_vote_origin(vote: &VoteEnvelope) -> bool {
                 target_number = vote.data.target_number,
                 "vote origin unverifiable: no snapshot for target",
             );
-            return false;
+            return OriginVerdict::Unverifiable;
         }
     }
 
     let Some(sp) = shared::get_snapshot_provider() else {
-        return false;
+        return OriginVerdict::Unverifiable;
     };
     let Some(parent_snap) = sp.snapshot_by_hash(&header.parent_hash) else {
         tracing::debug!(
@@ -689,15 +716,41 @@ fn verify_vote_origin(vote: &VoteEnvelope) -> bool {
             target_number = vote.data.target_number,
             "vote origin unverifiable: no snapshot for target's parent",
         );
-        return false;
+        return OriginVerdict::Unverifiable;
     };
 
-    let is_validator =
-        parent_snap.validators_map.values().any(|v| v.vote_addr == vote.vote_address);
-    if !is_validator {
+    if parent_snap.validators_map.values().any(|v| v.vote_addr == vote.vote_address) {
+        OriginVerdict::Ok
+    } else {
         metrics::counter!("votes.rejected.not_a_validator").increment(1);
+        OriginVerdict::Rejected
     }
-    is_validator
+}
+
+/// Remember an envelope that can never become valid, so a replay is dropped at
+/// `put_vote`'s cache check instead of paying for another BLS verification.
+///
+/// Only for verdicts that are properties of the envelope itself. Anything we
+/// merely could not judge yet must stay out of here.
+fn remember_rejected(vote_hash: B256) {
+    REJECTED_VOTES.write().expect("rejected vote cache poisoned").put(vote_hash, ());
+}
+
+/// Outcome of an origin check.
+///
+/// `Rejected` and `Unverifiable` both keep a vote out, but they must not be
+/// treated alike at admission: a rejection is a property of the envelope and
+/// cannot change, while "unverifiable" means only that we lack the snapshot to
+/// judge it yet. Caching the latter as rejected would blacklist a vote that a
+/// later copy could have proven valid.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OriginVerdict {
+    Ok,
+    /// The envelope contradicts the chain: wrong target height, wrong source
+    /// pair, or a sender absent from the set that governs its target.
+    Rejected,
+    /// We cannot tell yet — the target's snapshot or the provider is missing.
+    Unverifiable,
 }
 
 /// Whether a vote targeting `target_number` falls inside the admission window
@@ -780,7 +833,7 @@ pub fn put_vote(vote: VoteEnvelope) {
         return;
     }
 
-    put_vote_inner(vote);
+    put_vote_inner(vote, vote_hash);
 }
 
 /// Test-only ingress that skips signature verification and places the vote
@@ -803,7 +856,7 @@ pub fn put_vote_unchecked(vote: VoteEnvelope) {
     }
 }
 
-fn put_vote_inner(vote: VoteEnvelope) {
+fn put_vote_inner(vote: VoteEnvelope, vote_hash: B256) {
     let target_hash = vote.data.target_hash;
     let target_number = vote.data.target_number;
     let pending_block_number = shared::get_best_canonical_block_number().unwrap_or(0);
@@ -844,6 +897,11 @@ fn put_vote_inner(vote: VoteEnvelope) {
                     target_number,
                     "rejecting future vote from a non-validator",
                 );
+                // The sender is in no validator set, and `future_vote_sender_is_
+                // validator` only answers `Some` when no set change lies between
+                // our head and the target — so this envelope cannot start
+                // passing, and a replay must not cost another BLS verification.
+                remember_rejected(vote_hash);
                 return;
             }
             Some(true) => true,
@@ -854,14 +912,24 @@ fn put_vote_inner(vote: VoteEnvelope) {
     };
 
     // Current votes are origin-checked at admission; future votes at promotion.
-    if !is_future && !verify_vote_origin(&vote) {
-        tracing::debug!(
-            target: "bsc::vote_pool",
-            vote_address = %vote.vote_address,
-            target_number,
-            "rejecting vote that failed the origin check",
-        );
-        return;
+    if !is_future {
+        match verify_vote_origin(&vote) {
+            OriginVerdict::Ok => {}
+            verdict => {
+                tracing::debug!(
+                    target: "bsc::vote_pool",
+                    vote_address = %vote.vote_address,
+                    target_number,
+                    "rejecting vote that failed the origin check",
+                );
+                // Only a verdict about the envelope is cacheable. "Unverifiable"
+                // means a snapshot was missing, which a later copy may not hit.
+                if verdict == OriginVerdict::Rejected {
+                    remember_rejected(vote_hash);
+                }
+                return;
+            }
+        }
     }
 
     // Lazy prune, once per observed head advance. Promotion is driven by block
@@ -982,7 +1050,7 @@ pub fn promote_future_votes(head_number: BlockNumber) {
             candidate
                 .votes
                 .iter()
-                .map(|entry| (entry.hash, verify_vote_origin(&entry.envelope)))
+                .map(|entry| (entry.hash, verify_vote_origin(&entry.envelope) == OriginVerdict::Ok))
                 .collect(),
         );
     }
@@ -1780,6 +1848,53 @@ mod tests {
             vec![(50, true, 1), (100, false, 1)],
             "target 105 is still ahead of the head; 50 is past head-11 so it expires",
         );
+    }
+
+    /// One pass judges at most `MAX_PROMOTION_VOTES_PER_PASS` votes, so an
+    /// uncapped future bucket cannot put unbounded provider and snapshot reads on
+    /// the import path. The remainder is not lost: it stays future, its target
+    /// stays queued, and the next pass continues.
+    #[test]
+    fn promotion_candidates_bounds_the_votes_judged_per_pass() {
+        let target = B256::from([0xb1; 32]);
+        let mut pool = VotePool::new();
+        let oversized = MAX_PROMOTION_VOTES_PER_PASS + 40;
+        for i in 0..oversized {
+            let mut vote = future_vote(target, 100, 0);
+            // Distinct envelopes: `insert` dedups by hash.
+            vote.vote_address[1..3].copy_from_slice(&(i as u16).to_be_bytes());
+            pool.insert(vote, 0, true);
+        }
+
+        let candidates = pool.promotion_candidates(100);
+        let judged: usize = candidates.iter().map(|c| c.votes.len()).sum();
+        assert_eq!(judged, MAX_PROMOTION_VOTES_PER_PASS, "pass budget is enforced");
+
+        // Judge exactly what the pass captured; the rest must survive as future.
+        let verdicts: HashMap<B256, bool> =
+            candidates[0].votes.iter().map(|e| (e.hash, true)).collect();
+        let promoted = pool.apply_promotion(100, &[(target, verdicts)].into_iter().collect());
+
+        assert_eq!(promoted, vec![target]);
+        assert_eq!(
+            pool.future_votes.get(&target).map(|vm| vm.vote_messages.len()),
+            Some(oversized - MAX_PROMOTION_VOTES_PER_PASS),
+            "the unjudged remainder stays future",
+        );
+        assert_eq!(pool.future_votes_pq.heap.len(), 1, "and its target stays queued");
+    }
+
+    /// At most `MAX_PROMOTION_TARGETS_PER_PASS` targets are examined per pass.
+    #[test]
+    fn promotion_candidates_bounds_the_targets_per_pass() {
+        let mut pool = VotePool::new();
+        for i in 0..(MAX_PROMOTION_TARGETS_PER_PASS + 10) {
+            let mut hash = [0xc0u8; 32];
+            hash[0..2].copy_from_slice(&(i as u16).to_be_bytes());
+            pool.insert(future_vote(B256::from(hash), 100, 9), 0, true);
+        }
+
+        assert_eq!(pool.promotion_candidates(100).len(), MAX_PROMOTION_TARGETS_PER_PASS);
     }
 
     /// Registers a snapshot provider for tests, reusing whichever one another

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -61,6 +61,23 @@ struct VoteEntry {
     envelope: VoteEnvelope,
 }
 
+/// One future target considered for promotion, captured under the read lock.
+struct PromotionCandidate {
+    data: VoteData,
+    votes: Vec<VoteEntry>,
+    /// Past the `head + 11` window, so it can never become promotable later:
+    /// judge it now and drop what fails rather than holding it forever.
+    expired: bool,
+}
+
+/// Result of moving one target out of the future pool.
+struct PromotionOutcome {
+    /// At least one vote survived the origin check and reached the current pool.
+    promoted: bool,
+    /// Votes without a verdict remain, so the target must stay queued.
+    requeue: bool,
+}
+
 /// Container for votes associated with a specific block hash.
 #[derive(Default)]
 struct VoteMessages {
@@ -283,68 +300,107 @@ impl VotePool {
     ///
     /// Returns the target hashes that gained current votes, so the caller can
     /// run finality notification after releasing the pool lock.
-    fn transfer_future_votes(&mut self, latest: BlockNumber) -> Vec<B256> {
+    /// Future entries whose target height we have reached, with their votes
+    /// cloned out so the origin checks can run *without* the pool lock held.
+    ///
+    /// Read-only: nothing moves until `apply_promotion` runs with the verdicts.
+    fn promotion_candidates(&self, latest: BlockNumber) -> Vec<PromotionCandidate> {
+        self.future_votes_pq
+            .heap
+            .iter()
+            .map(|Reverse(vd)| *vd)
+            .filter(|vd| vd.target_number <= latest)
+            .map(|vd| PromotionCandidate {
+                expired: vd.target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
+                votes: self
+                    .future_votes
+                    .get(&vd.target_hash)
+                    .map(|vm| vm.vote_messages.clone())
+                    .unwrap_or_default(),
+                data: vd,
+            })
+            .collect()
+    }
+
+    /// Moves the targets in `resolved` into the current pool, using verdicts
+    /// computed outside the lock. Targets absent from `resolved` are ones whose
+    /// block we still do not hold; they stay future.
+    fn apply_promotion(
+        &mut self,
+        latest: BlockNumber,
+        resolved: &HashMap<B256, HashMap<B256, bool>>,
+    ) -> Vec<B256> {
         let mut promoted = Vec::new();
-
-        // Phase 1: too old to still be considered future.
-        while let Some(vd) = self.future_votes_pq.peek() {
-            if vd.target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) >= latest {
-                break;
-            }
-            let hash = vd.target_hash;
-            self.future_votes_pq.pop();
-            if self.promote(hash) {
-                promoted.push(hash);
-            }
-        }
-
-        // Phase 2: promote only what we can now resolve; retain the rest.
         let mut deferred = Vec::new();
+
         while let Some(vd) = self.future_votes_pq.peek() {
             if vd.target_number > latest {
                 break;
             }
             let vd = *vd;
             self.future_votes_pq.pop();
-            if shared::get_canonical_header_by_hash_from_provider(&vd.target_hash).is_none() {
-                deferred.push(vd);
-                continue;
-            }
-            if self.promote(vd.target_hash) {
-                promoted.push(vd.target_hash);
+            match resolved.get(&vd.target_hash) {
+                Some(verdicts) => {
+                    let outcome = self.promote_judged(vd.target_hash, verdicts);
+                    if outcome.promoted {
+                        promoted.push(vd.target_hash);
+                    }
+                    // Re-queue outside the loop: pushing here would let the same
+                    // entry be popped again on this pass, forever.
+                    if outcome.requeue {
+                        deferred.push(vd);
+                    }
+                }
+                None => deferred.push(vd),
             }
         }
+
         for vd in deferred {
             self.future_votes_pq.push(vd);
         }
-
         metrics::gauge!("futureVotesPq.local").set(self.future_votes_pq.heap.len() as f64);
         promoted
     }
 
-    /// Moves one target's future votes into the current pool, dropping any that
-    /// fail the origin check. Returns whether any vote survived.
+    /// Moves one target's future votes into the current pool, dropping those the
+    /// origin check rejected. Returns whether anything survived, and whether the
+    /// target must stay queued.
     ///
-    /// The caller has already popped this hash from the future queue.
-    fn promote(&mut self, block_hash: B256) -> bool {
+    /// Votes that arrived between the verdicts being taken and this write have no
+    /// verdict of their own. They are left in the future pool and the target is
+    /// re-queued, so the next pass judges them rather than this one guessing.
+    fn promote_judged(
+        &mut self,
+        block_hash: B256,
+        verdicts: &HashMap<B256, bool>,
+    ) -> PromotionOutcome {
         let Some(box_) = self.future_votes.remove(&block_hash) else {
-            return false;
+            return PromotionOutcome { promoted: false, requeue: false };
         };
 
         let mut valid = Vec::with_capacity(box_.vote_messages.len());
+        let mut unjudged = Vec::new();
         for entry in box_.vote_messages {
-            if verify_vote_origin(&entry.envelope) {
-                valid.push(entry);
-            } else {
-                // Drop from the dedup set too, so a later legitimate copy is not
-                // mistaken for a duplicate.
-                self.received_votes.remove(&entry.hash);
-                self.total_votes = self.total_votes.saturating_sub(1);
-                metrics::counter!("votes.rejected.origin_on_promote").increment(1);
+            match verdicts.get(&entry.hash) {
+                Some(true) => valid.push(entry),
+                Some(false) => {
+                    // Drop from the dedup set too, so a later legitimate copy is
+                    // not mistaken for a duplicate.
+                    self.received_votes.remove(&entry.hash);
+                    self.total_votes = self.total_votes.saturating_sub(1);
+                    metrics::counter!("votes.rejected.origin_on_promote").increment(1);
+                }
+                None => unjudged.push(entry),
             }
         }
+
+        let requeue = !unjudged.is_empty();
+        if requeue {
+            self.future_votes.entry(block_hash).or_default().vote_messages.extend(unjudged);
+        }
+
         if valid.is_empty() {
-            return false;
+            return PromotionOutcome { promoted: false, requeue };
         }
 
         let data = valid[0].envelope.data;
@@ -353,7 +409,7 @@ impl VotePool {
         }
         self.cur_votes.entry(block_hash).or_default().vote_messages.extend(valid);
         metrics::gauge!("curVotesPq.local").set(self.cur_votes_pq.heap.len() as f64);
-        true
+        PromotionOutcome { promoted: true, requeue }
     }
 
     /// Drops future votes, furthest-ahead target first, until at least `target`
@@ -808,10 +864,14 @@ fn put_vote_inner(vote: VoteEnvelope) {
         return;
     }
 
-    // Lazy prune and promotion: run once per observed head advance. Replaces
-    // geth-bsc's chain-head subscription by piggybacking on the vote ingest
-    // path, which is the same cadence in practice since votes arrive per block.
+    // Lazy prune, once per observed head advance. Promotion is driven by block
+    // import (`promote_future_votes`); the ingest path keeps calling it as a
+    // backstop for the case where the fork-choice engine is not yet wired, but
+    // *before* taking the write lock, since it does provider and snapshot reads.
     let need_head_work = pending_block_number > LAST_PRUNED_BLOCK.load(Ordering::Relaxed);
+    if need_head_work {
+        promote_future_votes(pending_block_number);
+    }
 
     let mut pool = VOTE_POOL.write().expect("vote pool poisoned");
 
@@ -829,9 +889,7 @@ fn put_vote_inner(vote: VoteEnvelope) {
 
     let votes_for_block = pool.insert(vote, pending_block_number, is_future);
 
-    let mut promoted = Vec::new();
     if need_head_work {
-        promoted = pool.transfer_future_votes(pending_block_number);
         pool.prune(pending_block_number);
         LAST_PRUNED_BLOCK.fetch_max(pending_block_number, Ordering::Relaxed);
     }
@@ -871,8 +929,6 @@ fn put_vote_inner(vote: VoteEnvelope) {
     }
 
     let size = pool.len();
-    let promoted_counts: Vec<(B256, usize)> =
-        promoted.iter().map(|h| (*h, pool.len_for_block(h))).collect();
     drop(pool);
     update_vote_pool_size_metric(size);
 
@@ -881,7 +937,67 @@ fn put_vote_inner(vote: VoteEnvelope) {
         block_stats::on_vote_received(target_hash, votes_for_block);
         maybe_notify_finality(target_hash, votes_for_block);
     }
-    // Promoted targets may have crossed quorum while sitting in the future pool.
+}
+
+/// Promote future votes whose target block we now hold, and judge those that
+/// have aged past the admission window.
+///
+/// Driven by **block import**, not by vote arrival. Promotion needs a *block*,
+/// and the vote that would trigger it may never come: `put_vote` returns at its
+/// dedup check, so a re-relayed copy is not an event, and a node that already
+/// received every vote for `N` before importing `N` has nothing left to arrive
+/// until a vote for `N+1` — which does not exist yet if we are the next
+/// proposer. The votes then sit unpromoted through exactly the window where the
+/// split was supposed to help: attestation assembly reads `cur_votes`, and so
+/// does `get_finalized_number_and_hash`, so a full node loses its one-block
+/// finalized lead the same way a validator loses the attestation.
+///
+/// go-bsc drives this off its `highestVerifiedBlock` event. The equivalent choke
+/// point here is `BscForkChoiceEngine::update_forkchoice`, which every node
+/// reaches on every import path. Raised by will-2012 on #491.
+///
+/// The provider and snapshot lookups run between the two locks, never under the
+/// write lock that every incoming vote contends for.
+pub fn promote_future_votes(head_number: BlockNumber) {
+    // Phase 1 — read lock: what is eligible, and the envelopes to judge.
+    let candidates = {
+        let pool = VOTE_POOL.read().expect("vote pool poisoned");
+        pool.promotion_candidates(head_number)
+    };
+    if candidates.is_empty() {
+        return;
+    }
+
+    // Phase 2 — no lock held: the provider and snapshot reads.
+    let mut resolved: HashMap<B256, HashMap<B256, bool>> = HashMap::new();
+    for candidate in candidates {
+        let target_hash = candidate.data.target_hash;
+        if !candidate.expired
+            && shared::get_canonical_header_by_hash_from_provider(&target_hash).is_none()
+        {
+            continue; // still future
+        }
+        resolved.insert(
+            target_hash,
+            candidate
+                .votes
+                .iter()
+                .map(|entry| (entry.hash, verify_vote_origin(&entry.envelope)))
+                .collect(),
+        );
+    }
+    if resolved.is_empty() {
+        return;
+    }
+
+    // Phase 3 — write lock: apply the verdicts.
+    let promoted_counts: Vec<(B256, usize)> = {
+        let mut pool = VOTE_POOL.write().expect("vote pool poisoned");
+        let promoted = pool.apply_promotion(head_number, &resolved);
+        promoted.into_iter().map(|hash| (hash, pool.len_for_block(&hash))).collect()
+    };
+
+    // A target may have crossed quorum while it sat in the future pool.
     for (hash, count) in promoted_counts {
         if count > 0 {
             maybe_notify_finality(hash, count);
@@ -1558,6 +1674,112 @@ mod tests {
         };
         let pair = justified_pair_of(&vote_data, || Some((0, genesis_hash)));
         assert_eq!(pair, Some((0, genesis_hash)));
+    }
+
+    /// A future vote for `target_number`, distinguished by `unique`.
+    fn future_vote(target_hash: B256, target_number: u64, unique: u8) -> VoteEnvelope {
+        let mut address = VoteAddress::default();
+        address[0] = unique;
+        let mut signature = VoteSignature::default();
+        signature[0] = unique;
+        VoteEnvelope {
+            vote_address: address,
+            signature,
+            data: VoteData {
+                source_number: target_number - 1,
+                source_hash: B256::from([0x01; 32]),
+                target_number,
+                target_hash,
+            },
+        }
+    }
+
+    fn verdicts(target: B256, entries: &[(B256, bool)]) -> HashMap<B256, HashMap<B256, bool>> {
+        let inner: HashMap<B256, bool> = entries.iter().copied().collect();
+        [(target, inner)].into_iter().collect()
+    }
+
+    /// Promotion applies verdicts computed outside the lock: accepted votes reach
+    /// the current pool, rejected ones are dropped along with their dedup entry.
+    #[test]
+    fn apply_promotion_moves_accepted_votes_and_drops_rejected() {
+        let target = B256::from([0x77; 32]);
+        let mut pool = VotePool::new();
+        let accepted = future_vote(target, 100, 1);
+        let rejected = future_vote(target, 100, 2);
+        pool.insert(accepted.clone(), 0, true);
+        pool.insert(rejected.clone(), 0, true);
+
+        let promoted = pool.apply_promotion(
+            100,
+            &verdicts(target, &[(accepted.hash(), true), (rejected.hash(), false)]),
+        );
+
+        assert_eq!(promoted, vec![target]);
+        assert_eq!(pool.fetch_vote_by_block_hash(target).len(), 1, "accepted vote is current");
+        assert!(!pool.future_votes.contains_key(&target), "nothing left in the future pool");
+        assert!(
+            !pool.received_votes.contains(&rejected.hash()),
+            "a rejected vote leaves the dedup set, so a legitimate copy can still arrive",
+        );
+    }
+
+    /// A vote that lands between the verdicts being taken and the write has no
+    /// verdict of its own. It must stay future and keep its target queued, rather
+    /// than being guessed either way — and re-queueing must not let the same
+    /// entry be popped again on this pass, which would never terminate.
+    #[test]
+    fn apply_promotion_requeues_votes_that_arrived_after_the_verdicts() {
+        let target = B256::from([0x88; 32]);
+        let mut pool = VotePool::new();
+        let judged = future_vote(target, 100, 3);
+        let latecomer = future_vote(target, 100, 4);
+        pool.insert(judged.clone(), 0, true);
+        pool.insert(latecomer.clone(), 0, true);
+
+        // Verdicts were taken before `latecomer` arrived.
+        let promoted = pool.apply_promotion(100, &verdicts(target, &[(judged.hash(), true)]));
+
+        assert_eq!(promoted, vec![target]);
+        assert_eq!(pool.fetch_vote_by_block_hash(target).len(), 1, "judged vote promoted");
+        assert_eq!(
+            pool.future_votes.get(&target).map(|vm| vm.vote_messages.len()),
+            Some(1),
+            "the unjudged vote stays future",
+        );
+        assert_eq!(
+            pool.future_votes_pq.heap.len(),
+            1,
+            "and its target stays queued so the next pass judges it",
+        );
+    }
+
+    /// Candidate selection is the read-lock half: everything at or below the head
+    /// is a candidate, anything past `head + 11` is flagged so promotion judges it
+    /// now instead of holding it forever, and targets above the head are left
+    /// alone.
+    #[test]
+    fn promotion_candidates_selects_reached_targets_and_flags_expired() {
+        let stale = B256::from([0xa1; 32]);
+        let current = B256::from([0xa2; 32]);
+        let ahead = B256::from([0xa3; 32]);
+        let mut pool = VotePool::new();
+        pool.insert(future_vote(stale, 50, 5), 0, true);
+        pool.insert(future_vote(current, 100, 6), 0, true);
+        pool.insert(future_vote(ahead, 105, 7), 0, true);
+
+        let mut got: Vec<(u64, bool, usize)> = pool
+            .promotion_candidates(100)
+            .into_iter()
+            .map(|c| (c.data.target_number, c.expired, c.votes.len()))
+            .collect();
+        got.sort();
+
+        assert_eq!(
+            got,
+            vec![(50, true, 1), (100, false, 1)],
+            "target 105 is still ahead of the head; 50 is past head-11 so it expires",
+        );
     }
 
     /// Registers a snapshot provider for tests, reusing whichever one another

--- a/src/consensus/parlia/vote_pool.rs
+++ b/src/consensus/parlia/vote_pool.rs
@@ -81,7 +81,8 @@ struct VoteEntry {
 /// `votes` may be a prefix of the target's bucket when the pass runs out of
 /// budget; the remainder stays future and is judged by a later pass.
 struct PromotionCandidate {
-    data: VoteData,
+    target_number: BlockNumber,
+    target_hash: B256,
     votes: Vec<VoteEntry>,
     /// More than `head - 11` behind, so judge it now and drop what fails rather
     /// than holding it forever.
@@ -93,6 +94,14 @@ struct PromotionCandidate {
     /// Upstream never prunes `futureVotes` by the 256-block bound — this sweep is
     /// what clears them.
     expired: bool,
+}
+
+/// What one promotion pass did, so the per-pass bound is observable in tests.
+struct PromotionApplied {
+    promoted: Vec<B256>,
+    /// Targets popped from the future queue. Never above
+    /// `MAX_PROMOTION_TARGETS_PER_PASS`.
+    examined: usize,
 }
 
 /// Result of moving one target out of the future pool.
@@ -330,26 +339,45 @@ impl VotePool {
     ///
     /// Read-only: nothing moves until `apply_promotion` runs with the verdicts.
     fn promotion_candidates(&self, latest: BlockNumber) -> Vec<PromotionCandidate> {
-        let mut candidates = Vec::new();
-        let mut vote_budget = MAX_PROMOTION_VOTES_PER_PASS;
-
+        // Select the *smallest* eligible targets, because that is the order
+        // `apply_promotion` pops in. An arbitrary subset would leave the write
+        // phase draining the whole queue to reach them, which is the cost the
+        // budget exists to prevent. A bounded max-heap keeps this O(n log k) with
+        // no allocation beyond k, under the read lock and without mutating.
+        let mut smallest: BinaryHeap<(BlockNumber, B256)> = BinaryHeap::new();
         for Reverse(vd) in self.future_votes_pq.heap.iter() {
-            if candidates.len() >= MAX_PROMOTION_TARGETS_PER_PASS || vote_budget == 0 {
-                break;
-            }
             if vd.target_number > latest {
                 continue;
             }
+            let key = (vd.target_number, vd.target_hash);
+            if smallest.len() < MAX_PROMOTION_TARGETS_PER_PASS {
+                smallest.push(key);
+            } else if smallest.peek().is_some_and(|&worst| key < worst) {
+                smallest.pop();
+                smallest.push(key);
+            }
+        }
+
+        let mut keys = smallest.into_sorted_vec();
+        keys.truncate(MAX_PROMOTION_TARGETS_PER_PASS);
+
+        let mut vote_budget = MAX_PROMOTION_VOTES_PER_PASS;
+        let mut candidates = Vec::with_capacity(keys.len());
+        for (target_number, target_hash) in keys {
+            if vote_budget == 0 {
+                break;
+            }
             let votes: Vec<VoteEntry> = self
                 .future_votes
-                .get(&vd.target_hash)
+                .get(&target_hash)
                 .map(|vm| vm.vote_messages.iter().take(vote_budget).cloned().collect())
                 .unwrap_or_default();
             vote_budget -= votes.len();
             candidates.push(PromotionCandidate {
-                expired: vd.target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
+                expired: target_number.saturating_add(UPPER_LIMIT_OF_VOTE_BLOCK_NUMBER) < latest,
                 votes,
-                data: *vd,
+                target_number,
+                target_hash,
             });
         }
 
@@ -363,16 +391,27 @@ impl VotePool {
         &mut self,
         latest: BlockNumber,
         resolved: &HashMap<B256, HashMap<B256, bool>>,
-    ) -> Vec<B256> {
+    ) -> PromotionApplied {
         let mut promoted = Vec::new();
         let mut deferred = Vec::new();
+        let mut examined = 0;
 
-        while let Some(vd) = self.future_votes_pq.peek() {
+        // Bounded by the same budget the candidates were selected under. Without
+        // this the loop drains every entry at or below `latest` and pushes back
+        // whatever it could not resolve — tens of thousands of heap operations
+        // per import, under the write lock every incoming vote contends for, no
+        // matter how few targets were actually judged. Reported by Hashdit Bot
+        // on #491.
+        while examined < MAX_PROMOTION_TARGETS_PER_PASS {
+            let Some(vd) = self.future_votes_pq.peek() else {
+                break;
+            };
             if vd.target_number > latest {
                 break;
             }
             let vd = *vd;
             self.future_votes_pq.pop();
+            examined += 1;
             match resolved.get(&vd.target_hash) {
                 Some(verdicts) => {
                     let outcome = self.promote_judged(vd.target_hash, verdicts);
@@ -393,7 +432,7 @@ impl VotePool {
             self.future_votes_pq.push(vd);
         }
         metrics::gauge!("futureVotesPq.local").set(self.future_votes_pq.heap.len() as f64);
-        promoted
+        PromotionApplied { promoted, examined }
     }
 
     /// Moves one target's future votes into the current pool, dropping those the
@@ -1046,7 +1085,7 @@ pub fn promote_future_votes(head_number: BlockNumber) {
     // Phase 2 — no lock held: the provider and snapshot reads.
     let mut resolved: HashMap<B256, HashMap<B256, bool>> = HashMap::new();
     for candidate in candidates {
-        let target_hash = candidate.data.target_hash;
+        let target_hash = candidate.target_hash;
         if !candidate.expired
             && shared::get_canonical_header_by_hash_from_provider(&target_hash).is_none()
         {
@@ -1068,8 +1107,8 @@ pub fn promote_future_votes(head_number: BlockNumber) {
     // Phase 3 — write lock: apply the verdicts.
     let promoted_counts: Vec<(B256, usize)> = {
         let mut pool = VOTE_POOL.write().expect("vote pool poisoned");
-        let promoted = pool.apply_promotion(head_number, &resolved);
-        promoted.into_iter().map(|hash| (hash, pool.len_for_block(&hash))).collect()
+        let applied = pool.apply_promotion(head_number, &resolved);
+        applied.promoted.into_iter().map(|hash| (hash, pool.len_for_block(&hash))).collect()
     };
 
     // A target may have crossed quorum while it sat in the future pool. Report the
@@ -1790,12 +1829,12 @@ mod tests {
         pool.insert(accepted.clone(), 0, true);
         pool.insert(rejected.clone(), 0, true);
 
-        let promoted = pool.apply_promotion(
+        let applied = pool.apply_promotion(
             100,
             &verdicts(target, &[(accepted.hash(), true), (rejected.hash(), false)]),
         );
 
-        assert_eq!(promoted, vec![target]);
+        assert_eq!(applied.promoted, vec![target]);
         assert_eq!(pool.fetch_vote_by_block_hash(target).len(), 1, "accepted vote is current");
         assert!(!pool.future_votes.contains_key(&target), "nothing left in the future pool");
         assert!(
@@ -1818,9 +1857,9 @@ mod tests {
         pool.insert(latecomer.clone(), 0, true);
 
         // Verdicts were taken before `latecomer` arrived.
-        let promoted = pool.apply_promotion(100, &verdicts(target, &[(judged.hash(), true)]));
+        let applied = pool.apply_promotion(100, &verdicts(target, &[(judged.hash(), true)]));
 
-        assert_eq!(promoted, vec![target]);
+        assert_eq!(applied.promoted, vec![target]);
         assert_eq!(pool.fetch_vote_by_block_hash(target).len(), 1, "judged vote promoted");
         assert_eq!(
             pool.future_votes.get(&target).map(|vm| vm.vote_messages.len()),
@@ -1852,7 +1891,7 @@ mod tests {
         let mut got: Vec<(u64, bool, usize)> = pool
             .promotion_candidates(100)
             .into_iter()
-            .map(|c| (c.data.target_number, c.expired, c.votes.len()))
+            .map(|c| (c.target_number, c.expired, c.votes.len()))
             .collect();
         got.sort();
 
@@ -1886,9 +1925,9 @@ mod tests {
         // Judge exactly what the pass captured; the rest must survive as future.
         let verdicts: HashMap<B256, bool> =
             candidates[0].votes.iter().map(|e| (e.hash, true)).collect();
-        let promoted = pool.apply_promotion(100, &[(target, verdicts)].into_iter().collect());
+        let applied = pool.apply_promotion(100, &[(target, verdicts)].into_iter().collect());
 
-        assert_eq!(promoted, vec![target]);
+        assert_eq!(applied.promoted, vec![target]);
         assert_eq!(
             pool.future_votes.get(&target).map(|vm| vm.vote_messages.len()),
             Some(oversized - MAX_PROMOTION_VOTES_PER_PASS),
@@ -1908,6 +1947,62 @@ mod tests {
         }
 
         assert_eq!(pool.promotion_candidates(100).len(), MAX_PROMOTION_TARGETS_PER_PASS);
+    }
+
+    /// Both halves of a promotion pass must respect the per-pass target bound.
+    /// Selection was already bounded, but application drained every eligible
+    /// entry and pushed back what it could not resolve, so an attacker who filled
+    /// the future pool with distinct target hashes could force tens of thousands
+    /// of heap operations per import under the pool write lock. Reported by
+    /// Hashdit Bot on #491.
+    #[test]
+    fn a_promotion_pass_touches_no_more_than_its_target_budget() {
+        let eligible = MAX_PROMOTION_TARGETS_PER_PASS * 20;
+        let mut pool = VotePool::new();
+        for i in 0..eligible {
+            let mut hash = [0u8; 32];
+            hash[0..4].copy_from_slice(&(i as u32).to_be_bytes());
+            pool.insert(future_vote(B256::from(hash), 100, 1), 0, true);
+        }
+
+        let candidates = pool.promotion_candidates(100);
+        assert_eq!(candidates.len(), MAX_PROMOTION_TARGETS_PER_PASS, "selection is bounded");
+
+        // Nothing resolves — the worst case, where every popped entry has to be
+        // put back. The pass must still stop at the bound.
+        let applied = pool.apply_promotion(100, &HashMap::new());
+        assert_eq!(applied.examined, MAX_PROMOTION_TARGETS_PER_PASS, "application is bounded");
+        assert!(applied.promoted.is_empty());
+        assert_eq!(pool.future_votes_pq.heap.len(), eligible, "deferred entries are kept");
+    }
+
+    /// Selection must pick the *smallest* eligible targets, because that is the
+    /// order application pops in. An arbitrary subset would leave the bounded
+    /// write phase unable to reach what was judged, and nothing would promote.
+    #[test]
+    fn promotion_selects_the_targets_the_write_phase_will_reach() {
+        let mut pool = VotePool::new();
+        for i in 0..(MAX_PROMOTION_TARGETS_PER_PASS * 3) {
+            let mut hash = [0u8; 32];
+            hash[0..4].copy_from_slice(&(i as u32).to_be_bytes());
+            // Spread across heights so ordering is meaningful.
+            pool.insert(future_vote(B256::from(hash), 50 + i as u64, 1), 0, true);
+        }
+
+        let selected: Vec<u64> =
+            pool.promotion_candidates(1000).into_iter().map(|c| c.target_number).collect();
+        let mut expected: Vec<u64> = (50..(50 + MAX_PROMOTION_TARGETS_PER_PASS as u64)).collect();
+        expected.sort();
+        assert_eq!(selected, expected, "the k smallest eligible targets, in pop order");
+
+        // And the write phase reaches exactly those.
+        let resolved: HashMap<B256, HashMap<B256, bool>> = pool
+            .promotion_candidates(1000)
+            .into_iter()
+            .map(|c| (c.target_hash, c.votes.iter().map(|e| (e.hash, true)).collect()))
+            .collect();
+        let applied = pool.apply_promotion(1000, &resolved);
+        assert_eq!(applied.promoted.len(), MAX_PROMOTION_TARGETS_PER_PASS, "all judged promoted");
     }
 
     /// Registers a snapshot provider for tests, reusing whichever one another

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -1371,19 +1371,16 @@ where
             return None;
         }
 
-        let sp = shared::get_snapshot_provider()?;
-
-        match sp.snapshot_by_hash(&header.hash_slow()) {
-            Some(snap) => Some((snap.vote_data.target_number, snap.vote_data.target_hash)),
-            None => {
-                tracing::warn!(
-                    target: "bsc::forkchoice",
-                    header_hash = ?header.hash_slow(),
-                    "Missing snapshot for header when get justified number and hash"
-                );
-                None
-            }
+        let hash = header.hash_slow();
+        let pair = crate::consensus::parlia::vote_pool::justified_pair_for_hash(&hash);
+        if pair.is_none() {
+            tracing::warn!(
+                target: "bsc::forkchoice",
+                header_hash = ?hash,
+                "Missing snapshot for header when get justified number and hash"
+            );
         }
+        pair
     }
 
     /// Gets the finalized number and hash from the header's snapshot.

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -1267,6 +1267,13 @@ where
 
         let new_canonical_head = if need_reorg { incoming_header } else { &current_head };
 
+        // Promote future votes now that a block is in hand. This is the import
+        // event go-bsc gets from `highestVerifiedBlock`: vote arrival cannot
+        // stand in for it, because the vote that would trigger promotion may
+        // already have been received and deduped. It must run before the reads
+        // below, which both source their votes from `cur_votes`.
+        crate::consensus::parlia::vote_pool::promote_future_votes(new_canonical_head.number);
+
         // Get safe block and finalized block with new canonical head
         // ref: https://github.com/bnb-chain/bsc/blob/f70aaa8399ccee429804eecf3fc4c6fd8d9e6cab/eth/api_backend.go#L72
         let (safe_block_number, safe_block_hash) =

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -1267,13 +1267,6 @@ where
 
         let new_canonical_head = if need_reorg { incoming_header } else { &current_head };
 
-        // Promote future votes now that a block is in hand. This is the import
-        // event go-bsc gets from `highestVerifiedBlock`: vote arrival cannot
-        // stand in for it, because the vote that would trigger promotion may
-        // already have been received and deduped. It must run before the reads
-        // below, which both source their votes from `cur_votes`.
-        crate::consensus::parlia::vote_pool::promote_future_votes(new_canonical_head.number);
-
         // Get safe block and finalized block with new canonical head
         // ref: https://github.com/bnb-chain/bsc/blob/f70aaa8399ccee429804eecf3fc4c6fd8d9e6cab/eth/api_backend.go#L72
         let (safe_block_number, safe_block_hash) =
@@ -1304,7 +1297,7 @@ where
             "Fork choice updated"
         );
 
-        match self
+        let outcome = match self
             .engine_handle
             .fork_choice_updated(state, None)
             .await
@@ -1316,7 +1309,28 @@ where
                 _ => Ok(()),
             },
             Err(err) => Err(ParliaConsensusErr::ForkChoiceUpdateError(err.to_string())),
+        };
+
+        // Promote future votes now that the block is canonical. This is the
+        // import event go-bsc gets from `highestVerifiedBlock`, and vote arrival
+        // cannot stand in for it: the vote that would trigger promotion may
+        // already have been received and deduped.
+        //
+        // It has to run *after* the forkchoice update, not before. reth
+        // canonicalizes in `on_forkchoice_updated`, never in `on_new_payload`,
+        // and `ConsistentProvider::header` resolves a hash only against the
+        // canonical in-memory chain or the database. Before the update the block
+        // we just imported is in neither, so every vote for it would be judged
+        // "still future" and skipped — leaving the next proposer reading an empty
+        // `cur_votes`, which is the lag this is meant to remove.
+        //
+        // A failed update means the block did not become canonical, so there is
+        // nothing to promote against.
+        if outcome.is_ok() {
+            crate::consensus::parlia::vote_pool::promote_future_votes(new_canonical_head.number);
         }
+
+        outcome
     }
 
     /// Determines if a chain reorganization is needed based on fork choice rules.

--- a/src/node/network/bsc_protocol/stream.rs
+++ b/src/node/network/bsc_protocol/stream.rs
@@ -670,4 +670,61 @@ mod tests {
         assert_eq!(votes::len(), before + 1, "peer must be served after the window rolls");
     }
 
+
+    /// Only the first vote of a packet is admitted, and that is correct.
+    ///
+    /// This pins a behaviour that looks like a bug and is not. go-bsc does the
+    /// same in `eth/handler_bsc.go`:
+    ///
+    /// ```text
+    ///   // Here we only put the first vote, to avoid ddos attack by sending a
+    ///   // large batch of votes. This won't abandon any valid vote, because one
+    ///   // vote is sent every time referring to func voteBroadcastLoop
+    ///   if len(votes) > 0 { h.votepool.PutVote(votes[0]) }
+    /// ```
+    ///
+    /// It arrived in `3fd5b0c149` ("defend ddos voting attack ... according to
+    /// audit", bnb-chain/bsc#1741, 2023-07-11), which *replaced* a
+    /// `for _, vote := range votes { PutVote(vote) }` loop and, in the same
+    /// commit, introduced the per-peer receive rate limit ported above. The two
+    /// are halves of one fix: bound what a packet can admit, and bound what a
+    /// peer may send.
+    ///
+    /// Nothing is lost, because geth's `voteBroadcastLoop` sends one vote per
+    /// message by design (`eth/handler.go`: "one vote will be sent instantly
+    /// without waiting for other votes for batch sending"). Multi-vote packets
+    /// only arise from the best-effort sync-on-connect dump.
+    ///
+    /// A reviewer working from a stale reading of upstream may try to "fix" this
+    /// into whole-packet ingestion. That would need the per-peer budget to
+    /// already be in place, and it would diverge from current go-bsc. This test
+    /// is here to force that conversation rather than let it happen silently.
+    #[test]
+    fn only_the_first_vote_of_a_packet_is_admitted() {
+        let first = B256::repeat_byte(0xa1);
+        let second = B256::repeat_byte(0xa2);
+        let third = B256::repeat_byte(0xa3);
+
+        let before = votes::len();
+        let reply = dispatch(&frame_of(VotesPacket(vec![
+            vote(30_001_000, first),
+            vote(30_001_001, second),
+            vote(30_001_002, third),
+        ])));
+
+        assert!(reply.is_none(), "a votes frame needs no reply");
+        assert_eq!(votes::len(), before + 1, "exactly one vote from the packet is admitted");
+        assert_eq!(
+            votes::fetch_any_vote_by_block_hash(first).len(),
+            1,
+            "the first vote is the one admitted",
+        );
+        for (label, hash) in [("second", second), ("third", third)] {
+            assert!(
+                votes::fetch_any_vote_by_block_hash(hash).is_empty(),
+                "the {label} vote must be discarded",
+            );
+        }
+    }
+
 }

--- a/src/node/vote_producer.rs
+++ b/src/node/vote_producer.rs
@@ -298,7 +298,7 @@ mod tests {
         // Journal writable: the vote reaches the pool.
         let ok = head_at(40_000_002);
         maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &ok);
-        assert_eq!(votes::fetch_vote_by_block_hash(ok.hash_slow()).len(), 1);
+        assert_eq!(votes::fetch_any_vote_by_block_hash(ok.hash_slow()).len(), 1);
 
         // Journal directory replaced by a regular file: persist_vote fails.
         std::fs::remove_dir_all(&dir).unwrap();
@@ -306,7 +306,7 @@ mod tests {
         let bad = head_at(40_000_003);
         maybe_produce_and_broadcast_for_head(spec.clone(), &sp, &bad);
         assert!(
-            votes::fetch_vote_by_block_hash(bad.hash_slow()).is_empty(),
+            votes::fetch_any_vote_by_block_hash(bad.hash_slow()).is_empty(),
             "unjournalled vote must not reach put_vote or broadcast_votes",
         );
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -410,6 +410,16 @@ where
     Ok(())
 }
 
+/// Whether the global header provider has been registered yet.
+///
+/// Distinguishes "no provider" from "provider has no such header". Callers that
+/// classify by block presence need that distinction: before the provider is
+/// registered every lookup misses, which is not the same as the block being
+/// absent from the chain.
+pub fn has_header_by_hash_provider() -> bool {
+    HEADER_BY_HASH_PROVIDER.get().is_some()
+}
+
 /// Get header by hash from the global header provider
 /// Directly calls the stored HeaderProvider::header() function
 pub fn get_canonical_header_by_hash_from_provider(block_hash: &B256) -> Option<Header> {


### PR DESCRIPTION
Final PR of the vote-ingestion series, after #486 (authentication + inbound cost bounds) and #489 (admission window). #492 is folded in here.

## Summary

Ports go-bsc's `curVotes`/`futureVotes` split, which is the prerequisite for the two remaining admission checks:

- **Validator-set membership at admission.** Membership resolves against the *target's parent snapshot*, so a vote for a block we do not hold cannot be checked at all. Upstream's answer is to hold such votes separately and check them at promotion. Without that, checking at ingest would discard every vote for a not-yet-imported block — routine, since votes are broadcast the moment a block is produced.
- **Per-target vote caps.** The two limits exist *because* of the split: a future target's validator set is unresolvable, so non-validator votes cannot be filtered yet.

Ingest classifies by whether the target block is known, applies the matching cap, and origin-checks current votes. `transfer_future_votes` promotes in upstream's two phases — unconditionally past `latest - 11`, then by availability — running the origin check at promotion and removing promoted-but-invalid votes from the dedup set so a later legitimate copy is not mistaken for a duplicate. Pruning covers the future queue too.

`justified_pair_for_hash` is extracted so the pool and `BscForkChoiceEngine` derive the justified pair one way instead of two.

## Departures from a literal port

**Canonical vs verified presence.** go-bsc tests *verified* presence; reth exposes no non-canonical header lookup, so a valid-but-not-yet-canonical target classifies as future. That defers its origin check rather than skipping it — conservative.

**Promotion trigger.** No chain-head subscription exists in reth's pool, so promotion piggybacks the vote-ingest path exactly as `prune` already does. Same cadence in practice.

**Fail-open before the header provider registers.** `build_network` calls `ctx.start_network` while the provider is registered later in `build_consensus`, so the node accepts peers before classification is possible. Those votes are held as *future*: uncapped, invisible to finality counting, and fully origin-checked at promotion. An earlier revision treated them as current, which was wrong — see below.

## Review findings addressed

Three Hashdit reports, all confirmed rather than waved off, and two of them corrected reasoning I had defended earlier in the series.

**Unauthenticated future votes could exhaust the per-target cap.** A future vote is signature-checked and nothing more, and a signature proves the signer holds the key in the envelope — not that the key belongs to a validator. Any peer could mint keys, self-sign enough envelopes to fill a bucket, and have genuine validator votes refused permanently, since votes are broadcast once. This falsified an argument I had made repeatedly: that caps are safe once signature verification is in place. True for current votes, which are origin-checked; false for future votes, where a signature carries no authority.

Fixed in two steps: the cap was dropped for future votes, then restored *conditionally*. `future_vote_sender_is_validator` judges the sender against the snapshot at our own head — sound because the validator set changes only on epoch boundaries and the admission window caps a future target at `head + 11`. Senders absent from that set are rejected before a bucket is created; the cap applies only to senders we authenticated, and is skipped when the answer is genuinely undecidable (no snapshot, or an epoch boundary inside `(head, target]` — 11 heights in every 200).

**Fail-open startup admitted unauthenticated votes as current.** Correct and reachable, as above. One half of the claim did not hold and is noted for the record: `maybe_notify_finality` returns early without `BEST_BLOCK_NUMBER_PROVIDER`, which is set in the same function as the header provider, so fake *finality* was not reachable in that window. The cap-exclusion half was, which is enough.

**Test key material.** `random_test_signer` now generates a fresh keypair, so no key-shaped literal remains anywhere in the source. The obvious version would have been flaky: `SecretKey::from_bytes` validates against the BLS12-381 group order, so unmasked random bytes are rejected roughly four times in five. The scalar's top nibble is cleared to keep it provably below the order.

## Also fixed here

**Oversize pruning reclaimed nothing.** `MAX_VOTES_IN_POOL` was a trigger, not a ceiling: it pruned relative to the *incoming* vote's target, so a flood aimed at recent heights freed nothing. Worse, `target_number` is attacker-supplied and was unbounded before #489, so a single vote claiming a target near `u64::MAX` produced an astronomically large prune height and evicted the entire pool. No panic accompanied it — `[profile.release]` sets no `overflow-checks`, so the addition inside `prune` wraps rather than trapping.

Now pruned relative to our head, with `shed_future_votes` as a fallback that releases future votes furthest-ahead first. Current votes cannot cause an overflow: they are origin-checked and capped per target, so the 267-block window bounds them at roughly `267 * 21`.

`extreme_target_number_cannot_wipe_the_pool` covers it, verified discriminating by mutation — restoring the attacker-supplied derivation fails it with the ordinary-height vote gone.

**Saturating arithmetic**, in `prune` as well as the window predicate and the future-prune loop. Go wraps silently on `uint64` overflow, so a faithful port of arithmetic over attacker-supplied heights carries a defect into Rust that is invisible in the original. Three sites in this series needed it — worth treating as a review heuristic for anything else ported from Parlia.

## First-vote-only packet admission *(folded in from #492)*

Admitting only the first vote of a `VotesPacket` looks like a defect and is not. go-bsc does the same in `eth/handler_bsc.go`, and has since `3fd5b0c149` (bnb-chain/bsc#1741) — a commit that *replaced* a `for _, vote := range votes { PutVote(vote) }` loop and, in the same change, added the per-peer receive limit now in #486. A conformance review comparing against that removed loop concludes reth is diverging when it is matching.

Neither client tests this — go-bsc's `testRecvVotes` sends a single vote and passes identically under either behaviour — so the test pins it with the upstream provenance attached. Verified discriminating by mutation: whole-packet admission fails it `3 != 1`.

## Validation

- `cargo test --all -- --test-threads=1` — 545 passed, 0 failed
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --tests --all-features` — clean
- **10-node devnet** (4 reth / 6 geth), rolling restart, 214 blocks: origin rejections **0/0/0/0**, cap rejections **0/0/0/0**, only 1–2 transient "unverifiable" during startup, attestations climbing 34/31/22/31 → 50/54/48/47, `finalized` tracking `head-1` throughout.

The reading that matters is the attestation growth: it is the direct evidence that classification puts votes in the *current* pool rather than stranding them in future, which was the main risk of this change.

Caveat: that devnet run predates the conditional-cap rework, the startup-routing fix and two rebases. The code paths are unchanged but the measured binary does not correspond to this SHA, so it is worth a re-run before merge if the evidence needs to match the commit.

## Series status

With #486 and #489 merged and this PR, the vote-ingestion workstream from the BEP conformance sweep is complete. Two items were closed as non-gaps during the work rather than implemented: blob retention (both clients target 19.2 days; reth's implementation lives in `bnb-chain/reth`, which is why grepping reth-bsc found nothing) and first-vote-only admission, above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
