### PR TITLE
feat(miner): persist BidBlock revokes across restarts

### DIFF
--- a/src/node/engine.rs
+++ b/src/node/engine.rs
@@ -106,6 +106,32 @@ where
         pool: Pool,
         _evm_config: Evm,
     ) -> eyre::Result<PayloadBuilderHandle<BscPayloadTypes>> {
+        // BidBlock revoke lockouts (validator-local MEV policy) journal to a single file under
+        // the datadir rather than chaindata — go-bsc parity (`BidBlockRevokesJournal`, default
+        // `bidblockrevokes.json`). Like go's config field, `BSC_BID_BLOCK_REVOKES_JOURNAL`
+        // overrides the location (a relative path is resolved under the datadir) and an empty
+        // value disables persistence entirely. Registered here, during component build, so it is
+        // in place before any consumer lazily initializes the global manager.
+        use reth_chainspec::EthChainSpec as _;
+        let datadir =
+            ctx.config().datadir.clone().resolve_datadir(ctx.chain_spec().chain());
+        let revokes_journal = match std::env::var("BSC_BID_BLOCK_REVOKES_JOURNAL") {
+            Ok(path) if path.is_empty() => None, // explicit opt-out: purely in-memory
+            Ok(path) => {
+                let path = std::path::PathBuf::from(path);
+                Some(if path.is_absolute() { path } else { datadir.data_dir().join(path) })
+            }
+            Err(_) => Some(datadir.data_dir().join("bidblockrevokes.json")),
+        };
+        if let Some(path) = revokes_journal {
+            if crate::shared::set_bid_block_revokes_journal(path).is_err() {
+                tracing::warn!(
+                    target: "payload_builder",
+                    "BidBlock revoke journal path already registered; keeping the existing one"
+                );
+            }
+        }
+
         let (tx, mut rx) = mpsc::unbounded_channel();
         // Load mining configuration from environment, allow override via CLI if set globally
         let mining_config =

--- a/src/node/miner/bid_block_permission.rs
+++ b/src/node/miner/bid_block_permission.rs
@@ -1,16 +1,43 @@
 //! BidBlock builder permission management (BEP-675).
 //!
-//! Tracks per-builder `SendBidBlock` revokes in memory. A builder is revoked for a lockout window
+//! Tracks per-builder `SendBidBlock` revokes. A builder is revoked for a lockout window
 //! (e.g. after submitting an invalid BidBlock, or by an operator), and the revoke expires lazily
 //! once the window passes. Ported from bnb-chain/bsc `miner/bid_block_permission.go` +
 //! `core/types/bid_block_permission.go`.
+//!
+//! # Persistence
+//!
+//! Revokes survive restarts through a JSON journal — a single standalone file under the node's
+//! datadir (`bidblockrevokes.json`), NOT the chain database: the lockouts are validator-local
+//! MEV policy, not chain state, and a plain file is inspectable and trivially resettable by
+//! deleting it. JSON over a binary codec for the same operability reason; the write pattern is a
+//! whole-map snapshot atomically replacing the file (temp file + rename), so no incremental
+//! format is needed and a crash mid-write leaves the previous journal intact.
+//!
+//! Persistence is asynchronous and best-effort: mutations snapshot the map and hand it to a
+//! background writer, so the mining path never waits on disk. Load happens once at startup and
+//! drops revokes whose window elapsed while the node was down. An empty journal path keeps the
+//! manager purely in-memory (the pre-persistence behavior).
+//!
+//! The journal is node-local and never exchanged between clients, so the value encoding is
+//! Rust-native (unix seconds for `revokedAt`, seconds for `duration`) while the JSON key names
+//! are pinned to go-bsc's tags — a key or meaning change needs a version bump, and an unknown
+//! version is refused on load (starting empty only costs the remaining lockout windows, which
+//! self-expire; misreading a future format could revoke or release the wrong builders).
 
 use alloy_primitives::{Address, B256};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
+use tracing::{info, warn};
 
 /// `Reason` value used when an operator manually revokes a builder via [`set_allowed`].
 /// Automatic revokes carry the underlying error or policy message as the reason directly.
@@ -40,14 +67,34 @@ pub struct BidBlockPermissionStatus {
     pub reset_at: u64,
 }
 
+/// Version of the on-disk revoke journal. Bump on any change to the JSON keys or their meaning;
+/// an older build refuses a newer journal (and starts empty) rather than misreading it.
+const BID_BLOCK_REVOKE_JOURNAL_VERSION: u32 = 1;
+
 /// One active revoke event.
-#[derive(Debug, Clone)]
+///
+/// The serde renames pin the journal's JSON keys (go-bsc's tags). They MUST stay stable across
+/// releases so restarts across upgrades keep working — change them only together with a
+/// [`BID_BLOCK_REVOKE_JOURNAL_VERSION`] bump.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct BidBlockRevokeRecord {
+    #[serde(rename = "revokedAt")]
     revoked_at: u64,
+    #[serde(rename = "duration")]
     duration_secs: u64,
     reason: String,
+    #[serde(rename = "blockHash")]
     block_hash: B256,
+    #[serde(rename = "blockNum")]
     block_num: u64,
+}
+
+/// On-disk envelope: a version stamp plus the whole revoke map. The journal is always written as
+/// one complete snapshot, never appended to.
+#[derive(Debug, Serialize, Deserialize)]
+struct BidBlockRevokeJournal {
+    version: u32,
+    revokes: HashMap<Address, BidBlockRevokeRecord>,
 }
 
 impl BidBlockRevokeRecord {
@@ -57,12 +104,83 @@ impl BidBlockRevokeRecord {
     }
 }
 
-/// Tracks per-builder `SendBidBlock` revokes. Revokes are kept in memory and expire lazily after
-/// their lockout window.
+/// Shared state of the background journal writer. Lives in an [`Arc`] so each fire-and-forget
+/// writer thread can own a handle without borrowing the manager.
+struct JournalState {
+    /// Journal file location (`<datadir>/bidblockrevokes.json`).
+    path: PathBuf,
+    /// Sequence stamped on each snapshot; bumped under the manager's write lock, so snapshot
+    /// content and sequence order always agree.
+    persist_seq: AtomicU64,
+    /// Highest sequence that entered the writer. The mutex serializes writers; the value drops
+    /// stale snapshots (see [`JournalState::persist`]).
+    persisted_seq: Mutex<u64>,
+}
+
+impl JournalState {
+    /// Writes `snapshot` to the journal file unless a newer snapshot has already been handled.
+    /// Errors are logged and swallowed: persistence is best-effort and must not affect the caller.
+    ///
+    /// The write is atomic (temp file + rename), so a crash mid-write leaves the previous journal
+    /// intact rather than a truncated one.
+    ///
+    /// `persisted_seq` is advanced BEFORE the write and regardless of its outcome. This makes the
+    /// sequence that actually reaches the disk strictly monotonic: once a newer snapshot has
+    /// entered here, every older one is dropped even if the newer write failed. Otherwise a newer
+    /// write failing could let an older snapshot win the disk afterwards and resurrect stale
+    /// state (e.g. a revoke overwriting a later manual clear). Losing the newest write on failure
+    /// is acceptable (best-effort); an older snapshot overwriting a newer one is not.
+    fn persist(&self, seq: u64, snapshot: HashMap<Address, BidBlockRevokeRecord>) {
+        let mut persisted = self.persisted_seq.lock();
+        if seq <= *persisted {
+            return; // an equal-or-newer snapshot has already been handled; this one is stale
+        }
+        *persisted = seq;
+        let blob = match serde_json::to_vec(&BidBlockRevokeJournal {
+            version: BID_BLOCK_REVOKE_JOURNAL_VERSION,
+            revokes: snapshot,
+        }) {
+            Ok(blob) => blob,
+            Err(err) => {
+                warn!(target: "miner::bid_block", %err, "Failed to encode BidBlock revokes for persistence");
+                return;
+            }
+        };
+        let mut tmp = self.path.clone().into_os_string();
+        tmp.push(".tmp");
+        let tmp = PathBuf::from(tmp);
+        if let Err(err) = write_owner_only(&tmp, &blob) {
+            warn!(target: "miner::bid_block", path = %tmp.display(), %err, "Failed to write BidBlock revoke journal");
+            return;
+        }
+        if let Err(err) = std::fs::rename(&tmp, &self.path) {
+            warn!(target: "miner::bid_block", path = %self.path.display(), %err, "Failed to replace BidBlock revoke journal");
+        }
+    }
+}
+
+/// Writes `blob` to `path`, creating/truncating it with owner-only permissions (0600) on unix —
+/// the journal names misbehaving builders, which is operator-private policy data.
+fn write_owner_only(path: &PathBuf, blob: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)?.write_all(blob)
+}
+
+/// Tracks per-builder `SendBidBlock` revokes. Revokes expire lazily after their lockout window
+/// and are mirrored to the journal file (when one is configured) so they survive restarts.
 pub struct BidBlockPermissionManager {
     revoked: RwLock<HashMap<Address, BidBlockRevokeRecord>>,
     /// Clock returning the current time in unix seconds; injectable for tests.
     clock: Box<dyn Fn() -> u64 + Send + Sync>,
+    /// Journal writer state; `None` keeps the manager purely in-memory (go-bsc's empty path).
+    journal: Option<Arc<JournalState>>,
 }
 
 impl Default for BidBlockPermissionManager {
@@ -72,16 +190,96 @@ impl Default for BidBlockPermissionManager {
 }
 
 impl BidBlockPermissionManager {
-    /// A fresh manager with no builders revoked, using the system clock.
+    /// A fresh manager with no builders revoked, using the system clock. Purely in-memory: no
+    /// journal is read or written.
     pub fn new() -> Self {
-        Self::with_clock(Box::new(|| {
-            SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
-        }))
+        Self::with_clock(Self::system_clock())
+    }
+
+    /// A manager persisting revokes to the journal file at `path`, restoring any still-active
+    /// revokes it holds. The load is synchronous, once, off the hot path; any load error leaves
+    /// the manager empty — same as a fresh node.
+    pub fn with_journal(path: PathBuf) -> Self {
+        let mut mgr = Self::with_clock(Self::system_clock());
+        mgr.journal = Some(Arc::new(JournalState {
+            path,
+            persist_seq: AtomicU64::new(0),
+            persisted_seq: Mutex::new(0),
+        }));
+        mgr.load();
+        mgr
     }
 
     /// A manager with a custom clock (used in tests to control expiry).
     pub fn with_clock(clock: Box<dyn Fn() -> u64 + Send + Sync>) -> Self {
-        Self { revoked: RwLock::new(HashMap::new()), clock }
+        Self { revoked: RwLock::new(HashMap::new()), clock, journal: None }
+    }
+
+    fn system_clock() -> Box<dyn Fn() -> u64 + Send + Sync> {
+        Box::new(|| {
+            SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
+        })
+    }
+
+    /// Restores persisted revokes at startup, dropping any whose window has already elapsed
+    /// (including time spent offline).
+    fn load(&self) {
+        let Some(journal) = &self.journal else { return };
+        let blob = match std::fs::read(&journal.path) {
+            Ok(blob) if !blob.is_empty() => blob,
+            _ => return, // no journal yet (or unreadable): start empty
+        };
+        let decoded: BidBlockRevokeJournal = match serde_json::from_slice(&blob) {
+            Ok(decoded) => decoded,
+            Err(err) => {
+                warn!(
+                    target: "miner::bid_block",
+                    path = %journal.path.display(), %err,
+                    "Failed to decode persisted BidBlock revokes, starting empty"
+                );
+                return;
+            }
+        };
+        if decoded.version != BID_BLOCK_REVOKE_JOURNAL_VERSION {
+            warn!(
+                target: "miner::bid_block",
+                path = %journal.path.display(),
+                version = decoded.version,
+                supported = BID_BLOCK_REVOKE_JOURNAL_VERSION,
+                "Unsupported BidBlock revoke journal version, starting empty"
+            );
+            return;
+        }
+        let now = (self.clock)();
+        let mut revoked = self.revoked.write();
+        for (builder, rec) in decoded.revokes {
+            if rec.is_active(now) {
+                revoked.insert(builder, rec);
+            }
+        }
+        if !revoked.is_empty() {
+            info!(
+                target: "miner::bid_block",
+                path = %journal.path.display(),
+                count = revoked.len(),
+                "Restored BidBlock revokes from journal"
+            );
+        }
+    }
+
+    /// Snapshots the current map and kicks off an asynchronous write. MUST be called with the
+    /// `revoked` write lock held (the caller passes the guarded map) so the snapshot and its
+    /// sequence agree; the caller returns immediately without waiting for the disk write.
+    ///
+    /// Fire-and-forget: mutations are rare (only on bad bids or operator action), so spawning a
+    /// thread per change is cheap. [`JournalState::persist`] serializes writers and drops stale
+    /// snapshots via the sequence guard.
+    fn mark_dirty_locked(&self, revoked: &HashMap<Address, BidBlockRevokeRecord>) {
+        let Some(journal) = &self.journal else { return };
+        let seq = journal.persist_seq.fetch_add(1, Ordering::SeqCst) + 1;
+        let snapshot = revoked.clone();
+        let journal = journal.clone();
+        std::thread::spawn(move || journal.persist(seq, snapshot));
     }
 
     /// Whether `builder` may currently use `SendBidBlock`.
@@ -105,7 +303,8 @@ impl BidBlockPermissionManager {
     ) {
         let duration_secs =
             if duration_secs == 0 { BID_BLOCK_REVOKE_DURATION_SECS } else { duration_secs };
-        self.revoked.write().insert(
+        let mut revoked = self.revoked.write();
+        revoked.insert(
             builder,
             BidBlockRevokeRecord {
                 revoked_at: (self.clock)(),
@@ -115,6 +314,7 @@ impl BidBlockPermissionManager {
                 block_num,
             },
         );
+        self.mark_dirty_locked(&revoked);
     }
 
     /// Current permission snapshot for `builder`.
@@ -143,6 +343,8 @@ impl BidBlockPermissionManager {
         let mut revoked = self.revoked.write();
         if allowed {
             revoked.remove(&builder);
+            // A manual clear is mirrored to disk too, so it is not resurrected on restart.
+            self.mark_dirty_locked(&revoked);
             return;
         }
         revoked.insert(
@@ -155,6 +357,7 @@ impl BidBlockPermissionManager {
                 block_num: 0,
             },
         );
+        self.mark_dirty_locked(&revoked);
     }
 
     /// Return the active revoke record for `builder`, if one exists and hasn't expired.
@@ -362,6 +565,228 @@ mod tests {
                 revoked_at: t,
                 reset_at: t + DAY,
             }
+        );
+    }
+
+    // --- Journal persistence (go-bsc PR #3796 parity) ---------------------------------------
+
+    /// Fresh journal path in a per-test temp directory (the go `testJournalPath` counterpart).
+    fn test_journal_path(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!("bid-block-revokes-{}-{name}", std::process::id()));
+        // A stale directory from an aborted earlier run must not leak state into this one.
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create test journal dir");
+        dir.join("bidblockrevokes.json")
+    }
+
+    /// Polls until the journal decodes and satisfies `pred` (the go `waitForBidBlockPersist`
+    /// counterpart — persistence is async and best-effort, so tests wait for the write).
+    fn wait_for_journal(
+        path: &std::path::Path,
+        pred: impl Fn(&BidBlockRevokeJournal) -> bool,
+    ) -> BidBlockRevokeJournal {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if let Ok(blob) = std::fs::read(path) {
+                if let Ok(journal) = serde_json::from_slice::<BidBlockRevokeJournal>(&blob) {
+                    if pred(&journal) {
+                        return journal;
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        panic!("journal at {} did not reach the expected state in time", path.display());
+    }
+
+    fn unix_now() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_secs()
+    }
+
+    fn seed_journal(path: &std::path::Path, journal: &BidBlockRevokeJournal) {
+        std::fs::write(path, serde_json::to_vec(journal).expect("marshal seed"))
+            .expect("seed journal");
+    }
+
+    /// Mirrors go `TestBidBlockPermission_SurvivesRestart`: a revoke persisted by one manager is
+    /// restored — with an identical status snapshot — by a brand-new manager over the same file.
+    #[test]
+    fn revoke_survives_restart() {
+        let path = test_journal_path("survives-restart");
+        let hash = B256::repeat_byte(0xab);
+
+        let m1 = BidBlockPermissionManager::with_journal(path.clone());
+        m1.revoke(BUILDER, INSERT_CHAIN_REASON, hash, 100);
+        wait_for_journal(&path, |j| j.revokes.contains_key(&BUILDER));
+        let want = m1.get_status(BUILDER);
+
+        // Simulate a restart: a brand-new manager over the same journal.
+        let m2 = BidBlockPermissionManager::with_journal(path);
+        assert!(!m2.is_allowed(BUILDER), "revoke must survive a restart within its window");
+        let got = m2.get_status(BUILDER);
+        assert_eq!(got.reset_at, want.reset_at, "resetAt changed across restart");
+        assert_eq!(got, want, "restored record differs from the persisted one");
+    }
+
+    /// Mirrors go `TestBidBlockPermission_ExpiredNotRestored`: a revoke whose window elapsed
+    /// while the process was down is dropped on load, while a still-active one is restored. The
+    /// journal is seeded directly so the elapsed time is deterministic.
+    #[test]
+    fn expired_revoke_not_restored() {
+        let path = test_journal_path("expired-not-restored");
+        let active = BUILDER_A;
+        let expired = BUILDER_B;
+
+        let now = unix_now();
+        let record = |revoked_at: u64, reason: &str| BidBlockRevokeRecord {
+            revoked_at,
+            duration_secs: BID_BLOCK_REVOKE_DURATION_SECS,
+            reason: reason.to_string(),
+            block_hash: B256::ZERO,
+            block_num: 0,
+        };
+        seed_journal(
+            &path,
+            &BidBlockRevokeJournal {
+                version: BID_BLOCK_REVOKE_JOURNAL_VERSION,
+                revokes: HashMap::from([
+                    (active, record(now - 60 * 60, "active")),
+                    (expired, record(now - 25 * 60 * 60, "expired")),
+                ]),
+            },
+        );
+
+        let mgr = BidBlockPermissionManager::with_journal(path);
+        assert!(!mgr.is_allowed(active), "still-active revoke must be restored");
+        assert!(mgr.is_allowed(expired), "revoke expired during downtime must not be restored");
+    }
+
+    /// Mirrors go `TestBidBlockPermission_LoadToleratesBadState`: a missing or corrupt journal
+    /// leaves the manager empty instead of panicking.
+    #[test]
+    fn load_tolerates_bad_state() {
+        // Corrupt journal: start empty, no panic.
+        let path = test_journal_path("load-tolerates-bad-state");
+        std::fs::write(&path, b"not json").expect("seed journal");
+        let mgr = BidBlockPermissionManager::with_journal(path);
+        assert!(mgr.is_allowed(BUILDER), "a corrupt journal must yield an empty manager");
+
+        // Missing file (fresh datadir): start empty, no panic.
+        let mgr = BidBlockPermissionManager::with_journal(test_journal_path("missing-journal"));
+        assert!(mgr.is_allowed(BUILDER), "a missing journal must yield an empty manager");
+    }
+
+    /// Mirrors go `TestBidBlockPermission_RejectsUnknownVersion`: a journal written by a future
+    /// build must be refused outright rather than decoded with this build's interpretation of the
+    /// fields. Starting empty only costs the remaining lockout windows, which self-expire;
+    /// misreading a changed field could revoke or release the wrong builders.
+    #[test]
+    fn rejects_unknown_journal_version() {
+        let path = test_journal_path("rejects-unknown-version");
+        seed_journal(
+            &path,
+            &BidBlockRevokeJournal {
+                version: BID_BLOCK_REVOKE_JOURNAL_VERSION + 1,
+                revokes: HashMap::from([(
+                    BUILDER,
+                    BidBlockRevokeRecord {
+                        revoked_at: unix_now(),
+                        duration_secs: BID_BLOCK_REVOKE_DURATION_SECS,
+                        reason: INSERT_CHAIN_REASON.to_string(),
+                        block_hash: B256::ZERO,
+                        block_num: 1,
+                    },
+                )]),
+            },
+        );
+
+        let mgr = BidBlockPermissionManager::with_journal(path);
+        assert!(mgr.is_allowed(BUILDER), "an unknown journal version must be refused wholesale");
+    }
+
+    /// Mirrors go `TestBidBlockPermission_JournalKeysAreStable`: the on-disk JSON keys are a
+    /// compatibility surface — a key change needs a version bump.
+    #[test]
+    fn journal_keys_are_stable() {
+        let path = test_journal_path("journal-keys-stable");
+        let mgr = BidBlockPermissionManager::with_journal(path.clone());
+        mgr.revoke(BUILDER, INSERT_CHAIN_REASON, B256::repeat_byte(0xab), 100);
+        wait_for_journal(&path, |j| j.revokes.contains_key(&BUILDER));
+
+        let blob = String::from_utf8(std::fs::read(&path).expect("read journal")).unwrap();
+        for key in
+            ["\"version\"", "\"revokes\"", "\"revokedAt\"", "\"duration\"", "\"reason\"", "\"blockHash\"", "\"blockNum\""]
+        {
+            assert!(
+                blob.contains(key),
+                "journal is missing the stable key {key}; a tag change needs a version bump\ngot: {blob}"
+            );
+        }
+    }
+
+    /// Mirrors go `TestBidBlockPermission_FailedNewerBlocksOlder`: once a newer snapshot has
+    /// entered the writer — even if its write fails — an older snapshot must never overwrite it
+    /// and resurrect stale state. `persist` is called directly to control ordering
+    /// deterministically; the write failure is injected by occupying the journal path with a
+    /// directory, which makes the atomic rename fail.
+    #[test]
+    fn failed_newer_write_blocks_older_snapshot() {
+        let path = test_journal_path("failed-newer-blocks-older");
+        let mgr = BidBlockPermissionManager::with_journal(path.clone());
+        let journal = mgr.journal.as_ref().expect("journal-backed manager").clone();
+
+        let revoked = HashMap::from([(
+            BUILDER,
+            BidBlockRevokeRecord {
+                revoked_at: unix_now(),
+                duration_secs: BID_BLOCK_REVOKE_DURATION_SECS,
+                reason: "revoke".to_string(),
+                block_hash: B256::ZERO,
+                block_num: 0,
+            },
+        )]);
+        let cleared = HashMap::new(); // the set_allowed(true) result
+
+        // The newer snapshot (seq 2, cleared) is attempted first but its write fails: the
+        // journal path is occupied by a directory.
+        std::fs::create_dir(&path).expect("occupy journal path");
+        journal.persist(2, cleared);
+        assert_eq!(
+            *journal.persisted_seq.lock(),
+            2,
+            "persisted_seq must advance even when the write fails"
+        );
+
+        // The older snapshot (seq 1, revoked) is now handled with writes working again — it
+        // must be dropped, not overwrite the newer intent.
+        std::fs::remove_dir(&path).expect("free journal path");
+        journal.persist(1, revoked);
+        assert!(
+            !path.exists(),
+            "older snapshot must not overwrite a newer (failed) one; journal should be absent"
+        );
+    }
+
+    /// Mirrors go `TestBidBlockPermission_SetAllowedPersists`: a manual clear is also mirrored
+    /// to disk, so it is not resurrected on restart.
+    #[test]
+    fn set_allowed_clear_persists() {
+        let path = test_journal_path("set-allowed-persists");
+
+        let m1 = BidBlockPermissionManager::with_journal(path.clone());
+        m1.revoke(BUILDER, INSERT_CHAIN_REASON, B256::repeat_byte(0xab), 100);
+        wait_for_journal(&path, |j| j.revokes.contains_key(&BUILDER));
+        m1.set_allowed(BUILDER, true); // manual clear must persist too
+        wait_for_journal(&path, |j| !j.revokes.contains_key(&BUILDER));
+
+        let m2 = BidBlockPermissionManager::with_journal(path);
+        assert!(
+            m2.is_allowed(BUILDER),
+            "a manually cleared builder must not be resurrected on restart"
         );
     }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -118,6 +118,12 @@ static BID_BLOCK_PERMISSION_MANAGER: OnceLock<
     Arc<crate::node::miner::bid_block_permission::BidBlockPermissionManager>,
 > = OnceLock::new();
 
+/// Journal file the BidBlock permission manager persists revokes to
+/// (`<datadir>/bidblockrevokes.json`). Set during component build (payload service builder) —
+/// before any consumer runs — so the lazily-initialized manager picks it up; a manager already
+/// initialized without it stays purely in-memory (the pre-persistence behavior).
+static BID_BLOCK_REVOKES_JOURNAL: OnceLock<std::path::PathBuf> = OnceLock::new();
+
 /// Global intake queue for admitted BEP-675 BidBlocks. `mev_sendBidBlock` pushes a decoded block
 /// here after admission; the miner pops it to pre-seal verify, execute, and select against the
 /// local block (mirrors the legacy [`BID_PACKAGE_QUEUE`] SendBid intake).
@@ -511,12 +517,26 @@ pub fn bid_package_queue_len() -> usize {
     BID_PACKAGE_QUEUE.get().map(|queue| queue.lock().len()).unwrap_or(0)
 }
 
-/// Get the global BidBlock permission manager, initializing it lazily on first access.
+/// Set the journal file the BidBlock permission manager persists revokes to. Must be called
+/// before the first [`get_bid_block_permission_manager`] call to take effect. Returns `Err` with
+/// the rejected path if a journal path was already set.
+pub fn set_bid_block_revokes_journal(path: std::path::PathBuf) -> Result<(), std::path::PathBuf> {
+    BID_BLOCK_REVOKES_JOURNAL.set(path)
+}
+
+/// Get the global BidBlock permission manager, initializing it lazily on first access. When a
+/// journal path was registered via [`set_bid_block_revokes_journal`], the first access restores
+/// persisted revokes from it and later mutations are mirrored back; otherwise the manager is
+/// purely in-memory.
 pub fn get_bid_block_permission_manager(
 ) -> Arc<crate::node::miner::bid_block_permission::BidBlockPermissionManager> {
     BID_BLOCK_PERMISSION_MANAGER
         .get_or_init(|| {
-            Arc::new(crate::node::miner::bid_block_permission::BidBlockPermissionManager::new())
+            use crate::node::miner::bid_block_permission::BidBlockPermissionManager;
+            Arc::new(match BID_BLOCK_REVOKES_JOURNAL.get() {
+                Some(path) => BidBlockPermissionManager::with_journal(path.clone()),
+                None => BidBlockPermissionManager::new(),
+            })
         })
         .clone()
 }


### PR DESCRIPTION
### Description

Port of bnb-chain/bsc#3796: persist BidBlock revoke lockouts (BEP-675, validator-local MEV policy) across restarts.

Revokes are mirrored to a JSON journal — a single standalone file under the datadir (`bidblockrevokes.json`), deliberately outside chaindata — and restored at startup, dropping any revoke whose window elapsed while the node was down. An empty journal path keeps the manager purely in-memory (the previous behavior, and go-bsc's `""` semantics).

### Rationale

BidBlock revoke lockouts previously lived only in memory, so restarting the validator silently released every revoked builder — an operator's manual revoke or an automatic invalid-block lockout did not survive a restart. go-bsc fixed this in bnb-chain/bsc#3796; this PR brings reth-bsc to functional parity:

- **Versioned envelope with pinned keys**: `{"version": 1, "revokes": {...}}` with record keys `revokedAt`/`duration`/`reason`/`blockHash`/`blockNum` matching go-bsc's JSON tags. An unknown version, corrupt file, or missing file starts empty rather than misreading the format (starting empty only costs the remaining lockout windows, which self-expire; misreading could revoke or release the wrong builders).
- **Async, best-effort persistence**: mutations snapshot the whole map under the write lock and hand it to a fire-and-forget writer — the mining path never waits on disk.
- **Ordering guarantee**: the persisted sequence advances before the write regardless of outcome, so once a newer snapshot has entered the writer, an older one can never win the disk afterwards and resurrect stale state (e.g. a revoke overwriting a later manual clear). Writes are atomic (temp file + rename, owner-only permissions).
- **Manual clears persist too**: `mev_setBuilderBlockPermission(builder, true)` is mirrored to disk so a cleared builder is not resurrected on restart.

### Example

```bash
# Default: revokes journal lives next to the chain databases
./target/release/reth-bsc node --chain bsc --datadir ./data_dir
cat ./data_dir/bidblockrevokes.json
# {"version":1,"revokes":{"0x...":{"revokedAt":1788600000,"duration":86400,"reason":"invalid bid block: ...","blockHash":"0x...","blockNum":63400000}}}

# Custom location (relative resolves under the datadir), empty disables persistence
BSC_BID_BLOCK_REVOKES_JOURNAL=policy/revokes.json ./target/release/reth-bsc node ...
BSC_BID_BLOCK_REVOKES_JOURNAL= ./target/release/reth-bsc node ...
```

### Changes

Notable changes:
* `src/node/miner/bid_block_permission.rs`: journal load at construction (expired-while-down revokes dropped), snapshot-and-spawn persistence on every mutation (`revoke`/`revoke_for`/`set_allowed` both branches), atomic replace writer with the advance-before-write sequence guard, versioned serde envelope with pinned JSON keys.
* `src/shared.rs`: `set_bid_block_revokes_journal(PathBuf)` global; the lazily-initialized global permission manager picks the journal up on first access and stays in-memory when none is registered.
* `src/node/engine.rs`: journal path registered during component build (payload service builder — the miner bootstrap point, mirroring go-bsc's `miner.New` wiring), default `<datadir>/bidblockrevokes.json`, overridable via `BSC_BID_BLOCK_REVOKES_JOURNAL` (go's `BidBlockRevokesJournal` config equivalent: relative paths resolve under the datadir, empty disables).
* Seven new unit tests mirroring the go additions 1:1: restart survival with an identical status snapshot, expired-not-restored, corrupt/missing journal tolerance, unknown-version refusal, stable-key pinning, failed-newer-write-blocks-older ordering, and manual-clear persistence.

### Potential Impacts

* Validators get a new small file (`bidblockrevokes.json`) in the datadir root; deleting it resets all BidBlock lockouts (same operability as go-bsc).
* `mev_sendBidBlock` admission and the `mev_getBuilderBlockPermission`/`mev_setBuilderBlockPermission` RPCs now reflect revokes recorded before the last restart, within their windows.
* No consensus, storage-schema, or network impact; persistence is best-effort and off the mining hot path. Nodes without MEV/BidBlock activity never write the file (it is created on the first revoke, not at startup).
