### PR TITLE
feat(rpc): include DelayLeftOver in MevParams

### DIFF
--- a/src/rpc/mev.rs
+++ b/src/rpc/mev.rs
@@ -81,6 +81,11 @@ pub struct MevParams {
     /// Time left when bid cannot be interrupted in nanoseconds
     #[serde(rename = "NoInterruptLeftOver")]
     pub no_interrupt_left_over: u64,
+    /// Time reserved to finalize a block, in nanoseconds; the BidBlock receive deadline is
+    /// `BidMustBefore = header.Time - DelayLeftOver`. Exposed so builders can compute
+    /// `BidMustBefore` per validator instead of hardcoding the 15ms default.
+    #[serde(rename = "DelayLeftOver")]
+    pub delay_left_over: u64,
     /// Maximum number of bids allowed per builder per block
     #[serde(rename = "MaxBidsPerBuilder")]
     pub max_bids_per_builder: u32,
@@ -1320,6 +1325,7 @@ impl BscMevApiServer for MevApiImpl {
             // Convert milliseconds to nanoseconds (1ms = 1,000,000 ns)
             bid_simulation_left_over: self.bid_simulation_left_over * 1_000_000,
             no_interrupt_left_over: self.no_interrupt_left_over * 1_000_000,
+            delay_left_over: self.delay_left_over * 1_000_000,
             max_bids_per_builder: self.max_bids_per_builder,
             gas_ceil: self.gas_ceil,
             gas_price: self.min_gas_price,
@@ -1386,6 +1392,7 @@ mod bid_block_param_tests {
             validator_commission: 100,
             bid_simulation_left_over: 0,
             no_interrupt_left_over: 0,
+            delay_left_over: 0,
             max_bids_per_builder: 3,
             gas_ceil: 0,
             gas_price: U256::ZERO,
@@ -1396,6 +1403,31 @@ mod bid_block_param_tests {
         let json = serde_json::to_value(&params).unwrap();
         // geth parity: the field is exposed as "BidBlockEnabled".
         assert_eq!(json.get("BidBlockEnabled"), Some(&serde_json::Value::Bool(true)));
+    }
+
+    #[test]
+    fn mev_params_exposes_delay_left_over_field() {
+        // geth parity (bnb-chain/bsc#3807): `Miner.Config.DelayLeftOver` is exposed as
+        // "DelayLeftOver" (a Go `time.Duration`, i.e. nanoseconds in JSON) so builders can
+        // compute `BidMustBefore` per validator instead of hardcoding the 15ms default.
+        let params = MevParams {
+            validator_commission: 100,
+            bid_simulation_left_over: 0,
+            no_interrupt_left_over: 0,
+            delay_left_over: 15 * 1_000_000, // 15ms in nanoseconds
+            max_bids_per_builder: 3,
+            gas_ceil: 0,
+            gas_price: U256::ZERO,
+            builder_fee_ceil: U256::ZERO,
+            bid_block_enabled: true,
+            version: "test".to_string(),
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(
+            json.get("DelayLeftOver"),
+            Some(&serde_json::Value::from(15_000_000u64)),
+            "DelayLeftOver must serialize under go-bsc's key, in nanoseconds"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Description

Port of bnb-chain/bsc#3807: expose the validator's `DelayLeftOver` via `mev_params` so builders can compute `BidMustBefore` per validator instead of hardcoding the 15ms default.

### Rationale

The BidBlock receive deadline is:

```
BidMustBefore = parent.MilliTimestamp + BlockInterval - DelayLeftOver
```

`DelayLeftOver` is a per-validator configuration (go-bsc `--miner.delayleftover`, reth-bsc `MiningConfig::delay_left_over`; default 15ms). Builders previously had to assume the default, so a validator running a non-default value silently shifted the real deadline and bids computed against 15ms could miss the seal (or leave margin on the table). go-bsc#3807 added the field to `MevParams`; this PR mirrors it.

`MevApiImpl` already tracks `delay_left_over` internally (it drives the `mev_sendBidBlock` admission deadline), so this only adds the field to the RPC response — no behavior change to admission, mining, or sync.

### Example

```bash
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"mev_params","params":[]}' http://localhost:8545
# {..., "NoInterruptLeftOver": 300000000, "DelayLeftOver": 15000000, "MaxBidsPerBuilder": 3, ...}
```

Like the other `time.Duration` fields, the value is in nanoseconds (go's JSON encoding of `time.Duration`), keeping the response byte-compatible with go-bsc.

### Changes

Notable changes:
* `src/rpc/mev.rs`: add `DelayLeftOver` to the `MevParams` response struct (go's field position and JSON key), filled from the already-tracked `delay_left_over` config with the same ms→ns conversion the neighboring duration fields use; serialization test pinning the key and nanosecond units.

### Potential Impacts

* `mev_params` responses gain one field; JSON-decoding clients ignore unknown fields, so existing builders are unaffected until they opt in to reading it.
* No consensus, sync, mining, or admission behavior change.
