### PR TITLE
feat:  add BEP-675 bid block gRPC service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes 1.11.1",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper 1.0.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes 1.11.1",
+ "futures-core",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5729,6 +5772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5963,6 +6012,12 @@ checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
  "unsigned-varint",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nom"
@@ -6514,6 +6569,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6917,6 +6983,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "pulldown-cmark 0.13.4",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6975,6 +7062,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6983,6 +7143,26 @@ dependencies = [
  "bitflags 2.11.1",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
+dependencies = [
+ "pulldown-cmark 0.13.4",
 ]
 
 [[package]]
@@ -10247,6 +10427,8 @@ dependencies = [
  "pbkdf2 0.12.2",
  "phf 0.11.3",
  "prost 0.12.6",
+ "prost 0.14.3",
+ "protoc-bin-vendored",
  "rand 0.9.4",
  "reth",
  "reth-basic-payload-builder",
@@ -10313,6 +10495,10 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
+ "tonic",
+ "tonic-health",
+ "tonic-prost",
+ "tonic-prost-build",
  "tracing",
  "uuid 1.23.2",
  "zeroize",
@@ -11617,7 +11803,7 @@ dependencies = [
  "cargo_metadata 0.14.2",
  "error-chain",
  "glob",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.6",
  "tempfile",
  "walkdir",
 ]
@@ -12365,8 +12551,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes 1.11.1",
+ "h2 0.4.16",
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -12375,6 +12563,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "socket2 0.6.4",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-stream",
@@ -12382,6 +12571,31 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
+dependencies = [
+ "prost 0.14.3",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -12393,6 +12607,22 @@ dependencies = [
  "bytes 1.11.1",
  "prost 0.14.3",
  "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types 0.14.3",
+ "quote",
+ "syn 2.0.117",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,10 @@ serde_cbor = "0.11"
 schnellru = "0.2"
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["full"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = { version = "0.14.6", features = ["transport"] }
+tonic-health = "0.14.6"
+tonic-prost = "0.14.6"
 tracing = "0.1"
 bit-set = "0.5.3"
 rand = "0.9"
@@ -160,7 +163,10 @@ cometbft-light-client-verifier = { git = "https://github.com/bnb-chain/greenfiel
 cometbft-proto = { git = "https://github.com/bnb-chain/greenfield-cometbft-rs.git", rev = "1282547" }
 cometbft-light-client = { git = "https://github.com/bnb-chain/greenfield-cometbft-rs.git", rev = "1282547" }
 
-prost = { version = "0.12.6" }
+# cometbft-proto is still generated with prost 0.12; the MEV gRPC API uses the
+# prost version paired with tonic 0.14.
+prost12 = { package = "prost", version = "0.12.6" }
+prost = { version = "0.14.3" }
 
 tendermint = { git = "https://github.com/bnb-chain/tendermint-rs-parlia", rev = "8c21ccbd58a174e07eed2c9343e63ccd00f0fbd5", features = [
     "secp256k1",
@@ -168,6 +174,10 @@ tendermint = { git = "https://github.com/bnb-chain/tendermint-rs-parlia", rev = 
 signature = "2.2.0"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 eth-keystore = "0.5"
+
+[build-dependencies]
+protoc-bin-vendored = "3"
+tonic-prost-build = "0.14.6"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemalloc-ctl = "0.6"

--- a/MINING_QUICKSTART.md
+++ b/MINING_QUICKSTART.md
@@ -165,6 +165,37 @@ BSC_MINING_ENABLED=true BSC_GAS_LIMIT=25000000 cargo run
 BSC_MINING_ENABLED=true BSC_MINING_INTERVAL_MS=200 cargo run
 ```
 
+### BEP-675 BidBlock over gRPC
+
+The optional gRPC listener exposes the same BidBlock admission path as
+`mev_sendBidBlock`. Enable both BidBlock admission and the listener:
+
+```bash
+./target/release/reth-bsc node \
+  --chain bsc \
+  --mining.enabled \
+  --mining.bid-block-enabled \
+  --mining.mev-grpc-port 8553
+```
+
+Equivalent environment settings:
+
+```bash
+export BSC_MINING_BID_BLOCK_ENABLED=true
+export BSC_MEV_GRPC_PORT=8553
+export BSC_MEV_GRPC_CONCURRENCY=32
+export BSC_MEV_GRPC_REQUEST_TIMEOUT_MS=10000
+```
+
+The protobuf service is `mev.v1.BidBlockService`, with unary method
+`SendBidBlock`. `bid_block_rlp` is the geth RLP encoding of
+`[header, transactions, sidecars]`; `signature` is the builder's 65-byte ECDSA
+signature. See [`proto/mev.proto`](proto/mev.proto) for the complete schema.
+
+The listener binds to the configured HTTP host and is plaintext, matching the
+go-bsc endpoint. Keep it on a private validator/sentry network or protect it
+with a trusted proxy, network ACL, or mTLS termination.
+
 ### Programmatic Configuration
 ```rust
 use reth_bsc::node::mining_config::MiningConfig;

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,17 @@
 use std::{collections::BTreeMap, fs, process::Command};
 
 fn main() {
+    println!("cargo:rerun-if-changed=proto/mev.proto");
+    let mut prost_config = tonic_prost_build::Config::new();
+    prost_config.protoc_executable(
+        protoc_bin_vendored::protoc_bin_path().expect("failed to locate vendored protoc binary"),
+    );
+    tonic_prost_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .compile_with_config(prost_config, &["proto/mev.proto"], &["proto"])
+        .expect("failed to compile MEV gRPC protobuf definitions");
+
     // Emit reth-bsc git SHA for startup version logging.
     let git_sha_short = Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])

--- a/proto/mev.proto
+++ b/proto/mev.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package mev.v1;
+
+option go_package = "github.com/ethereum/go-ethereum/core/types/builder/mevpb;mevpb";
+
+// BidBlockService accepts BEP-675 BidBlock submissions over gRPC.
+// Other MEV APIs remain on JSON-RPC.
+service BidBlockService {
+  rpc SendBidBlock(BidBlockRequest) returns (BidBlockResponse);
+}
+
+message BidBlockRequest {
+  // RLP encoding of the geth builder BidBlock structure.
+  bytes bid_block_rlp = 1;
+
+  // Builder ECDSA signature over BidBlock.Hash().
+  bytes signature = 2;
+
+  // Used by sentry routing. Validators intentionally ignore it.
+  string validator_host_name = 3;
+
+  reserved 4 to 10;
+}
+
+message BidBlockResponse {
+  bytes bid_hash = 1;
+}

--- a/src/evm/precompiles/cometbft.rs
+++ b/src/evm/precompiles/cometbft.rs
@@ -12,7 +12,7 @@ use cometbft_light_client_verifier::{
     types::{Validator, ValidatorSet},
 };
 use cometbft_proto::types::v1::LightBlock as TmLightBlock;
-use prost::Message;
+use prost12::Message;
 use revm::precompile::{
     u64_to_address, PrecompileHalt, PrecompileOutput, PrecompileResult, Precompile, PrecompileId,
 };

--- a/src/grpc/mev.rs
+++ b/src/grpc/mev.rs
@@ -1,0 +1,760 @@
+//! BEP-675 BidBlock gRPC ingress compatible with go-bsc.
+
+use crate::grpc::mev_proto::{
+    bid_block_service_server::{BidBlockService, BidBlockServiceServer},
+    BidBlockRequest, BidBlockResponse,
+};
+use crate::metrics::BscMevGrpcMetrics;
+use crate::node::miner::bid_block::{BidBlock, BidBlockArgs};
+use crate::rpc::mev::MevApiImpl;
+use alloy_primitives::{Bytes as AlloyBytes, B256};
+use alloy_rlp::Decodable;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::FutureExt;
+use jsonrpsee::types::ErrorObjectOwned;
+use prost::Message;
+use std::any::Any;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::codegen::{http, BoxFuture, Service};
+use tonic::service::interceptor::InterceptedService;
+use tonic::service::Interceptor;
+use tonic::transport::Server;
+use tonic::{Code, Request, Response, Status};
+use tonic_health::ServingStatus;
+
+/// `/mev.v1.BidBlockService/SendBidBlock`, matching go-bsc's public protobuf contract.
+pub const SEND_BID_BLOCK_METHOD: &str = "/mev.v1.BidBlockService/SendBidBlock";
+
+/// BSC `params.MaxBlockSize`, mirrored explicitly because reth has no equivalent protocol
+/// constant. Keep this synchronized with go-bsc when upgrading the compatibility baseline.
+const BSC_MAX_BLOCK_SIZE: usize = 8 * 1024 * 1024;
+/// go-bsc allows twice `params.MaxBlockSize` for the protobuf envelope.
+pub const MAX_MEV_GRPC_MESSAGE_SIZE: usize = 2 * BSC_MAX_BLOCK_SIZE;
+// Small decoder headroom lets the handler translate a protobuf envelope just over the public
+// limit into go-bsc's ResourceExhausted status. The transport still has a hard allocation cap.
+const MEV_GRPC_DECODER_HEADROOM: usize = 4 * 1024;
+const MEV_GRPC_STREAM_HEADROOM: u32 = 16;
+const MEV_GRPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+const MEV_ERROR_DOMAIN: &str = "mev.bnbchain.org";
+const JSON_RPC_ERROR_DATA_KEY: &str = "json_rpc_error_data";
+
+/// Runtime controls for the optional gRPC listener.
+#[derive(Debug, Clone, Copy)]
+pub struct MevGrpcConfig {
+    pub concurrency: u32,
+    pub request_timeout: Duration,
+}
+
+impl MevGrpcConfig {
+    pub fn new(concurrency: u32, request_timeout: Duration) -> Self {
+        Self {
+            concurrency: if concurrency == 0 { 32 } else { concurrency },
+            request_timeout: if request_timeout.is_zero() {
+                Duration::from_secs(10)
+            } else {
+                request_timeout
+            },
+        }
+    }
+}
+
+/// Transport-independent seam used to guarantee JSON-RPC and gRPC call the same admission code.
+#[async_trait]
+trait BidBlockSubmitter: Send + Sync {
+    async fn submit_bid_block(&self, args: BidBlockArgs) -> Result<B256, ErrorObjectOwned>;
+}
+
+#[async_trait]
+impl BidBlockSubmitter for MevApiImpl {
+    async fn submit_bid_block(&self, args: BidBlockArgs) -> Result<B256, ErrorObjectOwned> {
+        MevApiImpl::submit_bid_block(self, args).await
+    }
+}
+
+#[derive(Clone)]
+struct MevGrpcApi {
+    submitter: Arc<dyn BidBlockSubmitter>,
+    semaphore: Arc<Semaphore>,
+    metrics: BscMevGrpcMetrics,
+}
+
+impl MevGrpcApi {
+    fn new(submitter: Arc<dyn BidBlockSubmitter>, concurrency: u32) -> Self {
+        Self {
+            submitter,
+            semaphore: Arc::new(Semaphore::new(concurrency as usize)),
+            metrics: BscMevGrpcMetrics::default(),
+        }
+    }
+
+    fn acquire(&self) -> Result<Arc<ActiveRequest>, Status> {
+        let permit = Arc::clone(&self.semaphore).try_acquire_owned().map_err(|_| {
+            self.metrics.rejected_total.increment(1);
+            Status::resource_exhausted("concurrency limit reached")
+        })?;
+        self.metrics.active_requests.increment(1);
+        Ok(Arc::new(ActiveRequest { _permit: permit, metrics: self.metrics.clone() }))
+    }
+}
+
+/// Admission runs as a service interceptor, before tonic reads or decodes the protobuf body.
+/// It wraps only BidBlockService, so health checks remain available while BidBlock is saturated.
+#[derive(Clone)]
+struct MevGrpcAdmission {
+    api: MevGrpcApi,
+}
+
+impl Interceptor for MevGrpcAdmission {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        request.extensions_mut().insert(self.api.acquire()?);
+        Ok(request)
+    }
+}
+
+/// Per-BidBlock transport safety wrapper. Admission is outside this wrapper, so its timeout starts
+/// before protobuf body decoding; health is registered separately and bypasses both timeout and
+/// panic accounting.
+#[derive(Clone)]
+struct MevGrpcSafety<S> {
+    inner: S,
+    timeout: Duration,
+    metrics: BscMevGrpcMetrics,
+}
+
+impl<S> MevGrpcSafety<S> {
+    fn new(inner: S, timeout: Duration, metrics: BscMevGrpcMetrics) -> Self {
+        Self { inner, timeout, metrics }
+    }
+}
+
+impl<S: tonic::server::NamedService> tonic::server::NamedService for MevGrpcSafety<S> {
+    const NAME: &'static str = S::NAME;
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for MevGrpcSafety<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>>,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = http::Response<ResBody>;
+    type Error = S::Error;
+    type Future = BoxFuture<Self::Response, Self::Error>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<ReqBody>) -> Self::Future {
+        let future = match std::panic::catch_unwind(AssertUnwindSafe(|| self.inner.call(request))) {
+            Ok(future) => future,
+            Err(panic) => {
+                let response = grpc_panic_response::<ResBody>(&self.metrics, panic);
+                return Box::pin(async move { Ok(response) });
+            }
+        };
+        let timeout = self.timeout;
+        let metrics = self.metrics.clone();
+
+        Box::pin(async move {
+            match tokio::time::timeout(timeout, AssertUnwindSafe(future).catch_unwind()).await {
+                Ok(Ok(result)) => result,
+                Ok(Err(panic)) => Ok(grpc_panic_response::<ResBody>(&metrics, panic)),
+                Err(_) => {
+                    metrics.errors_total.increment(1);
+                    Ok(Status::deadline_exceeded("request timeout").into_http::<ResBody>())
+                }
+            }
+        })
+    }
+}
+
+fn grpc_panic_response<B: Default>(
+    metrics: &BscMevGrpcMetrics,
+    panic: Box<dyn Any + Send + 'static>,
+) -> http::Response<B> {
+    metrics.errors_total.increment(1);
+    let panic = if let Some(message) = panic.downcast_ref::<String>() {
+        message.as_str()
+    } else if let Some(message) = panic.downcast_ref::<&str>() {
+        message
+    } else {
+        "non-string panic payload"
+    };
+    tracing::error!(
+        method = SEND_BID_BLOCK_METHOD,
+        panic,
+        backtrace = %std::backtrace::Backtrace::force_capture(),
+        "panic in MEV gRPC handler"
+    );
+    Status::internal("internal error").into_http::<B>()
+}
+
+struct ActiveRequest {
+    _permit: OwnedSemaphorePermit,
+    metrics: BscMevGrpcMetrics,
+}
+
+impl Drop for ActiveRequest {
+    fn drop(&mut self) {
+        self.metrics.active_requests.decrement(1);
+    }
+}
+
+struct HandlerTimer {
+    started: Instant,
+    metrics: BscMevGrpcMetrics,
+}
+
+impl Drop for HandlerTimer {
+    fn drop(&mut self) {
+        self.metrics.handler_duration_seconds.record(self.started.elapsed().as_secs_f64());
+    }
+}
+
+#[tonic::async_trait]
+impl BidBlockService for MevGrpcApi {
+    async fn send_bid_block(
+        &self,
+        mut request: Request<BidBlockRequest>,
+    ) -> Result<Response<BidBlockResponse>, Status> {
+        // Direct unit calls do not traverse the transport interceptor; keep the fallback so the
+        // transport-independent handler is still testable without weakening production admission.
+        let _active = match request.extensions_mut().remove::<Arc<ActiveRequest>>() {
+            Some(active) => active,
+            None => self.acquire()?,
+        };
+        self.metrics.requests_total.increment(1);
+        let _timer = HandlerTimer { started: Instant::now(), metrics: self.metrics.clone() };
+
+        let request = request.into_inner();
+        tracing::info!(
+            transport = "grpc",
+            payload_bytes = request.bid_block_rlp.len(),
+            signature_bytes = request.signature.len(),
+            validator_host_name = %request.validator_host_name,
+            "[BID BLOCK GRPC RECEIVED]"
+        );
+        self.metrics.payload_size_bytes.record(request.bid_block_rlp.len() as f64);
+        if request.encoded_len() > MAX_MEV_GRPC_MESSAGE_SIZE {
+            self.metrics.errors_total.increment(1);
+            return Err(Status::resource_exhausted("message exceeds maximum size"));
+        }
+        if request.bid_block_rlp.is_empty() {
+            self.metrics.errors_total.increment(1);
+            return Err(mev_status(-38001, "empty BidBlock RLP"));
+        }
+
+        let decode_started = Instant::now();
+        let mut encoded = request.bid_block_rlp.as_slice();
+        let bid_block = BidBlock::decode(&mut encoded).map_err(|_| {
+            self.metrics.errors_total.increment(1);
+            mev_status(-38001, "invalid BidBlock RLP")
+        })?;
+        self.metrics.decode_duration_seconds.record(decode_started.elapsed().as_secs_f64());
+        if !encoded.is_empty() {
+            self.metrics.errors_total.increment(1);
+            return Err(mev_status(-38001, "invalid BidBlock RLP"));
+        }
+
+        tracing::info!(
+            transport = "grpc",
+            block = bid_block.header.number,
+            txs = bid_block.transactions.len(),
+            sidecars = bid_block.sidecars.len(),
+            "[BID BLOCK GRPC DECODED]"
+        );
+
+        let block_number = bid_block.header.number;
+
+        // validator_host_name is a sentry routing hint. Like go-bsc, a validator ignores it.
+        let args = BidBlockArgs { bid_block, signature: AlloyBytes::from(request.signature) };
+        let bid_hash = self.submitter.submit_bid_block(args).await.map_err(|err| {
+            self.metrics.errors_total.increment(1);
+            rpc_error_to_status(&err)
+        })?;
+
+        tracing::info!(
+            transport = "grpc",
+            block = block_number,
+            bid_hash = %bid_hash,
+            "[BID BLOCK GRPC ACCEPTED]"
+        );
+
+        Ok(Response::new(BidBlockResponse { bid_hash: bid_hash.as_slice().to_vec() }))
+    }
+}
+
+/// Running gRPC listener. [`Self::shutdown`] drains gracefully; dropping is a startup-failure
+/// safety net that signals shutdown and aborts the task so a listener can never detach silently.
+pub struct MevGrpcServerHandle {
+    local_addr: SocketAddr,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<Result<(), tonic::transport::Error>>>,
+}
+
+impl MevGrpcServerHandle {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(mut task) = self.task.take() {
+            if tokio::time::timeout(MEV_GRPC_SHUTDOWN_TIMEOUT, &mut task).await.is_err() {
+                task.abort();
+                let _ = task.await;
+            }
+        }
+    }
+}
+
+impl Drop for MevGrpcServerHandle {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+/// Bind and start the optional MEV gRPC service. Binding is synchronous so address conflicts fail
+/// node startup rather than surfacing later in a detached task.
+pub fn start_mev_grpc_server(
+    listen_addr: SocketAddr,
+    config: MevGrpcConfig,
+    api: Arc<MevApiImpl>,
+) -> eyre::Result<MevGrpcServerHandle> {
+    start_mev_grpc_server_with_submitter(listen_addr, config, api)
+}
+
+fn start_mev_grpc_server_with_submitter(
+    listen_addr: SocketAddr,
+    config: MevGrpcConfig,
+    submitter: Arc<dyn BidBlockSubmitter>,
+) -> eyre::Result<MevGrpcServerHandle> {
+    let listener = std::net::TcpListener::bind(listen_addr)?;
+    listener.set_nonblocking(true)?;
+    let local_addr = listener.local_addr()?;
+    let listener = tokio::net::TcpListener::from_std(listener)?;
+
+    let config = MevGrpcConfig::new(config.concurrency, config.request_timeout);
+    let service = MevGrpcApi::new(submitter, config.concurrency);
+    let admission = MevGrpcAdmission { api: service.clone() };
+    let safety_metrics = service.metrics.clone();
+    let bid_block_service = BidBlockServiceServer::new(service)
+        .max_decoding_message_size(MAX_MEV_GRPC_MESSAGE_SIZE + MEV_GRPC_DECODER_HEADROOM)
+        .max_encoding_message_size(MAX_MEV_GRPC_MESSAGE_SIZE);
+    let bid_block_service =
+        MevGrpcSafety::new(bid_block_service, config.request_timeout, safety_metrics);
+    let bid_block_service = InterceptedService::new(bid_block_service, admission);
+    let (health_reporter, health_service) = tonic_health::server::health_reporter();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let incoming = TcpListenerStream::new(listener);
+    let max_streams = config.concurrency.saturating_add(MEV_GRPC_STREAM_HEADROOM);
+
+    let task = tokio::spawn(async move {
+        health_reporter.set_service_status("", ServingStatus::Serving).await;
+        health_reporter.set_serving::<BidBlockServiceServer<MevGrpcApi>>().await;
+        let shutdown = async move {
+            let _ = shutdown_rx.await;
+            health_reporter.set_service_status("", ServingStatus::NotServing).await;
+            health_reporter.set_not_serving::<BidBlockServiceServer<MevGrpcApi>>().await;
+        };
+        let result = Server::builder()
+            .max_concurrent_streams(max_streams)
+            .add_service(health_service)
+            .add_service(bid_block_service)
+            .serve_with_incoming_shutdown(incoming, shutdown)
+            .await;
+        if let Err(error) = &result {
+            tracing::error!(%error, "MEV gRPC server stopped unexpectedly");
+        }
+        result
+    });
+
+    tracing::info!(
+        %local_addr,
+        concurrency = config.concurrency,
+        max_streams,
+        timeout_ms = config.request_timeout.as_millis(),
+        "MEV gRPC server started"
+    );
+    Ok(MevGrpcServerHandle { local_addr, shutdown: Some(shutdown_tx), task: Some(task) })
+}
+
+fn rpc_error_to_status(error: &ErrorObjectOwned) -> Status {
+    let code = error.code();
+    let grpc_code = match code {
+        -38001 | -38002 | -38007 => Code::InvalidArgument,
+        -38003 => Code::Unavailable,
+        -38004 => Code::ResourceExhausted,
+        -38005 => Code::FailedPrecondition,
+        -38006 => Code::PermissionDenied,
+        -38008 => Code::DeadlineExceeded,
+        _ => Code::Unknown,
+    };
+    let mut metadata = HashMap::new();
+    if let Some(data) = error.data() {
+        metadata.insert(JSON_RPC_ERROR_DATA_KEY.to_string(), data.get().to_string());
+    }
+    status_with_error_info(grpc_code, error.message(), code, metadata)
+}
+
+fn mev_status(json_rpc_code: i32, message: impl Into<String>) -> Status {
+    let message = message.into();
+    let grpc_code = match json_rpc_code {
+        -38001 | -38002 | -38007 => Code::InvalidArgument,
+        -38003 => Code::Unavailable,
+        -38004 => Code::ResourceExhausted,
+        -38005 => Code::FailedPrecondition,
+        -38006 => Code::PermissionDenied,
+        -38008 => Code::DeadlineExceeded,
+        _ => Code::Unknown,
+    };
+    status_with_error_info(grpc_code, &message, json_rpc_code, HashMap::new())
+}
+
+fn status_with_error_info(
+    grpc_code: Code,
+    message: &str,
+    json_rpc_code: i32,
+    metadata: HashMap<String, String>,
+) -> Status {
+    let error_info = ErrorInfo {
+        reason: json_rpc_code.to_string(),
+        domain: MEV_ERROR_DOMAIN.to_string(),
+        metadata,
+    };
+    let rpc_status = GoogleRpcStatus {
+        code: grpc_code as i32,
+        message: message.to_string(),
+        details: vec![ProtoAny {
+            type_url: "type.googleapis.com/google.rpc.ErrorInfo".to_string(),
+            value: error_info.encode_to_vec(),
+        }],
+    };
+    Status::with_details(grpc_code, message.to_string(), Bytes::from(rpc_status.encode_to_vec()))
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct GoogleRpcStatus {
+    #[prost(int32, tag = "1")]
+    code: i32,
+    #[prost(string, tag = "2")]
+    message: String,
+    #[prost(message, repeated, tag = "3")]
+    details: Vec<ProtoAny>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoAny {
+    #[prost(string, tag = "1")]
+    type_url: String,
+    #[prost(bytes = "vec", tag = "2")]
+    value: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ErrorInfo {
+    #[prost(string, tag = "1")]
+    reason: String,
+    #[prost(string, tag = "2")]
+    domain: String,
+    #[prost(map = "string, string", tag = "3")]
+    metadata: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_primitives::B256;
+    use std::sync::Mutex;
+    use tonic_health::pb::{
+        health_check_response::ServingStatus as PbServingStatus, health_client::HealthClient,
+        HealthCheckRequest,
+    };
+
+    struct MockSubmitter {
+        args: Mutex<Option<BidBlockArgs>>,
+        result: Result<B256, ErrorObjectOwned>,
+    }
+
+    struct PanicSubmitter;
+
+    struct SlowSubmitter {
+        delay: Duration,
+    }
+
+    #[async_trait]
+    impl BidBlockSubmitter for MockSubmitter {
+        async fn submit_bid_block(&self, args: BidBlockArgs) -> Result<B256, ErrorObjectOwned> {
+            *self.args.lock().unwrap() = Some(args);
+            self.result.clone()
+        }
+    }
+
+    #[async_trait]
+    impl BidBlockSubmitter for PanicSubmitter {
+        async fn submit_bid_block(&self, _args: BidBlockArgs) -> Result<B256, ErrorObjectOwned> {
+            panic!("intentional gRPC handler panic")
+        }
+    }
+
+    #[async_trait]
+    impl BidBlockSubmitter for SlowSubmitter {
+        async fn submit_bid_block(&self, _args: BidBlockArgs) -> Result<B256, ErrorObjectOwned> {
+            tokio::time::sleep(self.delay).await;
+            Ok(B256::ZERO)
+        }
+    }
+
+    fn request_block() -> BidBlock {
+        BidBlock {
+            header: Header {
+                number: 2,
+                gas_limit: 140_000_000,
+                gas_used: 21_000,
+                ..Default::default()
+            },
+            transactions: vec![AlloyBytes::from_static(&[1, 2, 3])],
+            sidecars: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn grpc_handler_decodes_rlp_and_forwards_signature() {
+        let block = request_block();
+        let encoded = alloy_rlp::encode(&block);
+        let expected_hash = B256::repeat_byte(0x12);
+        let submitter =
+            Arc::new(MockSubmitter { args: Mutex::new(None), result: Ok(expected_hash) });
+        let service = MevGrpcApi::new(submitter.clone(), 1);
+
+        let response = service
+            .send_bid_block(Request::new(BidBlockRequest {
+                bid_block_rlp: encoded,
+                signature: vec![0xaa, 0xbb],
+                validator_host_name: "ignored-by-validator".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.bid_hash, expected_hash.as_slice());
+        let args = submitter.args.lock().unwrap().take().unwrap();
+        assert_eq!(args.bid_block, block);
+        assert_eq!(args.signature.as_ref(), &[0xaa, 0xbb]);
+    }
+
+    #[tokio::test]
+    async fn grpc_handler_rejects_empty_invalid_and_trailing_rlp() {
+        let submitter = Arc::new(MockSubmitter { args: Mutex::new(None), result: Ok(B256::ZERO) });
+        let service = MevGrpcApi::new(submitter.clone(), 1);
+
+        for payload in [Vec::new(), vec![0xff], {
+            let mut encoded = alloy_rlp::encode(&request_block());
+            encoded.push(0x80);
+            encoded
+        }] {
+            let error = service
+                .send_bid_block(Request::new(BidBlockRequest {
+                    bid_block_rlp: payload,
+                    ..Default::default()
+                }))
+                .await
+                .unwrap_err();
+            assert_eq!(error.code(), Code::InvalidArgument);
+        }
+        assert!(submitter.args.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn grpc_admission_rejects_before_message_decode() {
+        let submitter = Arc::new(MockSubmitter { args: Mutex::new(None), result: Ok(B256::ZERO) });
+        let mut admission = MevGrpcAdmission { api: MevGrpcApi::new(submitter, 1) };
+
+        let admitted = admission.call(Request::new(())).unwrap();
+        let rejected = admission.call(Request::new(())).unwrap_err();
+        assert_eq!(rejected.code(), Code::ResourceExhausted);
+
+        drop(admitted);
+        assert!(admission.call(Request::new(())).is_ok());
+    }
+
+    #[tokio::test]
+    async fn grpc_listener_serves_bidblock_and_health() {
+        let block = request_block();
+        let expected_hash = B256::repeat_byte(0x34);
+        let submitter =
+            Arc::new(MockSubmitter { args: Mutex::new(None), result: Ok(expected_hash) });
+        let handle = start_mev_grpc_server_with_submitter(
+            "127.0.0.1:0".parse().unwrap(),
+            MevGrpcConfig::new(2, Duration::from_secs(1)),
+            submitter,
+        )
+        .unwrap();
+        let endpoint = format!("http://{}", handle.local_addr());
+
+        let channel =
+            tonic::transport::Endpoint::from_shared(endpoint).unwrap().connect().await.unwrap();
+        let mut health = HealthClient::new(channel.clone());
+        let health_response =
+            health.check(HealthCheckRequest { service: String::new() }).await.unwrap().into_inner();
+        assert_eq!(health_response.status, PbServingStatus::Serving as i32);
+
+        let mut client =
+            crate::grpc::mev_proto::bid_block_service_client::BidBlockServiceClient::new(channel);
+        let response = client
+            .send_bid_block(BidBlockRequest {
+                bid_block_rlp: alloy_rlp::encode(&block),
+                signature: vec![0xaa; 65],
+                validator_host_name: String::new(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.bid_hash, expected_hash.as_slice());
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn grpc_listener_rejects_oversized_payload_before_business_call() {
+        let submitter = Arc::new(MockSubmitter { args: Mutex::new(None), result: Ok(B256::ZERO) });
+        let handle = start_mev_grpc_server_with_submitter(
+            "127.0.0.1:0".parse().unwrap(),
+            MevGrpcConfig::new(1, Duration::from_secs(1)),
+            submitter.clone(),
+        )
+        .unwrap();
+        let endpoint = format!("http://{}", handle.local_addr());
+        let channel =
+            tonic::transport::Endpoint::from_shared(endpoint).unwrap().connect().await.unwrap();
+        let mut client =
+            crate::grpc::mev_proto::bid_block_service_client::BidBlockServiceClient::new(channel);
+
+        let error = client
+            .send_bid_block(BidBlockRequest {
+                bid_block_rlp: vec![0; MAX_MEV_GRPC_MESSAGE_SIZE],
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Code::ResourceExhausted);
+        assert!(submitter.args.lock().unwrap().is_none());
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn grpc_listener_recovers_handler_panic_and_stays_healthy() {
+        let handle = start_mev_grpc_server_with_submitter(
+            "127.0.0.1:0".parse().unwrap(),
+            MevGrpcConfig::new(1, Duration::from_secs(1)),
+            Arc::new(PanicSubmitter),
+        )
+        .unwrap();
+        let endpoint = format!("http://{}", handle.local_addr());
+        let channel =
+            tonic::transport::Endpoint::from_shared(endpoint).unwrap().connect().await.unwrap();
+        let mut client =
+            crate::grpc::mev_proto::bid_block_service_client::BidBlockServiceClient::new(
+                channel.clone(),
+            );
+
+        let error = client
+            .send_bid_block(BidBlockRequest {
+                bid_block_rlp: alloy_rlp::encode(&request_block()),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Code::Internal);
+
+        let mut health = HealthClient::new(channel);
+        let response =
+            health.check(HealthCheckRequest { service: String::new() }).await.unwrap().into_inner();
+        assert_eq!(response.status, PbServingStatus::Serving as i32);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn grpc_timeout_is_bidblock_only_and_releases_admission() {
+        let handle = start_mev_grpc_server_with_submitter(
+            "127.0.0.1:0".parse().unwrap(),
+            MevGrpcConfig::new(1, Duration::from_millis(20)),
+            Arc::new(SlowSubmitter { delay: Duration::from_secs(1) }),
+        )
+        .unwrap();
+        let endpoint = format!("http://{}", handle.local_addr());
+        let channel =
+            tonic::transport::Endpoint::from_shared(endpoint).unwrap().connect().await.unwrap();
+        let request = BidBlockRequest {
+            bid_block_rlp: alloy_rlp::encode(&request_block()),
+            ..Default::default()
+        };
+        let mut client =
+            crate::grpc::mev_proto::bid_block_service_client::BidBlockServiceClient::new(
+                channel.clone(),
+            );
+
+        for _ in 0..2 {
+            let error = client.send_bid_block(request.clone()).await.unwrap_err();
+            assert_eq!(error.code(), Code::DeadlineExceeded);
+        }
+
+        let mut health = HealthClient::new(channel);
+        let response =
+            health.check(HealthCheckRequest { service: String::new() }).await.unwrap().into_inner();
+        assert_eq!(response.status, PbServingStatus::Serving as i32);
+
+        handle.shutdown().await;
+    }
+
+    #[test]
+    fn grpc_error_preserves_json_rpc_code_as_error_info() {
+        let error =
+            ErrorObjectOwned::owned(-38006, "revoked", Some(serde_json::json!({ "retry": false })));
+        let status = rpc_error_to_status(&error);
+        assert_eq!(status.code(), Code::PermissionDenied);
+
+        let rpc_status = GoogleRpcStatus::decode(status.details()).unwrap();
+        assert_eq!(rpc_status.code, Code::PermissionDenied as i32);
+        assert_eq!(rpc_status.details.len(), 1);
+        let info = ErrorInfo::decode(rpc_status.details[0].value.as_slice()).unwrap();
+        assert_eq!(info.reason, "-38006");
+        assert_eq!(info.domain, MEV_ERROR_DOMAIN);
+        assert_eq!(info.metadata[JSON_RPC_ERROR_DATA_KEY], r#"{"retry":false}"#);
+    }
+
+    #[test]
+    fn configured_zero_values_use_geth_defaults() {
+        let config = MevGrpcConfig::new(0, Duration::ZERO);
+        assert_eq!(config.concurrency, 32);
+        assert_eq!(config.request_timeout, Duration::from_secs(10));
+        assert_eq!(SEND_BID_BLOCK_METHOD, "/mev.v1.BidBlockService/SendBidBlock");
+    }
+
+    #[test]
+    fn message_size_limit_matches_go_bsc_params() {
+        assert_eq!(BSC_MAX_BLOCK_SIZE, 8_388_608);
+        assert_eq!(MAX_MEV_GRPC_MESSAGE_SIZE, 16_777_216);
+    }
+}

--- a/src/grpc/mev.rs
+++ b/src/grpc/mev.rs
@@ -568,7 +568,7 @@ mod tests {
         let service = MevGrpcApi::new(submitter.clone(), 1);
 
         for payload in [Vec::new(), vec![0xff], {
-            let mut encoded = alloy_rlp::encode(&request_block());
+            let mut encoded = alloy_rlp::encode(request_block());
             encoded.push(0x80);
             encoded
         }] {
@@ -680,7 +680,7 @@ mod tests {
 
         let error = client
             .send_bid_block(BidBlockRequest {
-                bid_block_rlp: alloy_rlp::encode(&request_block()),
+                bid_block_rlp: alloy_rlp::encode(request_block()),
                 ..Default::default()
             })
             .await
@@ -707,7 +707,7 @@ mod tests {
         let channel =
             tonic::transport::Endpoint::from_shared(endpoint).unwrap().connect().await.unwrap();
         let request = BidBlockRequest {
-            bid_block_rlp: alloy_rlp::encode(&request_block()),
+            bid_block_rlp: alloy_rlp::encode(request_block()),
             ..Default::default()
         };
         let mut client =

--- a/src/grpc/mev.rs
+++ b/src/grpc/mev.rs
@@ -235,35 +235,60 @@ impl BidBlockService for MevGrpcApi {
             None => self.acquire()?,
         };
         self.metrics.requests_total.increment(1);
-        let _timer = HandlerTimer { started: Instant::now(), metrics: self.metrics.clone() };
+        let started = Instant::now();
+        let _timer = HandlerTimer { started, metrics: self.metrics.clone() };
 
         let request = request.into_inner();
+        let payload_bytes = request.bid_block_rlp.len();
         tracing::info!(
             transport = "grpc",
-            payload_bytes = request.bid_block_rlp.len(),
+            payload_bytes,
             signature_bytes = request.signature.len(),
-            validator_host_name = %request.validator_host_name,
+            // Untrusted wire input: `?` escapes control characters so a peer cannot forge log lines.
+            validator_host_name = ?request.validator_host_name,
             "[BID BLOCK GRPC RECEIVED]"
         );
-        self.metrics.payload_size_bytes.record(request.bid_block_rlp.len() as f64);
+        self.metrics.payload_size_bytes.record(payload_bytes as f64);
+
+        match self.handle_send_bid_block(request).await {
+            Ok(bid_hash) => {
+                Ok(Response::new(BidBlockResponse { bid_hash: bid_hash.as_slice().to_vec() }))
+            }
+            Err(status) => {
+                // go-bsc logs `[BID BLOCK GRPC FAILED]` for every rejected request; keep the same
+                // fields (payload size, gRPC code, elapsed, error) so operators can correlate.
+                self.metrics.errors_total.increment(1);
+                tracing::warn!(
+                    transport = "grpc",
+                    payload_bytes,
+                    code = ?status.code(),
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    err = %status.message(),
+                    "[BID BLOCK GRPC FAILED]"
+                );
+                Err(status)
+            }
+        }
+    }
+}
+
+impl MevGrpcApi {
+    /// Decode and admit one BidBlock. Every rejection returns through the caller, which owns the
+    /// single failure log and error metric.
+    async fn handle_send_bid_block(&self, request: BidBlockRequest) -> Result<B256, Status> {
         if request.encoded_len() > MAX_MEV_GRPC_MESSAGE_SIZE {
-            self.metrics.errors_total.increment(1);
             return Err(Status::resource_exhausted("message exceeds maximum size"));
         }
         if request.bid_block_rlp.is_empty() {
-            self.metrics.errors_total.increment(1);
             return Err(mev_status(-38001, "empty BidBlock RLP"));
         }
 
         let decode_started = Instant::now();
         let mut encoded = request.bid_block_rlp.as_slice();
-        let bid_block = BidBlock::decode(&mut encoded).map_err(|_| {
-            self.metrics.errors_total.increment(1);
-            mev_status(-38001, "invalid BidBlock RLP")
-        })?;
+        let bid_block =
+            BidBlock::decode(&mut encoded).map_err(|_| mev_status(-38001, "invalid BidBlock RLP"))?;
         self.metrics.decode_duration_seconds.record(decode_started.elapsed().as_secs_f64());
         if !encoded.is_empty() {
-            self.metrics.errors_total.increment(1);
             return Err(mev_status(-38001, "invalid BidBlock RLP"));
         }
 
@@ -279,10 +304,8 @@ impl BidBlockService for MevGrpcApi {
 
         // validator_host_name is a sentry routing hint. Like go-bsc, a validator ignores it.
         let args = BidBlockArgs { bid_block, signature: AlloyBytes::from(request.signature) };
-        let bid_hash = self.submitter.submit_bid_block(args).await.map_err(|err| {
-            self.metrics.errors_total.increment(1);
-            rpc_error_to_status(&err)
-        })?;
+        let bid_hash =
+            self.submitter.submit_bid_block(args).await.map_err(|err| rpc_error_to_status(&err))?;
 
         tracing::info!(
             transport = "grpc",
@@ -291,7 +314,7 @@ impl BidBlockService for MevGrpcApi {
             "[BID BLOCK GRPC ACCEPTED]"
         );
 
-        Ok(Response::new(BidBlockResponse { bid_hash: bid_hash.as_slice().to_vec() }))
+        Ok(bid_hash)
     }
 }
 

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,0 +1,8 @@
+//! BSC-specific gRPC services.
+
+pub mod mev;
+
+/// Protobuf definitions shared with go-bsc's BEP-675 gRPC endpoint.
+pub mod mev_proto {
+    tonic::include_proto!("mev.v1");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod chainspec;
 pub mod consensus;
 pub mod evm;
+pub mod grpc;
 pub mod hardforks;
 pub mod metrics;
 pub mod node;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,24 @@ pub struct BscCliArgs {
     #[arg(long = "mining.bid-block-enabled")]
     pub mining_bid_block_enabled: bool,
 
+    /// Port for the optional BEP-675 `BidBlockService` gRPC listener. Zero disables it.
+    ///
+    /// Env alternative: `BSC_MEV_GRPC_PORT`.
+    #[arg(long = "mining.mev-grpc-port")]
+    pub mining_mev_grpc_port: Option<u16>,
+
+    /// Maximum process-wide in-flight gRPC `SendBidBlock` requests.
+    ///
+    /// Env alternative: `BSC_MEV_GRPC_CONCURRENCY`.
+    #[arg(long = "mining.mev-grpc-concurrency")]
+    pub mining_mev_grpc_concurrency: Option<u32>,
+
+    /// Total gRPC `SendBidBlock` timeout in milliseconds.
+    ///
+    /// Env alternative: `BSC_MEV_GRPC_REQUEST_TIMEOUT_MS`.
+    #[arg(long = "mining.mev-grpc-request-timeout-ms")]
+    pub mining_mev_grpc_request_timeout_ms: Option<u64>,
+
     /// Private key for mining (hex format, for testing only)
     /// The validator address will be automatically derived from this key
     #[arg(long = "mining.private-key")]
@@ -286,6 +304,16 @@ fn main() -> eyre::Result<()> {
                     mining_config.bid_block_enabled = true;
                 }
 
+                if let Some(port) = args.mining_mev_grpc_port {
+                    mining_config.mev_grpc_port = port;
+                }
+                if let Some(concurrency) = args.mining_mev_grpc_concurrency {
+                    mining_config.mev_grpc_concurrency = concurrency;
+                }
+                if let Some(timeout_ms) = args.mining_mev_grpc_request_timeout_ms {
+                    mining_config.mev_grpc_request_timeout_ms = timeout_ms;
+                }
+
                 // Ensure keys are available if enabled but none provided
                 mining_config = mining_config.ensure_keys_available();
 
@@ -426,6 +454,28 @@ fn main() -> eyre::Result<()> {
                 }
             }
 
+            let mev_grpc_config =
+                reth_bsc::node::miner::config::get_global_mining_config().and_then(|config| {
+                    let port = config.get_mev_grpc_port();
+                    (port != 0).then(|| {
+                        (
+                            port,
+                            reth_bsc::grpc::mev::MevGrpcConfig::new(
+                                config.get_mev_grpc_concurrency(),
+                                std::time::Duration::from_millis(
+                                    config.get_mev_grpc_request_timeout_ms(),
+                                ),
+                            ),
+                        )
+                    })
+                });
+            // Match go-bsc: the gRPC listener uses the configured HTTP bind host and an independent
+            // port. The handle crosses the synchronous RPC-extension hook so it can be shut down
+            // after the node exit future resolves.
+            let mev_grpc_host = builder.config().rpc.http_addr;
+            let mev_grpc_handle = Arc::new(std::sync::Mutex::new(None));
+            let mev_grpc_handle_for_rpc = Arc::clone(&mev_grpc_handle);
+
             let (node, engine_handle_tx) = BscNode::new();
             let NodeHandle { node, node_exit_future: exit_future } =
                 builder.node(node)
@@ -477,8 +527,8 @@ fn main() -> eyre::Result<()> {
 
                         // Get chain spec from context
                         let chain_spec = std::sync::Arc::new(ctx.config().chain.clone().as_ref().clone());
-                        let mev_api = MevApiImpl::new(snapshot_provider, chain_spec);
-                        ctx.modules.merge_if_module_configured(RethRpcModule::Mev, mev_api.into_rpc())?;
+                        let mev_api = Arc::new(MevApiImpl::new(snapshot_provider, chain_spec));
+                        ctx.modules.merge_if_module_configured(RethRpcModule::Mev, mev_api.as_ref().clone().into_rpc())?;
                         tracing::info!("Succeed to register MEV RPC API");
 
                         tracing::info!("Start to register Miner RPC API...");
@@ -541,6 +591,18 @@ fn main() -> eyre::Result<()> {
                         );
                         ctx.modules.merge_if_module_configured(RethRpcModule::Eth, eth_config.into_rpc())?;
                         tracing::info!("Succeed to register eth_config (EIP-7910) API");
+
+                        // Bind only after all RPC module registration succeeded, so a later merge
+                        // error cannot leave a detached gRPC listener behind during failed startup.
+                        if let Some((port, grpc_config)) = mev_grpc_config {
+                            let listen_addr = std::net::SocketAddr::new(mev_grpc_host, port);
+                            let handle = reth_bsc::grpc::mev::start_mev_grpc_server(
+                                listen_addr,
+                                grpc_config,
+                                mev_api,
+                            )?;
+                            *mev_grpc_handle_for_rpc.lock().unwrap() = Some(handle);
+                        }
                         Ok(())
                     })
                     .launch().await?;
@@ -560,7 +622,12 @@ fn main() -> eyre::Result<()> {
             // Set the IPC client
             reth_bsc::shared::set_ipc_client(ipc_path).await.unwrap();
 
-            exit_future.await
+            let grpc_handle = mev_grpc_handle.lock().unwrap().take();
+            let exit_result = exit_future.await;
+            if let Some(handle) = grpc_handle {
+                handle.shutdown().await;
+            }
+            exit_result
         },
     )?;
     Ok(())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -191,6 +191,32 @@ pub struct BscMevMetrics {
     pub bid_interrupt_late_total: Counter,
 }
 
+/// Metrics for the BEP-675 gRPC ingress.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "bsc.mev.grpc")]
+pub struct BscMevGrpcMetrics {
+    /// Total `SendBidBlock` requests that reached the gRPC handler.
+    pub requests_total: Counter,
+
+    /// Total gRPC BidBlock requests rejected by decoding or MEV admission.
+    pub errors_total: Counter,
+
+    /// Total requests rejected because the process-wide concurrency budget was exhausted.
+    pub rejected_total: Counter,
+
+    /// Current number of gRPC BidBlock requests holding an admission permit.
+    pub active_requests: Gauge,
+
+    /// RLP BidBlock decode duration in seconds.
+    pub decode_duration_seconds: Histogram,
+
+    /// End-to-end handler duration in seconds.
+    pub handler_duration_seconds: Histogram,
+
+    /// Submitted RLP payload size in bytes.
+    pub payload_size_bytes: Histogram,
+}
+
 /// Metrics for BSC miner/worker operations
 ///
 /// Tracks block production and finalization metrics.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -217,6 +217,14 @@ pub struct BscMevGrpcMetrics {
     pub payload_size_bytes: Histogram,
 }
 
+/// Live-sync bad-block diagnostics, independent of builder revocation evidence.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "bsc.blockchain")]
+pub struct BscBadBlockMetrics {
+    /// Invalid blocks tagged as BEP-675 BidBlocks, deduplicated by a bounded hash cache.
+    pub bad_bid_blocks_total: Counter,
+}
+
 /// Metrics for BEP-675 cross-validator bad-BidBlock evidence.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "bsc.mev.bid_block_evidence")]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -217,6 +217,16 @@ pub struct BscMevGrpcMetrics {
     pub payload_size_bytes: Histogram,
 }
 
+/// Metrics for BEP-675 cross-validator bad-BidBlock evidence.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "bsc.mev.bid_block_evidence")]
+pub struct BscBidBlockEvidenceMetrics {
+    /// Evidence events dropped because the bounded queue was full.
+    pub dropped_total: Counter,
+    /// Builder revocations triggered after cross-validator evidence reached its threshold.
+    pub revokes_total: Counter,
+}
+
 /// Metrics for BSC miner/worker operations
 ///
 /// Tracks block production and finalization metrics.
@@ -370,6 +380,7 @@ mod tests {
         let _rewards_metrics = BscRewardsMetrics::default();
         let _vote_metrics = BscVoteMetrics::default();
         let _mev_metrics = BscMevMetrics::default();
+        let _bid_block_evidence_metrics = BscBidBlockEvidenceMetrics::default();
         let _miner_metrics = BscMinerMetrics::default();
         let _finality_metrics = BscFinalityMetrics::default();
         let _blockchain_metrics = BscBlockchainMetrics::default();

--- a/src/node/engine_api/bad_block.rs
+++ b/src/node/engine_api/bad_block.rs
@@ -1,0 +1,80 @@
+//! Live-sync bad-block diagnostics. The header's builder tag is self-declared, not proof.
+
+use crate::{
+    metrics::BscBadBlockMetrics,
+    node::miner::block_mev_info::{decode_block_mev_info, BlockMevInfoVersion},
+    BscBlock,
+};
+use alloy_primitives::{Address, B256};
+use lru::LruCache;
+use parking_lot::Mutex;
+use reth_engine_tree::tree::error::{InsertBlockError, InsertBlockErrorKind};
+use std::{num::NonZeroUsize, sync::LazyLock};
+
+static METRICS: LazyLock<BscBadBlockMetrics> = LazyLock::new(BscBadBlockMetrics::default);
+// Separate from revocation evidence: diagnostics also include unauthenticated bad headers.
+static COUNTED: LazyLock<Mutex<LruCache<B256, ()>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(1_000).unwrap())));
+
+fn bid_block_builder(requests_hash: Option<B256>) -> Option<Address> {
+    let (version, builder) = decode_block_mev_info(requests_hash?)?;
+    (version == BlockMevInfoVersion::BidBlock).then_some(builder)
+}
+
+pub(super) fn report(error: &InsertBlockError<BscBlock>) {
+    // Internal/provider errors do not establish that the block is bad.
+    let invalid = match error.kind() {
+        InsertBlockErrorKind::Consensus(_) => true,
+        InsertBlockErrorKind::Execution(error) => error.as_validation().is_some(),
+        _ => false,
+    };
+    if !invalid {
+        return;
+    }
+    let block = error.block();
+    let header = block.header();
+    let builder = bid_block_builder(header.requests_hash);
+    if builder.is_some() && COUNTED.lock().put(block.hash(), ()).is_none() {
+        METRICS.bad_bid_blocks_total.increment(1);
+    }
+    tracing::warn!(
+        target: "bsc::bad_block",
+        invalid_hash = %block.hash(),
+        invalid_number = header.number,
+        miner = %header.beneficiary,
+        requests_hash = ?header.requests_hash,
+        is_bid_block = builder.is_some(),
+        builder = ?builder,
+        validation_err = %error,
+        "Invalid block on live sync"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::miner::block_mev_info::encode_block_mev_info;
+
+    #[test]
+    fn bad_block_only_recognizes_valid_bidblock_tags() {
+        let builder = Address::with_last_byte(1);
+        let tag = encode_block_mev_info(BlockMevInfoVersion::BidBlock, builder);
+        assert_eq!(bid_block_builder(Some(tag)), Some(builder));
+        assert_eq!(bid_block_builder(None), None);
+        assert_eq!(bid_block_builder(Some(B256::ZERO)), None);
+        assert_eq!(
+            bid_block_builder(Some(encode_block_mev_info(BlockMevInfoVersion::Bid, builder))),
+            None
+        );
+        assert_eq!(
+            bid_block_builder(Some(encode_block_mev_info(
+                BlockMevInfoVersion::BidBlock,
+                Address::ZERO
+            ))),
+            None
+        );
+        let mut malformed = tag;
+        malformed[0] = 1;
+        assert_eq!(bid_block_builder(Some(malformed)), None);
+    }
+}

--- a/src/node/engine_api/mod.rs
+++ b/src/node/engine_api/mod.rs
@@ -12,6 +12,7 @@ use reth_node_ethereum::engine::EthPayloadAttributes;
 
 
 pub mod builder;
+mod bad_block;
 pub mod payload;
 pub mod validator;
 

--- a/src/node/engine_api/validator.rs
+++ b/src/node/engine_api/validator.rs
@@ -5,17 +5,30 @@ use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_engine::PayloadError;
 use reth::{
-    api::{FullNodeComponents, NodeTypes},
+    api::{FullNodeComponents, NodeTypes, TreeConfig},
     builder::{
-        rpc::{BasicEngineValidatorBuilder, PayloadValidatorBuilder},
+        invalid_block_hook::InvalidBlockHookExt,
+        rpc::{
+            BasicEngineValidator, ChangesetCache, EngineValidator, EngineValidatorBuilder,
+            PayloadValidatorBuilder,
+        },
         AddOnsContext,
     },
     consensus::ConsensusError,
 };
-use reth_engine_primitives::{ExecutionPayload, PayloadValidator};
-use reth_payload_primitives::NewPayloadError;
-use reth_primitives_traits::{RecoveredBlock, SealedBlock};
-use reth_primitives_traits::Block;
+use reth_chain_state::ExecutedBlock;
+use reth_chainspec::EthChainSpec;
+use reth_engine_primitives::{ExecutionPayload, InvalidBlockHooks, PayloadValidator};
+use reth_engine_tree::tree::{
+    error::{InsertBlockErrorKind, InsertPayloadError},
+    payload_processor::multiproof::StateRootHandle,
+    payload_validator::{TreeCtx, ValidationOutcome},
+    CacheWaitDurations, EngineApiTreeState, SavedCache, WaitForCaches,
+};
+use reth_evm::{ConfigureEngineEvm, ConfigureEvm};
+use reth_payload_primitives::{InvalidPayloadAttributesError, NewPayloadError, PayloadTypes};
+use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
+use reth_provider::HeaderProvider;
 use reth_trie_common::HashedPostState;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, OnceLock};
@@ -37,8 +50,172 @@ where
     }
 }
 
-/// BSC engine validator builder that wraps the payload validator
-pub type BscEngineValidatorBuilder = BasicEngineValidatorBuilder<BscPayloadValidatorBuilder>;
+/// BSC engine validator builder that combines reth's configured invalid-block diagnostics with
+/// the BEP-675 cross-validator bad-BidBlock evidence hook.
+#[derive(Debug, Default, Clone)]
+pub struct BscEngineValidatorBuilder;
+
+impl<Node, Types> EngineValidatorBuilder<Node> for BscEngineValidatorBuilder
+where
+    Types:
+        NodeTypes<ChainSpec = BscChainSpec, Payload = BscPayloadTypes, Primitives = BscPrimitives>,
+    Node: FullNodeComponents<Types = Types, Evm: ConfigureEngineEvm<BscExecutionData>>,
+{
+    type EngineValidator = BscEngineValidatorWithEvidence<Node::Provider, Node::Evm>;
+
+    async fn build_tree_validator(
+        self,
+        ctx: &AddOnsContext<'_, Node>,
+        tree_config: TreeConfig,
+        changeset_cache: ChangesetCache,
+    ) -> eyre::Result<Self::EngineValidator> {
+        let validator = BscPayloadValidatorBuilder.build(ctx).await?;
+        let data_dir = ctx.config.datadir.clone().resolve_datadir(ctx.config.chain.chain());
+        let configured_hook = ctx.create_invalid_block_hook(&data_dir).await?;
+        let evidence_reporter =
+            crate::node::miner::bid_block_evidence::BadBidBlockEvidenceReporter::spawn(
+                ctx.node.provider().clone(),
+                ctx.config.chain.clone(),
+                ctx.node.task_executor(),
+            );
+        // Enqueue evidence first; the configured witness hook may synchronously re-execute the
+        // invalid block and should not delay cross-validator propagation.
+        let invalid_block_hook =
+            InvalidBlockHooks(vec![Box::new(evidence_reporter.clone()), configured_hook]);
+
+        let inner = BasicEngineValidator::new(
+            ctx.node.provider().clone(),
+            Arc::new(ctx.node.consensus().clone()),
+            ctx.node.evm_config().clone(),
+            validator,
+            tree_config,
+            Box::new(invalid_block_hook),
+            changeset_cache,
+            ctx.node.task_executor().clone(),
+        );
+
+        Ok(BscEngineValidatorWithEvidence {
+            inner,
+            provider: ctx.node.provider().clone(),
+            evidence_reporter,
+        })
+    }
+}
+
+/// Adds evidence reporting for execution errors that occur before an execution output exists.
+///
+/// Reth's invalid-block hook covers state-root and post-execution failures. Transaction execution
+/// errors return before that hook can run, so this wrapper observes the final validation outcome.
+/// The inner validator checks the header and body; typed Parlia pre-execution errors are excluded
+/// because they do not establish that the claimed sealer authenticated the block.
+pub struct BscEngineValidatorWithEvidence<P, Evm: ConfigureEvm> {
+    inner: BasicEngineValidator<P, Evm, BscEngineValidator>,
+    provider: P,
+    evidence_reporter: crate::node::miner::bid_block_evidence::BadBidBlockEvidenceReporter,
+}
+
+impl<P, Evm> BscEngineValidatorWithEvidence<P, Evm>
+where
+    P: HeaderProvider<Header = alloy_consensus::Header>,
+    Evm: ConfigureEvm,
+{
+    fn report_execution_error(&self, outcome: &ValidationOutcome<BscPrimitives>) {
+        let Err(InsertPayloadError::Block(error)) = outcome else { return };
+        let InsertBlockErrorKind::Execution(execution_error) = error.kind() else { return };
+        if !crate::node::evm::error::is_execution_evidence(execution_error) {
+            return;
+        }
+
+        let block = error.block();
+        match self.provider.sealed_header_by_hash(block.parent_hash()) {
+            Ok(Some(parent)) => self.evidence_reporter.report(&parent, block),
+            Ok(None) => tracing::debug!(
+                target: "bsc::bid_block_evidence",
+                parent_hash = %block.parent_hash(),
+                block_hash = %block.hash(),
+                "Parent header unavailable for bad BidBlock evidence"
+            ),
+            Err(err) => tracing::warn!(
+                target: "bsc::bid_block_evidence",
+                parent_hash = %block.parent_hash(),
+                block_hash = %block.hash(),
+                %err,
+                "Failed to load parent header for bad BidBlock evidence"
+            ),
+        }
+    }
+}
+
+impl<P, Evm> EngineValidator<BscPayloadTypes, BscPrimitives>
+    for BscEngineValidatorWithEvidence<P, Evm>
+where
+    BasicEngineValidator<P, Evm, BscEngineValidator>:
+        EngineValidator<BscPayloadTypes, BscPrimitives>,
+    P: HeaderProvider<Header = alloy_consensus::Header> + Send + Sync + 'static,
+    Evm: ConfigureEvm + Send + Sync + 'static,
+{
+    fn validate_payload_attributes_against_header(
+        &self,
+        attr: &<BscPayloadTypes as PayloadTypes>::PayloadAttributes,
+        header: &alloy_consensus::Header,
+    ) -> Result<(), InvalidPayloadAttributesError> {
+        self.inner.validate_payload_attributes_against_header(attr, header)
+    }
+
+    fn convert_payload_to_block(
+        &self,
+        payload: BscExecutionData,
+    ) -> Result<SealedBlock<BscBlock>, NewPayloadError> {
+        self.inner.convert_payload_to_block(payload)
+    }
+
+    fn validate_payload(
+        &mut self,
+        payload: BscExecutionData,
+        ctx: TreeCtx<'_, BscPrimitives>,
+    ) -> ValidationOutcome<BscPrimitives> {
+        let outcome = self.inner.validate_payload(payload, ctx);
+        self.report_execution_error(&outcome);
+        outcome
+    }
+
+    fn validate_block(
+        &mut self,
+        block: SealedBlock<BscBlock>,
+        ctx: TreeCtx<'_, BscPrimitives>,
+    ) -> ValidationOutcome<BscPrimitives> {
+        let outcome = self.inner.validate_block(block, ctx);
+        self.report_execution_error(&outcome);
+        outcome
+    }
+
+    fn on_inserted_executed_block(&self, block: ExecutedBlock<BscPrimitives>) {
+        self.inner.on_inserted_executed_block(block)
+    }
+
+    fn cache_for(&self, block_hash: B256) -> Option<SavedCache> {
+        self.inner.cache_for(block_hash)
+    }
+
+    fn sparse_trie_handle_for(
+        &self,
+        parent_hash: B256,
+        parent_state_root: B256,
+        state: &EngineApiTreeState<BscPrimitives>,
+    ) -> Option<StateRootHandle> {
+        self.inner.sparse_trie_handle_for(parent_hash, parent_state_root, state)
+    }
+}
+
+impl<P, Evm> WaitForCaches for BscEngineValidatorWithEvidence<P, Evm>
+where
+    BasicEngineValidator<P, Evm, BscEngineValidator>: WaitForCaches,
+    Evm: ConfigureEvm,
+{
+    fn wait_for_caches(&self) -> CacheWaitDurations {
+        self.inner.wait_for_caches()
+    }
+}
 
 /// Validator for Optimism engine API.
 #[derive(Debug, Clone)]

--- a/src/node/engine_api/validator.rs
+++ b/src/node/engine_api/validator.rs
@@ -119,8 +119,9 @@ where
     P: HeaderProvider<Header = alloy_consensus::Header>,
     Evm: ConfigureEvm,
 {
-    fn report_execution_error(&self, outcome: &ValidationOutcome<BscPrimitives>) {
+    fn report_invalid_block(&self, outcome: &ValidationOutcome<BscPrimitives>) {
         let Err(InsertPayloadError::Block(error)) = outcome else { return };
+        super::bad_block::report(error);
         let InsertBlockErrorKind::Execution(execution_error) = error.kind() else { return };
         if !crate::node::evm::error::is_execution_evidence(execution_error) {
             return;
@@ -175,7 +176,7 @@ where
         ctx: TreeCtx<'_, BscPrimitives>,
     ) -> ValidationOutcome<BscPrimitives> {
         let outcome = self.inner.validate_payload(payload, ctx);
-        self.report_execution_error(&outcome);
+        self.report_invalid_block(&outcome);
         outcome
     }
 
@@ -185,7 +186,7 @@ where
         ctx: TreeCtx<'_, BscPrimitives>,
     ) -> ValidationOutcome<BscPrimitives> {
         let outcome = self.inner.validate_block(block, ctx);
-        self.report_execution_error(&outcome);
+        self.report_invalid_block(&outcome);
         outcome
     }
 

--- a/src/node/evm/error.rs
+++ b/src/node/evm/error.rs
@@ -6,6 +6,76 @@ use reth_evm::execute::{BlockExecutionError, BlockValidationError};
 use reth_provider::ProviderError;
 use reth_primitives_traits::{GotExpected, GotExpectedBoxed};
 
+/// A validation failure before Parlia has authenticated the imported block.
+/// Keep this typed across the engine boundary: it invalidates the block, but cannot be used
+/// as evidence against the builder named in its untrusted header.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct PreExecutionValidationError(BlockValidationError);
+
+pub(crate) fn mark_pre_execution_error(error: BlockExecutionError) -> BlockExecutionError {
+    match error {
+        BlockExecutionError::Validation(error) => BlockExecutionError::Validation(
+            BlockValidationError::Other(Box::new(PreExecutionValidationError(error))),
+        ),
+        internal => internal,
+    }
+}
+
+pub(crate) fn is_execution_evidence(error: &BlockExecutionError) -> bool {
+    match error {
+        BlockExecutionError::Validation(BlockValidationError::Other(error)) => {
+            !error.is::<PreExecutionValidationError>()
+        }
+        BlockExecutionError::Validation(_) => true,
+        BlockExecutionError::Internal(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod bid_block_evidence_tests {
+    use super::*;
+
+    #[test]
+    fn unauthenticated_seal_errors_cannot_be_evidence() {
+        let failures = [
+            BscBlockValidationError::WrongHeaderSigner {
+                block_number: 1,
+                signer: GotExpected {
+                    got: Address::with_last_byte(1),
+                    expected: Address::with_last_byte(2),
+                }
+                .into(),
+            },
+            BscBlockValidationError::SignerUnauthorized {
+                block_number: 1,
+                proposer: Address::with_last_byte(1),
+            },
+            BscBlockValidationError::InvalidAttestationSignature,
+        ];
+        for failure in failures {
+            let error: BlockExecutionError = BscBlockExecutionError::Validation(failure).into();
+            let marked = mark_pre_execution_error(error);
+            assert!(marked.as_validation().is_some(), "must still invalidate the block");
+            assert!(!is_execution_evidence(&marked), "must never count unauthenticated evidence");
+        }
+    }
+
+    #[test]
+    fn execution_failures_are_evidence_but_internal_errors_are_not() {
+        let error = BlockExecutionError::Validation(
+            BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                transaction_gas_limit: 100,
+                block_available_gas: 10,
+            },
+        );
+        assert!(is_execution_evidence(&error));
+        let error = mark_pre_execution_error(BlockExecutionError::msg("parent state unavailable"));
+        assert!(error.as_internal().is_some());
+        assert!(!is_execution_evidence(&error));
+    }
+}
+
 /// BSC specific block validation error
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum BscBlockValidationError {

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -470,7 +470,8 @@ where
         if self.ctx.mode.authors_block() {
             self.prepare_new_block(&block_env)?;
         } else {
-            self.check_new_block(&block_env)?;
+            self.check_new_block(&block_env)
+                .map_err(crate::node::evm::error::mark_pre_execution_error)?;
         }
 
         let parent_timestamp = self.inner_ctx.parent_header.as_ref().unwrap().timestamp;

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -104,6 +104,9 @@ where
 
 /// Classify `address` against the full cabinet-first validator set at `parent`, returning
 /// the cabinet and total counts for this event's majority thresholds.
+///
+/// The counts are returned even when `address` is absent ([`ValidatorRole::None`]) so callers
+/// can fall back to another membership source without losing the thresholds in force.
 pub(crate) fn validator_role_at_parent<S, Spec>(
     state: S,
     spec: Spec,
@@ -122,10 +125,6 @@ where
     let validators = system_contracts
         .unpack_all_validators(&output)
         .map_err(BlockExecutionError::msg)?;
-    let Some(index) = validators.iter().position(|validator| *validator == address) else {
-        return Ok((ValidatorRole::None, 0, 0));
-    };
-
     let (to, data) = system_contracts.get_num_of_cabinets();
     let output = view_call_at_header(&mut db, &spec, parent.header(), to, data)?;
     let configured_cabinets =
@@ -138,7 +137,11 @@ where
         };
 
     let cabinets = configured_cabinets.min(validators.len());
-    Ok((classify_working_validator(index, validators.len(), cabinets), cabinets, validators.len()))
+    let role = match validators.iter().position(|validator| *validator == address) {
+        Some(index) => classify_working_validator(index, validators.len(), cabinets),
+        None => ValidatorRole::None,
+    };
+    Ok((role, cabinets, validators.len()))
 }
 
 #[cfg(test)]

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -35,6 +35,43 @@ const BLST_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
 pub type EpochValidators = (Vec<Address>, Vec<VoteAddress>);
 
+/// An address's role in the validator set used for BEP-675 bad-block evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValidatorRole {
+    /// The address is not in the validator set.
+    None,
+    /// The address is in the cabinet prefix of the validator set.
+    Cabinet,
+    /// The address is a candidate validator outside the cabinet prefix.
+    Candidate,
+}
+
+impl std::fmt::Display for ValidatorRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::None => "none",
+            Self::Cabinet => "cabinet",
+            Self::Candidate => "candidate",
+        })
+    }
+}
+
+/// Fallback used by `BSCValidatorSet` while `numOfCabinets` is unset.
+const INIT_NUM_OF_CABINETS: usize = 21;
+
+fn classify_working_validator(
+    index: usize,
+    validator_count: usize,
+    cabinet_count: usize,
+) -> ValidatorRole {
+    let guaranteed_cabinets = cabinet_count.min(validator_count);
+    if index < guaranteed_cabinets {
+        ValidatorRole::Cabinet
+    } else {
+        ValidatorRole::Candidate
+    }
+}
+
 type ValidatorCache = LruMap<BlockHash, EpochValidators, ByLength>;
 type TurnLengthCache = LruMap<BlockHash, u8, ByLength>;
 
@@ -47,7 +84,7 @@ pub static TURN_LENGTH_CACHE: LazyLock<Mutex<TurnLengthCache>> = LazyLock::new(|
 });
 
 /// Runs a read-only system-contract call in `header`'s env over `header`'s post-state.
-fn view_call_at_header<DB, Spec>(
+pub(crate) fn view_call_at_header<DB, Spec>(
     db: DB,
     spec: &Spec,
     header: &Header,
@@ -63,6 +100,62 @@ where
     // Use `Evm::transact` so system-transaction overrides still apply.
     let result = Evm::transact(&mut evm, tx_env).map_err(BlockExecutionError::other)?.result;
     view_call_output(to, &data, result)
+}
+
+/// Classify `address` against the full cabinet-first validator set at `parent`, returning
+/// the cabinet and total counts for this event's majority thresholds.
+pub(crate) fn validator_role_at_parent<S, Spec>(
+    state: S,
+    spec: Spec,
+    parent: &SealedHeader,
+    address: Address,
+) -> Result<(ValidatorRole, usize, usize), BlockExecutionError>
+where
+    S: EvmStateProvider,
+    Spec: EthChainSpec + crate::hardforks::BscHardforks + Clone,
+{
+    let mut db = State::builder().with_database(StateProviderDatabase::new(state)).build();
+    let system_contracts = SystemContract::new(spec.clone());
+
+    let (to, data) = system_contracts.get_all_validators();
+    let output = view_call_at_header(&mut db, &spec, parent.header(), to, data)?;
+    let validators = system_contracts
+        .unpack_all_validators(&output)
+        .map_err(BlockExecutionError::msg)?;
+    let Some(index) = validators.iter().position(|validator| *validator == address) else {
+        return Ok((ValidatorRole::None, 0, 0));
+    };
+
+    let (to, data) = system_contracts.get_num_of_cabinets();
+    let output = view_call_at_header(&mut db, &spec, parent.header(), to, data)?;
+    let configured_cabinets =
+        system_contracts.unpack_num_of_cabinets(&output).map_err(BlockExecutionError::msg)?;
+    let configured_cabinets =
+        if configured_cabinets.is_zero() || configured_cabinets > U256::from(i64::MAX as u64) {
+            INIT_NUM_OF_CABINETS
+        } else {
+            usize::try_from(configured_cabinets).unwrap_or(INIT_NUM_OF_CABINETS)
+        };
+
+    let cabinets = configured_cabinets.min(validators.len());
+    Ok((classify_working_validator(index, validators.len(), cabinets), cabinets, validators.len()))
+}
+
+#[cfg(test)]
+mod bid_block_evidence_tests {
+    use super::*;
+
+    #[test]
+    fn full_set_uses_cabinet_prefix() {
+        assert_eq!(classify_working_validator(20, 45, 21), ValidatorRole::Cabinet);
+        assert_eq!(classify_working_validator(21, 45, 21), ValidatorRole::Candidate);
+        assert_eq!(classify_working_validator(44, 45, 21), ValidatorRole::Candidate);
+    }
+
+    #[test]
+    fn cabinet_prefix_is_capped_by_set_size() {
+        assert_eq!(classify_working_validator(4, 5, 21), ValidatorRole::Cabinet);
+    }
 }
 
 /// `getMiningValidators()` on `parent`'s post-state in `parent`'s env.

--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -542,11 +542,11 @@ pub fn validate_bid_block_average_gas_price<R: alloy_consensus::TxReceipt>(
 /// Pre-seal verification of an admitted BidBlock (go-bsc `bidSimulator.preSealVerifyBidBlock`).
 ///
 /// Runs the cheap checks a validator makes before sealing a builder block, in go-bsc's order:
-/// coinbase is the validator, gas limit matches the in-turn target, the header is a valid unsealed
-/// Parlia header, the timestamp is within the slot, the deposit (gas-fee) value is non-zero, blob
-/// sidecars are well-formed, no user tx exceeds the per-tx gas cap, and the trailing system-tx
-/// region is valid. KZG proofs and parent-relative cascading fields are re-checked at block
-/// insertion. Returns the located `(system_tx_start, gas_fee)`.
+/// state root is non-zero, coinbase is the validator, gas limit matches the in-turn target, the
+/// header is a valid unsealed Parlia header, the timestamp is within the slot, the deposit
+/// (gas-fee) value is non-zero, blob sidecars are well-formed, no user tx exceeds the per-tx gas
+/// cap, and the trailing system-tx region is valid. KZG proofs and parent-relative cascading fields
+/// are re-checked at block insertion. Returns the located `(system_tx_start, gas_fee)`.
 ///
 /// `expected_gas_limit` is the caller's `calculate_block_gas_limit(parent.gas_limit, ceil)` (reth's
 /// `core.CalcGasLimit`); `etherbase` is the validator address; `snap` is the parent's snapshot.
@@ -560,6 +560,10 @@ pub fn pre_seal_verify_bid_block(
     etherbase: Address,
     expected_gas_limit: u64,
 ) -> Result<(usize, U256), PreSealVerifyError> {
+    // bsc #3798: reject the sentinel root before doing any Parlia or payload work. Builders must
+    // commit to their expected post-state even though zero-simulate verifies it after broadcast.
+    verify_bid_block_state_root(&decoded.header)?;
+
     // go-bsc checks coinbase/gasLimit before VerifyUnsealedHeader (see preSealVerifyBidBlock) —
     // matters now that verify_bid_block_header's cascading checks depend on the header's coinbase
     // too, so a header with a *wrong* coinbase must surface `InvalidCoinbase`, not
@@ -660,6 +664,9 @@ pub fn verify_bid_block_payload(
     expected_gas_limit: u64,
 ) -> Result<(usize, U256), PreSealVerifyError> {
     let header = &decoded.header;
+    // This is the production admission/simulation seam in reth-bsc. Keep the same cheap guard here
+    // as in `pre_seal_verify_bid_block` so both the synchronous RPC path and miner path benefit.
+    verify_bid_block_state_root(header)?;
     verify_bid_block_coinbase_and_gas_limit(header, etherbase, expected_gas_limit)?;
 
     // go-bsc `preSealVerifyBidBlock`: `DeriveSha(decoded.Txs) == header.TxHash`.
@@ -711,9 +718,18 @@ pub fn verify_bid_block_payload(
     Ok((system_tx_start, gas_fee))
 }
 
+fn verify_bid_block_state_root(header: &Header) -> Result<(), PreSealVerifyError> {
+    if header.state_root == B256::ZERO {
+        return Err(PreSealVerifyError::ZeroStateRoot);
+    }
+    Ok(())
+}
+
 /// Why an admitted BidBlock failed pre-seal verification (see [`pre_seal_verify_bid_block`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PreSealVerifyError {
+    /// Builder supplied the zero state-root sentinel (bsc #3798).
+    ZeroStateRoot,
     /// Header coinbase is not the in-turn validator.
     InvalidCoinbase { got: Address, want: Address },
     /// Header gas limit does not equal the in-turn target.
@@ -744,6 +760,9 @@ pub enum PreSealVerifyError {
 impl fmt::Display for PreSealVerifyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::ZeroStateRoot => {
+                write!(f, "bid block rejected due to zero state root")
+            }
             Self::InvalidCoinbase { got, want } => {
                 write!(f, "invalid coinbase: got {got}, want {want}")
             }
@@ -1509,6 +1528,7 @@ mod tests {
             beneficiary: etherbase,
             gas_limit,
             gas_used: 21_000,
+            state_root: B256::repeat_byte(0x44),
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
             extra_data: Bytes::from(vec![0u8; 32 + 65]),
             // `snap_with_interval`'s lone validator is always in-turn (a single-member set has
@@ -1661,6 +1681,33 @@ mod tests {
                 header.gas_limit
             ),
             Ok((1, U256::from(100)))
+        );
+    }
+
+    #[test]
+    fn pre_seal_rejects_zero_state_root_before_other_checks() {
+        let spec = preseal_spec();
+        let parlia = parlia_engine(spec.clone());
+        let snap = snap_with_interval(3_000);
+        let etherbase = Address::repeat_byte(0x11);
+        // Deliberately also use the wrong coinbase: bsc #3798 requires the zero-root rejection to
+        // win because it is the first pre-seal check.
+        let mut header = valid_bid_header(Address::repeat_byte(0x22), 30_000_000);
+        header.state_root = B256::ZERO;
+        let parent = Header { number: 0, timestamp: 1, gas_limit: 30_000_000, ..Default::default() };
+        let d = decoded_block(header, vec![], vec![]);
+
+        assert_eq!(
+            pre_seal_verify_bid_block(&parlia, &spec, &d, &parent, &snap, etherbase, 30_000_000),
+            Err(PreSealVerifyError::ZeroStateRoot)
+        );
+        assert_eq!(
+            verify_bid_block_payload(&spec, &d, &parent, etherbase, 30_000_000),
+            Err(PreSealVerifyError::ZeroStateRoot)
+        );
+        assert_eq!(
+            PreSealVerifyError::ZeroStateRoot.to_string(),
+            "bid block rejected due to zero state root"
         );
     }
 

--- a/src/node/miner/bid_block.rs
+++ b/src/node/miner/bid_block.rs
@@ -28,7 +28,7 @@ use alloy_consensus::transaction::RlpEcdsaDecodableTx;
 use alloy_consensus::{Header, Transaction, TxLegacy};
 use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::{keccak256, Address, Bytes, Signature, B256, U256};
-use alloy_rlp::Decodable;
+use alloy_rlp::{Decodable, Encodable};
 use reth::primitives::SealedHeader;
 use reth_chainspec::EthChainSpec;
 use reth_ethereum_primitives::{BlockBody, TransactionSigned};
@@ -59,6 +59,46 @@ pub struct BidBlock {
     /// Blob sidecars for any blob transactions (empty/omitted when there are none).
     #[serde(default)]
     pub sidecars: Vec<BscBlobTransactionSidecar>,
+}
+
+// go-bsc transports BidBlock over gRPC as the ordinary RLP encoding of its three exported fields:
+// [header, transactions, sidecars]. Keep this implementation on the domain type so the gRPC path
+// and any future binary ingress cannot drift from the structure builders encode with geth/rlp.
+impl Encodable for BidBlock {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        let payload_length =
+            self.header.length() + self.transactions.length() + self.sidecars.length();
+        alloy_rlp::Header { list: true, payload_length }.encode(out);
+        self.header.encode(out);
+        self.transactions.encode(out);
+        self.sidecars.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length =
+            self.header.length() + self.transactions.length() + self.sidecars.length();
+        alloy_rlp::Header { list: true, payload_length }.length() + payload_length
+    }
+}
+
+impl Decodable for BidBlock {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+
+        let block = Self {
+            header: Header::decode(buf)?,
+            transactions: Vec::<Bytes>::decode(buf)?,
+            sidecars: Vec::<BscBlobTransactionSidecar>::decode(buf)?,
+        };
+        if remaining.saturating_sub(buf.len()) != header.payload_length {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(block)
+    }
 }
 
 impl BidBlock {
@@ -939,8 +979,6 @@ pub fn simulate_bid_block(
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Needed by the hand-rolled RLP fixtures below; the production path no longer RLP-encodes.
-    use alloy_rlp::Encodable;
     use alloy_primitives::{address, b256, bytes, hex};
 
     /// Repro for the blob-BidBlock admission stack overflow: run the decode+hash path a tokio
@@ -1037,6 +1075,21 @@ mod tests {
             h.extra_data = Bytes::from(vec![0u8; 32]);
         });
         BidBlock { header, transactions: Vec::new(), sidecars: Vec::new() }
+    }
+
+    #[test]
+    fn bid_block_rlp_roundtrip_matches_grpc_wire_shape() {
+        let block = BidBlock {
+            header: vector_a_block().header,
+            transactions: vec![bytes!("0x010203"), bytes!("0xdeadbeef")],
+            sidecars: Vec::new(),
+        };
+        let encoded = alloy_rlp::encode(&block);
+        let mut input = encoded.as_slice();
+        let decoded = BidBlock::decode(&mut input).unwrap();
+
+        assert!(input.is_empty(), "BidBlock decoder must consume one complete RLP value");
+        assert_eq!(decoded, block);
     }
 
     #[test]

--- a/src/node/miner/bid_block_evidence.rs
+++ b/src/node/miner/bid_block_evidence.rs
@@ -1,0 +1,416 @@
+//! Cross-validator bad-BidBlock evidence for BEP-675.
+//!
+//! A local validator revokes a builder immediately when its own blind-signed BidBlock fails
+//! post-broadcast verification. This module also observes execution-invalid BidBlocks sealed by
+//! other validators. Once distinct sealers reach the cabinet or total-validator threshold within
+//! 24 hours, the builder is revoked locally before it can burn this validator's slot.
+
+use crate::{
+    chainspec::BscChainSpec,
+    metrics::BscBidBlockEvidenceMetrics,
+    node::{
+        evm::pre_execution::{validator_role_at_parent, ValidatorRole},
+        miner::block_mev_info::{decode_block_mev_info, BlockMevInfoVersion},
+        primitives::{BscBlock, BscPrimitives},
+    },
+    shared,
+};
+use alloy_consensus::{BlockHeader, Header};
+use alloy_primitives::{Address, B256};
+use lru::LruCache;
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use reth_engine_primitives::InvalidBlockHook;
+use reth_ethereum_primitives::Receipt;
+use reth_execution_types::BlockExecutionOutput;
+use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
+use reth_provider::StateProviderFactory;
+use reth_tasks::TaskExecutor;
+use reth_trie_common::updates::TrieUpdates;
+use std::{
+    collections::HashMap,
+    num::NonZeroUsize,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::sync::mpsc;
+
+const EVIDENCE_WINDOW: Duration = Duration::from_secs(24 * 60 * 60);
+const EVIDENCE_QUEUE_SIZE: usize = 64;
+const EVIDENCED_BLOCK_CACHE_SIZE: usize = 1_000;
+
+const fn majority_threshold(validators: usize) -> usize {
+    validators / 2 + 1
+}
+
+static EVIDENCE_METRICS: Lazy<BscBidBlockEvidenceMetrics> =
+    Lazy::new(BscBidBlockEvidenceMetrics::default);
+
+#[derive(Debug)]
+struct BadBidBlockEvidence {
+    builder: Address,
+    sealer: Address,
+    hash: B256,
+    number: u64,
+    parent: SealedHeader<Header>,
+}
+
+/// A lightweight engine-tree hook. Contract reads and threshold accounting happen on the
+/// background consumer so invalid-block handling never waits for them.
+#[derive(Clone)]
+pub(crate) struct BadBidBlockEvidenceReporter {
+    sender: mpsc::Sender<BadBidBlockEvidence>,
+    evidenced: Arc<Mutex<LruCache<B256, ()>>>,
+}
+
+impl BadBidBlockEvidenceReporter {
+    pub(crate) fn spawn<P>(
+        provider: P,
+        chain_spec: Arc<BscChainSpec>,
+        task_executor: &TaskExecutor,
+    ) -> Self
+    where
+        P: StateProviderFactory + Clone + Send + Sync + 'static,
+    {
+        let (sender, receiver) = mpsc::channel(EVIDENCE_QUEUE_SIZE);
+        task_executor.spawn_critical_task(
+            "bad bid block evidence",
+            run_evidence_service(receiver, provider, chain_spec),
+        );
+
+        Self::new(sender)
+    }
+
+    fn new(sender: mpsc::Sender<BadBidBlockEvidence>) -> Self {
+        Self {
+            sender,
+            evidenced: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(EVIDENCED_BLOCK_CACHE_SIZE).unwrap(),
+            ))),
+        }
+    }
+
+    fn evidence_for(
+        parent_header: &SealedHeader<Header>,
+        block: &SealedBlock<BscBlock>,
+    ) -> Option<BadBidBlockEvidence> {
+        let tag = block.header().requests_hash?;
+        let (version, builder) = decode_block_mev_info(tag)?;
+        if version != BlockMevInfoVersion::BidBlock {
+            return None;
+        }
+
+        Some(BadBidBlockEvidence {
+            builder,
+            sealer: block.header().beneficiary,
+            hash: block.hash(),
+            number: block.number(),
+            // The hook is invoked only after pre-execution validation has succeeded. This parent
+            // therefore anchors both the execution state and the validator set that authorized
+            // the sealer.
+            parent: parent_header.clone(),
+        })
+    }
+
+    pub(crate) fn report(
+        &self,
+        parent_header: &SealedHeader<Header>,
+        block: &SealedBlock<BscBlock>,
+    ) {
+        let Some(evidence) = Self::evidence_for(parent_header, block) else { return };
+
+        // Keep check-and-insert atomic across hook/reporter clones. As in BSC, even a dropped
+        // event is remembered so repeated announcements cannot crowd the queue.
+        {
+            let mut evidenced = self.evidenced.lock();
+            if evidenced.contains(&evidence.hash) {
+                return;
+            }
+            evidenced.put(evidence.hash, ());
+        }
+        match self.sender.try_send(evidence) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(evidence)) => {
+                EVIDENCE_METRICS.dropped_total.increment(1);
+                tracing::warn!(
+                    target: "bsc::bid_block_evidence",
+                    hash = %evidence.hash,
+                    "Bad BidBlock evidence dropped, queue full"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(evidence)) => {
+                tracing::warn!(
+                    target: "bsc::bid_block_evidence",
+                    builder = %evidence.builder,
+                    number = evidence.number,
+                    hash = %evidence.hash,
+                    "Bad BidBlock evidence service is unavailable"
+                );
+            }
+        }
+    }
+}
+
+impl InvalidBlockHook<BscPrimitives> for BadBidBlockEvidenceReporter {
+    fn on_invalid_block(
+        &self,
+        parent_header: &SealedHeader<Header>,
+        block: &RecoveredBlock<BscBlock>,
+        _output: &BlockExecutionOutput<Receipt>,
+        _trie_updates: Option<(&TrieUpdates, B256)>,
+    ) {
+        self.report(parent_header, block.sealed_block())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Sighting {
+    at: Instant,
+    cabinet: bool,
+}
+
+#[derive(Debug, Default)]
+struct BadBidBlockTracker {
+    seen: HashMap<Address, HashMap<Address, Sighting>>,
+}
+
+impl BadBidBlockTracker {
+    /// Repeat sightings from one sealer refresh its timestamp without adding another vote. Cabinet
+    /// membership is sticky inside the window so a later demotion cannot reduce collected proof.
+    fn add(
+        &mut self,
+        builder: Address,
+        sealer: Address,
+        cabinet: bool,
+        now: Instant,
+    ) -> (usize, usize) {
+        let sightings = self.seen.entry(builder).or_default();
+        let previous = sightings.get(&sealer).copied();
+        sightings.insert(
+            sealer,
+            Sighting { at: now, cabinet: previous.is_some_and(|s| s.cabinet) || cabinet },
+        );
+
+        sightings.retain(|_, sighting| now.duration_since(sighting.at) < EVIDENCE_WINDOW);
+        let total = sightings.len();
+        let cabinet = sightings.values().filter(|sighting| sighting.cabinet).count();
+        (cabinet, total)
+    }
+
+    fn clear(&mut self, builder: Address) {
+        self.seen.remove(&builder);
+    }
+}
+
+async fn run_evidence_service<P>(
+    mut receiver: mpsc::Receiver<BadBidBlockEvidence>,
+    provider: P,
+    chain_spec: Arc<BscChainSpec>,
+) where
+    P: StateProviderFactory + Clone + Send + Sync + 'static,
+{
+    let mut tracker = BadBidBlockTracker::default();
+
+    while let Some(evidence) = receiver.recv().await {
+        let Some(config) = crate::node::miner::config::get_global_mining_config() else { continue };
+        if !config.enabled || !config.bid_block_enabled {
+            continue;
+        }
+
+        let permissions = shared::get_bid_block_permission_manager();
+        if !permissions.is_allowed(evidence.builder) {
+            continue;
+        }
+
+        let state = match provider.state_by_block_hash(evidence.parent.hash()) {
+            Ok(state) => state,
+            Err(err) => {
+                tracing::warn!(
+                    target: "bsc::bid_block_evidence",
+                    builder = %evidence.builder,
+                    sealer = %evidence.sealer,
+                    parent_hash = %evidence.parent.hash(),
+                    %err,
+                    "Failed to open parent state for bad BidBlock evidence"
+                );
+                continue;
+            }
+        };
+        let (role, cabinet_count, total_count) = match validator_role_at_parent(
+            state,
+            chain_spec.as_ref().clone(),
+            &evidence.parent,
+            evidence.sealer,
+        ) {
+            Ok(result) => result,
+            Err(err) => {
+                tracing::warn!(
+                    target: "bsc::bid_block_evidence",
+                    builder = %evidence.builder,
+                    sealer = %evidence.sealer,
+                    %err,
+                    "Validator lookup failed for bad BidBlock evidence"
+                );
+                continue;
+            }
+        };
+        if role == ValidatorRole::None {
+            tracing::debug!(
+                target: "bsc::bid_block_evidence",
+                builder = %evidence.builder,
+                sealer = %evidence.sealer,
+                number = evidence.number,
+                "Bad BidBlock sealer is not in the parent validator set"
+            );
+            continue;
+        }
+
+        let (cabinet_votes, total_votes) = tracker.add(
+            evidence.builder,
+            evidence.sealer,
+            role == ValidatorRole::Cabinet,
+            Instant::now(),
+        );
+        let cabinet_threshold = majority_threshold(cabinet_count);
+        let total_threshold = majority_threshold(total_count);
+        if cabinet_votes < cabinet_threshold && total_votes < total_threshold {
+            tracing::info!(
+                target: "bsc::bid_block_evidence",
+                builder = %evidence.builder,
+                sealer = %evidence.sealer,
+                role = %role,
+                number = evidence.number,
+                hash = %evidence.hash,
+                cabinet_votes,
+                cabinet_threshold,
+                total_votes,
+                total_threshold,
+                "Recorded bad BidBlock evidence"
+            );
+            continue;
+        }
+
+        let reason =
+            format!("bad BidBlocks from {cabinet_votes}/{cabinet_threshold} cabinet and {total_votes}/{total_threshold} total validators");
+        tracing::error!(
+            target: "bsc::bid_block_evidence",
+            builder = %evidence.builder,
+            cabinet_votes,
+            cabinet_threshold,
+            total_votes,
+            total_threshold,
+            last_sealer = %evidence.sealer,
+            number = evidence.number,
+            hash = %evidence.hash,
+            "Revoking builder based on cross-validator bad BidBlock evidence"
+        );
+        permissions.revoke(evidence.builder, reason, evidence.hash, evidence.number);
+        EVIDENCE_METRICS.revokes_total.increment(1);
+        tracker.clear(evidence.builder);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{miner::block_mev_info::encode_block_mev_info, primitives::BscBlockBody};
+    use reth_ethereum_primitives::BlockBody;
+
+    fn address(n: u8) -> Address {
+        Address::with_last_byte(n)
+    }
+
+    fn recovered_block(version: BlockMevInfoVersion) -> RecoveredBlock<BscBlock> {
+        let header = Header {
+            beneficiary: address(9),
+            number: 7,
+            requests_hash: Some(encode_block_mev_info(version, address(0xb0))),
+            ..Default::default()
+        };
+        RecoveredBlock::new_unhashed(
+            BscBlock {
+                header,
+                body: BscBlockBody {
+                    inner: BlockBody {
+                        transactions: Vec::new(),
+                        ommers: Vec::new(),
+                        withdrawals: None,
+                    },
+                    sidecars: None,
+                },
+            },
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn evidence_only_accepts_bid_block_tags() {
+        let parent_header = Header::default();
+        let parent = SealedHeader::new(parent_header.clone(), parent_header.hash_slow());
+
+        let evidence = BadBidBlockEvidenceReporter::evidence_for(
+            &parent,
+            recovered_block(BlockMevInfoVersion::BidBlock).sealed_block(),
+        )
+        .unwrap();
+        assert_eq!(evidence.builder, address(0xb0));
+        assert_eq!(evidence.sealer, address(9));
+        assert_eq!(evidence.number, 7);
+
+        assert!(BadBidBlockEvidenceReporter::evidence_for(
+            &parent,
+            recovered_block(BlockMevInfoVersion::Bid).sealed_block(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn tracker_counts_distinct_sealers_and_expires_old_sightings() {
+        let mut tracker = BadBidBlockTracker::default();
+        let start = Instant::now();
+        let builder = address(0xb0);
+
+        tracker.add(builder, address(1), true, start);
+        tracker.add(builder, address(1), true, start);
+        assert_eq!(tracker.add(builder, address(2), false, start), (1, 2));
+
+        let later = start + EVIDENCE_WINDOW + Duration::from_secs(1);
+        assert_eq!(tracker.add(builder, address(3), false, later), (0, 1));
+    }
+
+    #[test]
+    fn cabinet_membership_is_sticky_inside_the_window() {
+        let mut tracker = BadBidBlockTracker::default();
+        let now = Instant::now();
+        let builder = address(0xb0);
+        tracker.add(builder, address(1), true, now);
+        assert_eq!(tracker.add(builder, address(1), false, now), (1, 1));
+    }
+
+    #[test]
+    fn revoke_thresholds_match_bsc() {
+        assert_eq!(majority_threshold(21), 11);
+        assert_eq!(majority_threshold(45), 23);
+        assert_eq!(majority_threshold(3), 2);
+        assert_eq!(majority_threshold(4), 3);
+    }
+
+    #[test]
+    fn queue_is_bounded_and_clones_deduplicate_before_enqueue() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let reporter = BadBidBlockEvidenceReporter::new(sender);
+        let parent = SealedHeader::seal_slow(Header::default());
+        let first = recovered_block(BlockMevInfoVersion::BidBlock);
+        reporter.report(&parent, first.sealed_block());
+        reporter.clone().report(&parent, first.sealed_block());
+        assert_eq!(receiver.len(), 1);
+        let mut second = first.clone().into_sealed_block().into_block();
+        second.header.number += 1;
+        let second = SealedBlock::seal_slow(second);
+        reporter.report(&parent, &second); // Full: dropped without blocking.
+        assert_eq!(receiver.len(), 1);
+        assert_eq!(receiver.try_recv().unwrap().hash, first.hash());
+        reporter.report(&parent, &second); // A dropped hash is also deduplicated.
+        assert!(receiver.try_recv().is_err());
+    }
+}

--- a/src/node/miner/bid_block_evidence.rs
+++ b/src/node/miner/bid_block_evidence.rs
@@ -202,6 +202,28 @@ impl BadBidBlockTracker {
     }
 }
 
+/// Whether the parent Parlia snapshot authorized `sealer` to seal the evidenced block.
+fn sealer_in_parent_snapshot(evidence: &BadBidBlockEvidence) -> bool {
+    shared::get_snapshot_provider()
+        .and_then(|provider| provider.snapshot_by_hash(&evidence.parent.hash()))
+        .is_some_and(|snapshot| snapshot.validators.contains(&evidence.sealer))
+}
+
+/// Combine the contract-derived role with snapshot membership.
+///
+/// Parlia applies a new validator set only `len/2` blocks after the epoch block, so for that
+/// window the contract state at `parent` already holds the next set while the sealer was still
+/// authorized by the previous one. The snapshot is authoritative for who may seal: a sealer found
+/// there but absent from the contract set is counted as a candidate, since it holds no cabinet
+/// seat in the set now in force. A sealer in neither is not evidence.
+fn resolve_sealer_role(contract_role: ValidatorRole, in_snapshot: bool) -> Option<ValidatorRole> {
+    match contract_role {
+        ValidatorRole::None if in_snapshot => Some(ValidatorRole::Candidate),
+        ValidatorRole::None => None,
+        role => Some(role),
+    }
+}
+
 async fn run_evidence_service<P>(
     mut receiver: mpsc::Receiver<BadBidBlockEvidence>,
     provider: P,
@@ -254,7 +276,7 @@ async fn run_evidence_service<P>(
                 continue;
             }
         };
-        if role == ValidatorRole::None {
+        let Some(role) = resolve_sealer_role(role, sealer_in_parent_snapshot(&evidence)) else {
             tracing::debug!(
                 target: "bsc::bid_block_evidence",
                 builder = %evidence.builder,
@@ -263,7 +285,7 @@ async fn run_evidence_service<P>(
                 "Bad BidBlock sealer is not in the parent validator set"
             );
             continue;
-        }
+        };
 
         let (cabinet_votes, total_votes) = tracker.add(
             evidence.builder,
@@ -385,6 +407,26 @@ mod tests {
         let builder = address(0xb0);
         tracker.add(builder, address(1), true, now);
         assert_eq!(tracker.add(builder, address(1), false, now), (1, 1));
+    }
+
+    #[test]
+    fn snapshot_membership_covers_epoch_transition_lag() {
+        // Contract already holds the next set, snapshot still authorizes the sealer.
+        assert_eq!(
+            resolve_sealer_role(ValidatorRole::None, true),
+            Some(ValidatorRole::Candidate)
+        );
+        // In neither source: not evidence.
+        assert_eq!(resolve_sealer_role(ValidatorRole::None, false), None);
+        // Contract classification wins whenever it exists.
+        assert_eq!(
+            resolve_sealer_role(ValidatorRole::Cabinet, false),
+            Some(ValidatorRole::Cabinet)
+        );
+        assert_eq!(
+            resolve_sealer_role(ValidatorRole::Candidate, true),
+            Some(ValidatorRole::Candidate)
+        );
     }
 
     #[test]

--- a/src/node/miner/config.rs
+++ b/src/node/miner/config.rs
@@ -49,6 +49,12 @@ pub struct MiningConfig {
     /// Whether the `mev_sendBidBlock` RPC (BEP-675 builder-proposed blocks) is accepted.
     /// Off by default; enable with `--mining.bid-block-enabled` or `BSC_MINING_BID_BLOCK_ENABLED`.
     pub bid_block_enabled: bool,
+    /// Optional BEP-675 gRPC listener port. Zero disables the service.
+    pub mev_grpc_port: u16,
+    /// Maximum process-wide in-flight gRPC `SendBidBlock` calls.
+    pub mev_grpc_concurrency: u32,
+    /// Total gRPC request timeout in milliseconds.
+    pub mev_grpc_request_timeout_ms: u64,
     /// Use the reth 2.0 sparse-trie background task for state-root computation
     /// during payload build.
     ///
@@ -80,6 +86,9 @@ impl std::fmt::Debug for MiningConfig {
             .field("builder_fee_ceil", &self.builder_fee_ceil)
             .field("allowed_builders", &self.allowed_builders)
             .field("bid_block_enabled", &self.bid_block_enabled)
+            .field("mev_grpc_port", &self.mev_grpc_port)
+            .field("mev_grpc_concurrency", &self.mev_grpc_concurrency)
+            .field("mev_grpc_request_timeout_ms", &self.mev_grpc_request_timeout_ms)
             .field("use_sparse_trie_state_root", &self.use_sparse_trie_state_root)
             .finish()
     }
@@ -123,6 +132,9 @@ impl Default for MiningConfig {
             builder_fee_ceil: Some(1_000_000_000_000_000_000), // 1 BNB
             allowed_builders: None, // No whitelist by default (allow all)
             bid_block_enabled: false, // BEP-675 BidBlock path off by default
+            mev_grpc_port: 0,
+            mev_grpc_concurrency: 32,
+            mev_grpc_request_timeout_ms: 10_000,
             use_sparse_trie_state_root: false, // Opt-in for now (perf testing)
         }
     }
@@ -210,6 +222,29 @@ impl MiningConfig {
         self.bid_block_enabled
     }
 
+    /// Configured BEP-675 gRPC port; zero means disabled.
+    pub fn get_mev_grpc_port(&self) -> u16 {
+        self.mev_grpc_port
+    }
+
+    /// Maximum in-flight gRPC submissions, applying the go-bsc default when set to zero.
+    pub fn get_mev_grpc_concurrency(&self) -> u32 {
+        if self.mev_grpc_concurrency == 0 {
+            32
+        } else {
+            self.mev_grpc_concurrency
+        }
+    }
+
+    /// Total gRPC request timeout in milliseconds, applying the go-bsc default when set to zero.
+    pub fn get_mev_grpc_request_timeout_ms(&self) -> u64 {
+        if self.mev_grpc_request_timeout_ms == 0 {
+            10_000
+        } else {
+            self.mev_grpc_request_timeout_ms
+        }
+    }
+
     /// Generate a new validator configuration with a freshly generated random key.
     ///
     /// The key is random per call and per process. It previously hard-coded Anvil development
@@ -255,6 +290,9 @@ impl MiningConfig {
                 builder_fee_ceil: Some(1_000_000_000_000_000_000),
                 allowed_builders: None,
                 bid_block_enabled: false,
+                mev_grpc_port: 0,
+                mev_grpc_concurrency: 32,
+                mev_grpc_request_timeout_ms: 10_000,
                 greedy_merge: true,
                 use_sparse_trie_state_root: false,
             }
@@ -357,6 +395,17 @@ impl MiningConfig {
             .map(|v| v.to_lowercase() == "true")
             .unwrap_or(false);
 
+        let mev_grpc_port =
+            std::env::var("BSC_MEV_GRPC_PORT").ok().and_then(|v| v.parse().ok()).unwrap_or(0);
+        let mev_grpc_concurrency = std::env::var("BSC_MEV_GRPC_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(32);
+        let mev_grpc_request_timeout_ms = std::env::var("BSC_MEV_GRPC_REQUEST_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10_000);
+
         let mut cfg = Self {
             enabled,
             private_key_hex,
@@ -374,6 +423,9 @@ impl MiningConfig {
             builder_fee_ceil,
             allowed_builders,
             bid_block_enabled,
+            mev_grpc_port,
+            mev_grpc_concurrency,
+            mev_grpc_request_timeout_ms,
             use_sparse_trie_state_root,
             ..Default::default()
         };
@@ -480,6 +532,14 @@ mod tests {
     #[test]
     fn bid_block_disabled_by_default() {
         assert!(!MiningConfig::default().get_bid_block_enabled());
+    }
+
+    #[test]
+    fn mev_grpc_defaults_match_go_bsc() {
+        let config = MiningConfig::default();
+        assert_eq!(config.get_mev_grpc_port(), 0);
+        assert_eq!(config.get_mev_grpc_concurrency(), 32);
+        assert_eq!(config.get_mev_grpc_request_timeout_ms(), 10_000);
     }
 
     #[test]

--- a/src/node/miner/mod.rs
+++ b/src/node/miner/mod.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod bid_simulator;
 pub mod block_mev_info;
 pub mod bid_block_permission;
+pub(crate) mod bid_block_evidence;
 pub mod bid_block;
 
 pub use bsc_miner::BscMiner;

--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -321,7 +321,11 @@ fn bid_must_before_ms(parent_timestamp_ms: u64, block_interval_ms: u64, delay_le
         .saturating_sub(delay_left_over_ms as u128)
 }
 
-/// Implementation of the MEV Builder RPC API
+/// Implementation of the MEV Builder RPC API.
+///
+/// Clones share the whitelist and pending-BidBlock accounting. This lets JSON-RPC and gRPC expose
+/// the same admission object without creating separate duplicate/quota state.
+#[derive(Clone)]
 pub struct MevApiImpl {
     snapshot_provider: Arc<dyn SnapshotProvider + Send + Sync>,
     chain_spec: Arc<BscChainSpec>,
@@ -556,6 +560,65 @@ impl MevApiImpl {
     /// Internal error (`-32603`) for conditions go-bsc never hits (e.g. the chain head missing).
     fn internal_err(msg: impl Into<String>) -> jsonrpsee::types::ErrorObjectOwned {
         jsonrpsee::types::ErrorObject::owned(-32603, msg.into(), None::<()>)
+    }
+
+    /// Submit a builder-proposed BEP-675 block through the common validator admission path.
+    ///
+    /// Both `mev_sendBidBlock` and `mev.v1.BidBlockService/SendBidBlock` call this method so the
+    /// fork gate, signature/permission checks, duplicate quota and miner queue cannot diverge by
+    /// transport.
+    pub async fn submit_bid_block(&self, args: BidBlockArgs) -> RpcResult<B256> {
+        let bb = &args.bid_block;
+
+        if !crate::shared::is_mev_running() {
+            return Err(Self::mev_not_running());
+        }
+
+        // Chain-head context (the parent the bid must build on); go-bsc reads `CurrentBlock()`.
+        let head_number = crate::shared::get_best_canonical_block_number()
+            .ok_or_else(|| Self::internal_err("chain head unavailable"))?;
+        let head_header = self
+            .get_header_by_number(head_number)
+            .ok_or_else(|| Self::internal_err("chain head header unavailable"))?;
+
+        // Number, then in-turn, then parent-hash alignment — go-bsc's order, enforced in
+        // `validate_bid_block_structure` so the ordering itself is unit-tested.
+        let block_number = bb.header.number;
+        let parent_hash = head_header.hash_slow();
+        let is_inturn = self
+            .snapshot_provider
+            .snapshot_by_hash(&parent_hash)
+            .is_some_and(|snapshot| snapshot.is_inturn(self.validator_address));
+
+        if let Err(rejection) = validate_bid_block_structure(
+            block_number,
+            head_number,
+            is_inturn,
+            bb.header.parent_hash,
+            parent_hash,
+            bb.header.gas_used,
+            bb.transactions.len(),
+        ) {
+            use BidBlockStructuralRejection as R;
+            return Err(match rejection {
+                R::StaleNumber => Self::invalid_bid(format!(
+                    "stale block number: {block_number}, latest block: {head_number}"
+                )),
+                R::FutureNumber => Self::invalid_bid(format!(
+                    "block in future: {block_number}, latest block: {head_number}"
+                )),
+                R::NotInTurn => Self::mev_not_in_turn(),
+                R::NonAlignedParent => {
+                    Self::invalid_bid(format!("non-aligned parent hash: {parent_hash:?}"))
+                }
+                R::EmptyGasUsed => Self::invalid_bid("empty gasUsed in header"),
+                R::EmptyTransactions => Self::invalid_bid("empty transactions"),
+            });
+        }
+
+        // Every rejection above returns before this point, so nothing structurally invalid can
+        // reach the miner queue (TC-009's `bid_block_queue_len()` invariant).
+        self.admit_bid_block(&args, &head_header)
     }
 
     /// Miner-side BidBlock admission — mirrors the front of go-bsc `Miner.SendBidBlock`:
@@ -1240,57 +1303,7 @@ impl BscMevApiServer for MevApiImpl {
     /// non-empty gasUsed/txs). It then delegates to [`MevApiImpl::admit_bid_block`], which mirrors
     /// `Miner.SendBidBlock`.
     async fn send_bid_block(&self, args: BidBlockArgs) -> RpcResult<B256> {
-        let bb = &args.bid_block;
-
-        if !crate::shared::is_mev_running() {
-            return Err(Self::mev_not_running());
-        }
-
-        // Chain-head context (the parent the bid must build on); go-bsc reads `CurrentBlock()`.
-        let head_number = crate::shared::get_best_canonical_block_number()
-            .ok_or_else(|| Self::internal_err("chain head unavailable"))?;
-        let head_header = self
-            .get_header_by_number(head_number)
-            .ok_or_else(|| Self::internal_err("chain head header unavailable"))?;
-
-        // Number, then in-turn, then parent-hash alignment — go-bsc's order, enforced in
-        // `validate_bid_block_structure` so the ordering itself is unit-tested.
-        let block_number = bb.header.number;
-        let parent_hash = head_header.hash_slow();
-        let is_inturn = self
-            .snapshot_provider
-            .snapshot_by_hash(&parent_hash)
-            .is_some_and(|snapshot| snapshot.is_inturn(self.validator_address));
-
-        if let Err(rejection) = validate_bid_block_structure(
-            block_number,
-            head_number,
-            is_inturn,
-            bb.header.parent_hash,
-            parent_hash,
-            bb.header.gas_used,
-            bb.transactions.len(),
-        ) {
-            use BidBlockStructuralRejection as R;
-            return Err(match rejection {
-                R::StaleNumber => Self::invalid_bid(format!(
-                    "stale block number: {block_number}, latest block: {head_number}"
-                )),
-                R::FutureNumber => Self::invalid_bid(format!(
-                    "block in future: {block_number}, latest block: {head_number}"
-                )),
-                R::NotInTurn => Self::mev_not_in_turn(),
-                R::NonAlignedParent => {
-                    Self::invalid_bid(format!("non-aligned parent hash: {parent_hash:?}"))
-                }
-                R::EmptyGasUsed => Self::invalid_bid("empty gasUsed in header"),
-                R::EmptyTransactions => Self::invalid_bid("empty transactions"),
-            });
-        }
-
-        // Every rejection above returns before this point, so nothing structurally invalid can reach
-        // the miner queue (TC-009's `bid_block_queue_len()` invariant).
-        self.admit_bid_block(&args, &head_header)
+        self.submit_bid_block(args).await
     }
 
     /// Get MEV parameters

--- a/src/system_contracts/mod.rs
+++ b/src/system_contracts/mod.rs
@@ -123,6 +123,62 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
         (consensus_addresses, vote_address)
     }
 
+    /// Return the full cabinet-first validator set, including candidates.
+    pub(crate) fn get_all_validators(&self) -> (Address, Bytes) {
+        let function = self.validator_abi.function("getValidators").unwrap().first().unwrap();
+        (VALIDATOR_CONTRACT, Bytes::from(function.abi_encode_input(&[]).unwrap()))
+    }
+
+    /// Decode the validator addresses returned by `getValidators()` without panicking on
+    /// malformed returndata.
+    pub(crate) fn unpack_all_validators(
+        &self,
+        data: &[u8],
+    ) -> Result<Vec<Address>, String> {
+        let function = self.validator_abi.function("getValidators").unwrap().first().unwrap();
+        let output = function
+            .abi_decode_output(data)
+            .map_err(|err| format!("decode getValidators output: {err}"))?;
+        let validators = output
+            .first()
+            .and_then(DynSolValue::as_array)
+            .ok_or_else(|| "getValidators returned a non-address-array value".to_string())?;
+
+        validators
+            .iter()
+            .map(|value| {
+                value
+                    .as_address()
+                    .ok_or_else(|| "getValidators returned a non-address element".to_string())
+            })
+            .collect()
+    }
+
+    /// Return the validator contract and calldata for `numOfCabinets()`.
+    pub(crate) fn get_num_of_cabinets(&self) -> (Address, Bytes) {
+        let function = self.validator_abi.function("numOfCabinets").unwrap().first().unwrap();
+        (VALIDATOR_CONTRACT, Bytes::from(function.abi_encode_input(&[]).unwrap()))
+    }
+
+    /// Decode the single `uint256` returned by `numOfCabinets()` without panicking on malformed
+    /// returndata.
+    pub(crate) fn unpack_num_of_cabinets(&self, data: &[u8]) -> Result<U256, String> {
+        self.unpack_validator_uint("numOfCabinets", data)
+    }
+
+    fn unpack_validator_uint(&self, method: &str, data: &[u8]) -> Result<U256, String> {
+        let function = self.validator_abi.function(method).unwrap().first().unwrap();
+        let output = function
+            .abi_decode_output(data)
+            .map_err(|err| format!("decode {method} output: {err}"))?;
+
+        output
+            .first()
+            .and_then(DynSolValue::as_uint)
+            .map(|value| value.0)
+            .ok_or_else(|| format!("{method} returned a non-uint value"))
+    }
+
     /// Return system address and input which is used to query max elected validators.
     pub fn get_max_elected_validators(&self) -> (Address, Bytes) {
         let function =
@@ -1165,6 +1221,44 @@ mod tests {
 
     fn dummy_sig() -> Signature {
         Signature::new(U256::ZERO, U256::ZERO, false)
+    }
+
+    #[test]
+    fn bid_block_evidence_validator_set_outputs_round_trip() {
+        let contracts = SystemContract::new(crate::chainspec::BscChainSpec::from(bsc_mainnet()));
+        let validators = vec![
+            address!("1111111111111111111111111111111111111111"),
+            address!("2222222222222222222222222222222222222222"),
+        ];
+        let validator_values = validators.iter().copied().map(DynSolValue::from).collect();
+        let validators_output = contracts
+            .validator_abi
+            .function("getValidators")
+            .unwrap()
+            .first()
+            .unwrap()
+            .abi_encode_output(&[
+                DynSolValue::Array(validator_values),
+            ])
+            .unwrap();
+        assert_eq!(
+            contracts.unpack_all_validators(&validators_output).unwrap(),
+            validators
+        );
+
+        let cabinets = U256::from(21);
+        let cabinets_output = contracts
+            .validator_abi
+            .function("numOfCabinets")
+            .unwrap()
+            .first()
+            .unwrap()
+            .abi_encode_output(&[DynSolValue::from(cabinets)])
+            .unwrap();
+        assert_eq!(contracts.unpack_num_of_cabinets(&cabinets_output).unwrap(), cabinets);
+
+        assert!(contracts.unpack_all_validators(&[]).is_err());
+        assert!(contracts.unpack_num_of_cabinets(&[]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Description

1. Add BEP-675 BidBlock support over gRPC. （finish e2e test)
2. Add validator configuration for enabling the MEV gRPC service.
3. Reject bid blocks with a zero state root.
4. Record builder info in bad block from bep 675

Enabling gRPC on reth-bsc: the BEP-675 BidBlockService listener is off by default, matching go-bsc's Miner.Mev.GRPCPort. Start it by passing --mining.mev-grpc-port <port> (or BSC_MEV_GRPC_PORT=<port>) together with --mining.enabled --mining.bid-block-enabled; it binds to the --http.addr host on that port, plaintext HTTP/2. Optional tuning: --mining.mev-grpc-concurrency (default 32) and --mining.mev-grpc-request-timeout-ms (default 10000).
`
related pr:

1.  https://github.com/bnb-chain/bsc/pull/3774
2. https://github.com/bnb-chain/bsc/pull/3798
3. https://github.com/bnb-chain/bsc/pull/3806
4. https://github.com/bnb-chain/bsc/pull/3804

                
### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
