### PR TITLE
fix: remove panic paths from the unwrap/expect inventory

### DIFF
--- a/src/consensus/parlia/util.rs
+++ b/src/consensus/parlia/util.rs
@@ -27,7 +27,8 @@ pub fn is_breathe_block(last_block_time: u64, block_time: u64) -> bool {
 /// Print all header fields that participate for debug.
 pub fn debug_header(header: &Header, chain_id: u64, context: &str) {
     let block_id = format!("#{}-0x{:x}", header.number, alloy_primitives::keccak256(header.parent_hash.as_slice()));
-    let signed_extra_data = &header.extra_data[..header.extra_data.len().saturating_sub(EXTRA_SEAL_LEN)];
+    let signed_extra_data =
+        &header.extra_data[..header.extra_data.len().saturating_sub(EXTRA_SEAL_LEN)];
     
     tracing::trace!(
         target: "bsc::parlia::util",
@@ -81,16 +82,24 @@ pub fn encode_header_with_chain_id(header: &Header, out: &mut dyn BufMut, chain_
     Encodable::encode(&header.gas_limit, out);
     Encodable::encode(&header.gas_used, out);
     Encodable::encode(&header.timestamp, out);
-    Encodable::encode(&header.extra_data[..header.extra_data.len() - EXTRA_SEAL_LEN], out); // will panic if extra_data is less than EXTRA_SEAL_LEN
+    // `saturating_sub` so a short `extra_data` yields an empty slice instead of panicking;
+    // callers reject such headers, this only keeps the hasher itself total.
+    let signed_extra_data =
+        &header.extra_data[..header.extra_data.len().saturating_sub(EXTRA_SEAL_LEN)];
+    Encodable::encode(&signed_extra_data, out);
     Encodable::encode(&header.mix_hash, out);
     Encodable::encode(&header.nonce, out);
 
     if let Some(parent_beacon_block_root) = header.parent_beacon_block_root {
         if parent_beacon_block_root == B256::default() {
-            Encodable::encode(&U256::from(header.base_fee_per_gas.unwrap()), out);
-            Encodable::encode(&header.withdrawals_root.unwrap(), out);
-            Encodable::encode(&header.blob_gas_used.unwrap(), out);
-            Encodable::encode(&header.excess_blob_gas.unwrap(), out);
+            // A header decoded from the wire cannot reach here with these fields unset (they
+            // precede `parent_beacon_block_root` positionally in the RLP list), but a
+            // hand-constructed one can. Encode the default so the hash simply fails to match
+            // instead of panicking; `rlp_header` below must use the same defaults.
+            Encodable::encode(&U256::from(header.base_fee_per_gas.unwrap_or_default()), out);
+            Encodable::encode(&header.withdrawals_root.unwrap_or_default(), out);
+            Encodable::encode(&header.blob_gas_used.unwrap_or_default(), out);
+            Encodable::encode(&header.excess_blob_gas.unwrap_or_default(), out);
             Encodable::encode(&parent_beacon_block_root, out);
             // https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-466.md
             if let Some(requests_hash) = header.requests_hash {
@@ -117,17 +126,21 @@ fn rlp_header(header: &Header, chain_id: u64) -> alloy_rlp::Header {
     rlp_head.payload_length += header.gas_limit.length(); // gas_limit
     rlp_head.payload_length += header.gas_used.length(); // gas_used
     rlp_head.payload_length += header.timestamp.length(); // timestamp
-    rlp_head.payload_length +=
-        &header.extra_data[..header.extra_data.len() - EXTRA_SEAL_LEN].length(); // extra_data
+    let signed_extra_data =
+        &header.extra_data[..header.extra_data.len().saturating_sub(EXTRA_SEAL_LEN)];
+    rlp_head.payload_length += signed_extra_data.length(); // extra_data
     rlp_head.payload_length += header.mix_hash.length(); // mix_hash
     rlp_head.payload_length += header.nonce.length(); // nonce
 
     if let Some(parent_beacon_block_root) = header.parent_beacon_block_root {
         if parent_beacon_block_root == B256::default() {
-            rlp_head.payload_length += U256::from(header.base_fee_per_gas.unwrap()).length();
-            rlp_head.payload_length += header.withdrawals_root.unwrap().length();
-            rlp_head.payload_length += header.blob_gas_used.unwrap().length();
-            rlp_head.payload_length += header.excess_blob_gas.unwrap().length();
+            // Same defaults as `encode_header_with_chain_id`, or the declared payload length
+            // would not match the bytes actually written.
+            rlp_head.payload_length +=
+                U256::from(header.base_fee_per_gas.unwrap_or_default()).length();
+            rlp_head.payload_length += header.withdrawals_root.unwrap_or_default().length();
+            rlp_head.payload_length += header.blob_gas_used.unwrap_or_default().length();
+            rlp_head.payload_length += header.excess_blob_gas.unwrap_or_default().length();
             rlp_head.payload_length += parent_beacon_block_root.length();
             // https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-466.md
             if let Some(requests_hash) = header.requests_hash {
@@ -182,6 +195,39 @@ mod tests {
     use super::*;
     use alloy_consensus::Header;
     use alloy_primitives::B256;
+
+    /// `parent_beacon_block_root` is set but the optional fields that precede it in the RLP
+    /// list are not — impossible for a header decoded from the wire, but reachable for a
+    /// hand-built one, and it used to unwrap straight into a panic.
+    #[test]
+    fn hash_with_chain_id_tolerates_missing_optional_fields() {
+        let header = Header {
+            extra_data: vec![0u8; EXTRA_SEAL_LEN + 32].into(),
+            parent_beacon_block_root: Some(B256::ZERO),
+            base_fee_per_gas: None,
+            withdrawals_root: None,
+            blob_gas_used: None,
+            excess_blob_gas: None,
+            ..Default::default()
+        };
+
+        // No panic, and the declared RLP payload length matches what was written: the
+        // encoder and the length calculation have to agree on the substituted defaults.
+        let mut out = BytesMut::new();
+        encode_header_with_chain_id(&header, &mut out, 56);
+        let mut slice: &[u8] = out.as_ref();
+        let rlp_head = alloy_rlp::Header::decode(&mut slice).expect("valid RLP list");
+        assert!(rlp_head.list);
+        assert_eq!(rlp_head.payload_length, slice.len());
+    }
+
+    /// `extra_data` shorter than the seal is rejected by callers, but the hasher itself must
+    /// not underflow on it.
+    #[test]
+    fn hash_with_chain_id_tolerates_short_extra_data() {
+        let header = Header { extra_data: vec![0u8; 3].into(), ..Default::default() };
+        let _ = hash_with_chain_id(&header, 56);
+    }
 
     #[test]
     fn test_calculate_millisecond_timestamp_without_mix_hash() {

--- a/src/evm/precompiles/cometbft.rs
+++ b/src/evm/precompiles/cometbft.rs
@@ -140,17 +140,22 @@ fn cometbft_light_block_validation_run_inner(
 
 type ConvertLightBlockResult = Result<LightBlock, PrecompileHalt>;
 fn convert_light_block_from_proto(light_block_proto: &TmLightBlock) -> ConvertLightBlockResult {
-    let signed_header =
-        match SignedHeader::try_from(light_block_proto.signed_header.as_ref().unwrap().clone()) {
-            Ok(sh) => sh.clone(),
-            Err(_) => return Err(BscPrecompileError::InvalidInput.into()),
-        };
+    // Both fields are optional in the protobuf definition, so any caller can omit them by
+    // crafting the precompile input; treat a missing field as invalid input instead of
+    // unwrapping it.
+    let signed_header_proto =
+        light_block_proto.signed_header.as_ref().ok_or(BscPrecompileError::InvalidInput)?;
+    let signed_header = match SignedHeader::try_from(signed_header_proto.clone()) {
+        Ok(sh) => sh.clone(),
+        Err(_) => return Err(BscPrecompileError::InvalidInput.into()),
+    };
 
-    let validator_set =
-        match Set::try_from(light_block_proto.validator_set.as_ref().unwrap().clone()) {
-            Ok(vs) => vs.clone(),
-            Err(_) => return Err(BscPrecompileError::InvalidInput.into()),
-        };
+    let validator_set_proto =
+        light_block_proto.validator_set.as_ref().ok_or(BscPrecompileError::InvalidInput)?;
+    let validator_set = match Set::try_from(validator_set_proto.clone()) {
+        Ok(vs) => vs.clone(),
+        Err(_) => return Err(BscPrecompileError::InvalidInput.into()),
+    };
 
     let next_validator_set = validator_set.clone();
     let peer_id = cometbft::node::Id::new([0u8; 20]);
@@ -475,11 +480,54 @@ mod tests {
 
     use super::*;
 
+    /// The first valid `cometbft_light_block_validation` fixture, kept as a string so tests
+    /// can rebuild an input around a modified light block.
+    const VALID_LIGHT_BLOCK_INPUT: &str = "000000000000000000000000000000000000000000000000000000000000018c677265656e6669656c645f393030302d3132310000000000000000000000000000000000000000013c350cd55b99dc6c2b7da9bef5410fbfb869fede858e7b95bf7ca294e228bb40e33f6e876d63791ebd05ff617a1b4f4ad1aa2ce65e3c3a9cdfb33e0ffa7e8423000000000098968015154514f68ce65a0d9eecc578c0ab12da0a2a28a0805521b5b7ae56eb3fb24555efbfe59e1622bfe9f7be8c9022e9b3f2442739c1ce870b9adee169afe60f674edd7c86451c5363d89052fde8351895eeea166ce5373c36e31b518ed191d0c599aa0f5b0000000000989680432f6c4908a9aa5f3444421f466b11645235c99b831b2a2de9e504d7ea299e52a202ce529808618eb3bfc0addf13d8c5f2df821d81e18f9bc61583510b322d067d46323b0a572635c06a049c0a2a929e3c8184a50cf6a8b95708c25834ade456f399015a0000000000989680864cb9828254d712f8e59b164fc6a9402dc4e6c59065e38cff24f5323c8c5da888a0f97e5ee4ba1e11b0674b0a0d06204c1dfa247c370cd4be3e799fc4f6f48d977ac7ca0aeb060adb030a02080b1213677265656e6669656c645f393030302d3132311802220c08b2d7f3a10610e8d2adb3032a480a20ec6ecb5db4ffb17fabe40c60ca7b8441e9c5d77585d0831186f3c37aa16e9c15122408011220a2ab9e1eb9ea52812f413526e424b326aff2f258a56e00d690db9f805b60fe7e32200f40aeff672e8309b7b0aefbb9a1ae3d4299b5c445b7d54e8ff398488467f0053a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85542203c350cd55b99dc6c2b7da9bef5410fbfb869fede858e7b95bf7ca294e228bb404a203c350cd55b99dc6c2b7da9bef5410fbfb869fede858e7b95bf7ca294e228bb405220294d8fbd0b94b767a7eba9840f299a3586da7fe6b5dead3b7eecba193c400f935a20bc50557c12d7392b0d07d75df0b61232d48f86a74fdea6d1485d9be6317d268c6220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8556a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85572146699336aa109d1beab3946198c8e59f3b2cbd92f7a4065e3cd89e315ca39d87dee92835b98f8b8ec0861d6d9bb2c60156df5d375b3ceb1fbe71af6a244907d62548a694165caa660fec7a9b4e7b9198191361c71be0b128a0308021a480a20726abd0fdbfb6f779b0483e6e4b4b6f12241f6ea2bf374233ab1a316692b6415122408011220159f10ff15a8b58fc67a92ffd7f33c8cd407d4ce81b04ca79177dfd00ca19a67226808021214050cff76cc632760ba9db796c046004c900967361a0c08b3d7f3a10610808cadba03224080713027ffb776a702d78fd0406205c629ba473e1f8d6af646190f6eb9262cd67d69be90d10e597b91e06d7298eb6fa4b8f1eb7752ebf352a1f51560294548042268080212146699336aa109d1beab3946198c8e59f3b2cbd92f1a0c08b3d7f3a10610b087c1c00322405e2ddb70acfe4904438be3d9f4206c0ace905ac4fc306a42cfc9e86268950a0fbfd6ec5f526d3e41a3ef52bf9f9f358e3cb4c3feac76c762fa3651c1244fe004226808021214c55765fd2d0570e869f6ac22e7f2916a35ea300d1a0c08b3d7f3a10610f0b3d492032240ca17898bd22232fc9374e1188636ee321a396444a5b1a79f7628e4a11f265734b2ab50caf21e8092c55d701248e82b2f011426cb35ba22043b497a6b4661930612a0050aa8010a14050cff76cc632760ba9db796c046004c9009673612220a20e33f6e876d63791ebd05ff617a1b4f4ad1aa2ce65e3c3a9cdfb33e0ffa7e84231880ade2042080a6bbf6ffffffffff012a30a0805521b5b7ae56eb3fb24555efbfe59e1622bfe9f7be8c9022e9b3f2442739c1ce870b9adee169afe60f674edd7c86321415154514f68ce65a0d9eecc578c0ab12da0a2a283a14ee7a2a6a44d427f6949eeb8f12ea9fbb2501da880aa2010a146699336aa109d1beab3946198c8e59f3b2cbd92f12220a20451c5363d89052fde8351895eeea166ce5373c36e31b518ed191d0c599aa0f5b1880ade2042080ade2042a30831b2a2de9e504d7ea299e52a202ce529808618eb3bfc0addf13d8c5f2df821d81e18f9bc61583510b322d067d46323b3214432f6c4908a9aa5f3444421f466b11645235c99b3a14a0a7769429468054e19059af4867da0a495567e50aa2010a14c55765fd2d0570e869f6ac22e7f2916a35ea300d12220a200a572635c06a049c0a2a929e3c8184a50cf6a8b95708c25834ade456f399015a1880ade2042080ade2042a309065e38cff24f5323c8c5da888a0f97e5ee4ba1e11b0674b0a0d06204c1dfa247c370cd4be3e799fc4f6f48d977ac7ca3214864cb9828254d712f8e59b164fc6a9402dc4e6c53a143139916d97df0c589312b89950b6ab9795f34d1a12a8010a14050cff76cc632760ba9db796c046004c9009673612220a20e33f6e876d63791ebd05ff617a1b4f4ad1aa2ce65e3c3a9cdfb33e0ffa7e84231880ade2042080a6bbf6ffffffffff012a30a0805521b5b7ae56eb3fb24555efbfe59e1622bfe9f7be8c9022e9b3f2442739c1ce870b9adee169afe60f674edd7c86321415154514f68ce65a0d9eecc578c0ab12da0a2a283a14ee7a2a6a44d427f6949eeb8f12ea9fbb2501da88";
+
+    fn valid_light_block_input() -> Vec<u8> {
+        hex::decode(VALID_LIGHT_BLOCK_INPUT).expect("fixture is valid hex")
+    }
+
+    /// `signed_header` and `validator_set` are optional protobuf fields, so any caller can
+    /// omit them. They used to be unwrapped, panicking the node before the precompile's own
+    /// `InvalidInput` handling could run — reachable by anyone for the base gas cost.
+    #[test]
+    fn light_block_missing_optional_proto_fields_is_invalid_input() {
+        assert!(convert_light_block_from_proto(&TmLightBlock::default()).is_err());
+
+        let input = valid_light_block_input();
+        let cs_length = u64::from_be_bytes(
+            input[(CONSENSUS_STATE_LENGTH_BYTES_LENGTH - UINT64_TYPE_LENGTH) as usize..
+                CONSENSUS_STATE_LENGTH_BYTES_LENGTH as usize]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let split = CONSENSUS_STATE_LENGTH_BYTES_LENGTH as usize + cs_length;
+        let (prefix, tail) = input.split_at(split);
+        let full = TmLightBlock::decode(tail).expect("fixture light block decodes");
+
+        // Neither field set, then only `validator_set` missing.
+        let mut without_validator_set = full.clone();
+        without_validator_set.validator_set = None;
+        for proto in [TmLightBlock::default(), without_validator_set] {
+            let mut crafted = prefix.to_vec();
+            crafted.extend_from_slice(&proto.encode_to_vec());
+
+            let output = cometbft_light_block_validation_run(&crafted, 10_000_000, 0)
+                .expect("a missing proto field must not be a fatal error");
+            assert!(output.is_halt(), "expected an InvalidInput halt");
+
+            // Pasteur shares `convert_light_block_from_proto`.
+            let output = cometbft_light_block_validation_run_pasteur(&crafted, 10_000_000, 0)
+                .expect("a missing proto field must not be a fatal error");
+            assert!(output.is_halt(), "expected an InvalidInput halt");
+        }
+    }
+
     #[test]
     fn test_cometbft_light_block_validate() {
         {
-            let input = Bytes::from(hex!(
-                "000000000000000000000000000000000000000000000000000000000000018c677265656e6669656c645f393030302d3132310000000000000000000000000000000000000000013c350cd55b99dc6c2b7da9bef5410fbfb869fede858e7b95bf7ca294e228bb40e33f6e876d63791ebd05ff617a1b4f4ad1aa2ce65e3c3a9cdfb33e0ffa7e8423000000000098968015154514f68ce65a0d9eecc578c0ab12da0a2a28a0805521b5b7ae56eb3fb24555efbfe59e1622bfe9f7be8c9022e9b3f2442739c1ce870b9adee169afe60f674edd7c86451c5363d89052fde8351895eeea166ce5373c36e31b518ed191d0c599aa0f5b0000000000989680432f6c4908a9aa5f3444421f466b11645235c99b831b2a2de9e504d7ea299e52a202ce529808618eb3bfc0addf13d8c5f2df821d81e18f9bc61583510b322d067d46323b0a572635c06a049c0a2a929e3c8184a50cf6a8b95708c25834ade456f399015a0000000000989680864cb9828254d712f8e59b164fc6a9402dc4e6c59065e38cff24f5323c8c5da888a0f97e5ee4ba1e11b0674b0a0d06204c1dfa247c370cd4be3e799fc4f6f48d977ac7ca0aeb060adb030a02080b1213677265656e6669656c645f393030302d3132311802220c08b2d7f3a10610e8d2adb3032a480a20ec6ecb5db4ffb17fabe40c60ca7b8441e9c5d77585d0831186f3c37aa16e9c15122408011220a2ab9e1eb9ea52812f413526e424b326aff2f258a56e00d690db9f805b60fe7e32200f40aeff672e8309b7b0aefbb9a1ae3d4299b5c445b7d54e8ff398488467f0053a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85542203c350cd55b99dc6c2b7da9bef5410fbfb869fede858e7b95bf7ca294e228bb404a203c350cd55b99dc6c2b7da9bef5410fbfb869fede858e7b95bf7ca294e228bb405220294d8fbd0b94b767a7eba9840f299a3586da7fe6b5dead3b7eecba193c400f935a20bc50557c12d7392b0d07d75df0b61232d48f86a74fdea6d1485d9be6317d268c6220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8556a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85572146699336aa109d1beab3946198c8e59f3b2cbd92f7a4065e3cd89e315ca39d87dee92835b98f8b8ec0861d6d9bb2c60156df5d375b3ceb1fbe71af6a244907d62548a694165caa660fec7a9b4e7b9198191361c71be0b128a0308021a480a20726abd0fdbfb6f779b0483e6e4b4b6f12241f6ea2bf374233ab1a316692b6415122408011220159f10ff15a8b58fc67a92ffd7f33c8cd407d4ce81b04ca79177dfd00ca19a67226808021214050cff76cc632760ba9db796c046004c900967361a0c08b3d7f3a10610808cadba03224080713027ffb776a702d78fd0406205c629ba473e1f8d6af646190f6eb9262cd67d69be90d10e597b91e06d7298eb6fa4b8f1eb7752ebf352a1f51560294548042268080212146699336aa109d1beab3946198c8e59f3b2cbd92f1a0c08b3d7f3a10610b087c1c00322405e2ddb70acfe4904438be3d9f4206c0ace905ac4fc306a42cfc9e86268950a0fbfd6ec5f526d3e41a3ef52bf9f9f358e3cb4c3feac76c762fa3651c1244fe004226808021214c55765fd2d0570e869f6ac22e7f2916a35ea300d1a0c08b3d7f3a10610f0b3d492032240ca17898bd22232fc9374e1188636ee321a396444a5b1a79f7628e4a11f265734b2ab50caf21e8092c55d701248e82b2f011426cb35ba22043b497a6b4661930612a0050aa8010a14050cff76cc632760ba9db796c046004c9009673612220a20e33f6e876d63791ebd05ff617a1b4f4ad1aa2ce65e3c3a9cdfb33e0ffa7e84231880ade2042080a6bbf6ffffffffff012a30a0805521b5b7ae56eb3fb24555efbfe59e1622bfe9f7be8c9022e9b3f2442739c1ce870b9adee169afe60f674edd7c86321415154514f68ce65a0d9eecc578c0ab12da0a2a283a14ee7a2a6a44d427f6949eeb8f12ea9fbb2501da880aa2010a146699336aa109d1beab3946198c8e59f3b2cbd92f12220a20451c5363d89052fde8351895eeea166ce5373c36e31b518ed191d0c599aa0f5b1880ade2042080ade2042a30831b2a2de9e504d7ea299e52a202ce529808618eb3bfc0addf13d8c5f2df821d81e18f9bc61583510b322d067d46323b3214432f6c4908a9aa5f3444421f466b11645235c99b3a14a0a7769429468054e19059af4867da0a495567e50aa2010a14c55765fd2d0570e869f6ac22e7f2916a35ea300d12220a200a572635c06a049c0a2a929e3c8184a50cf6a8b95708c25834ade456f399015a1880ade2042080ade2042a309065e38cff24f5323c8c5da888a0f97e5ee4ba1e11b0674b0a0d06204c1dfa247c370cd4be3e799fc4f6f48d977ac7ca3214864cb9828254d712f8e59b164fc6a9402dc4e6c53a143139916d97df0c589312b89950b6ab9795f34d1a12a8010a14050cff76cc632760ba9db796c046004c9009673612220a20e33f6e876d63791ebd05ff617a1b4f4ad1aa2ce65e3c3a9cdfb33e0ffa7e84231880ade2042080a6bbf6ffffffffff012a30a0805521b5b7ae56eb3fb24555efbfe59e1622bfe9f7be8c9022e9b3f2442739c1ce870b9adee169afe60f674edd7c86321415154514f68ce65a0d9eecc578c0ab12da0a2a283a14ee7a2a6a44d427f6949eeb8f12ea9fbb2501da88"));
+            let input = Bytes::from(valid_light_block_input());
             let except_output = Bytes::from(hex!(
                 "000000000000000000000000000000000000000000000000000000000000018c677265656e6669656c645f393030302d3132310000000000000000000000000000000000000000023c350cd55b99dc6c2b7da9bef5410fbfb869fede858e7b95bf7ca294e228bb40e33f6e876d63791ebd05ff617a1b4f4ad1aa2ce65e3c3a9cdfb33e0ffa7e8423000000000098968015154514f68ce65a0d9eecc578c0ab12da0a2a28a0805521b5b7ae56eb3fb24555efbfe59e1622bfe9f7be8c9022e9b3f2442739c1ce870b9adee169afe60f674edd7c86451c5363d89052fde8351895eeea166ce5373c36e31b518ed191d0c599aa0f5b0000000000989680432f6c4908a9aa5f3444421f466b11645235c99b831b2a2de9e504d7ea299e52a202ce529808618eb3bfc0addf13d8c5f2df821d81e18f9bc61583510b322d067d46323b0a572635c06a049c0a2a929e3c8184a50cf6a8b95708c25834ade456f399015a0000000000989680864cb9828254d712f8e59b164fc6a9402dc4e6c59065e38cff24f5323c8c5da888a0f97e5ee4ba1e11b0674b0a0d06204c1dfa247c370cd4be3e799fc4f6f48d977ac7ca"
             ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,8 +557,9 @@ fn main() -> eyre::Result<()> {
                 node.provider.canonical_in_memory_state(),
             );
 
-            // Set the IPC client
-            reth_bsc::shared::set_ipc_client(ipc_path).await.unwrap();
+            // Set the IPC client. IPC is required (see the `--ipc.disable` check above), so a
+            // failure here is a startup error rather than something to panic on.
+            reth_bsc::shared::set_ipc_client(ipc_path).await?;
 
             exit_future.await
         },

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -303,11 +303,10 @@ where
         };
         
         {   // finalize_new_header
-            let parent_header = crate::node::evm::util::HEADER_CACHE_READER
-                .lock()
-                .unwrap()
-                .get_header_by_hash(&header.parent_hash)
-                .ok_or(BlockExecutionError::msg("Failed to get header from global header reader"))?;
+            let parent_header =
+                crate::node::evm::util::get_header_by_hash_from_cache(&header.parent_hash).ok_or(
+                    BlockExecutionError::msg("Failed to get header from global header reader"),
+                )?;
             let parent_header = SealedHeader::new(parent_header, header.parent_hash);
             let parent_snap = snapshot_provider
                 .snapshot_by_hash(&header.parent_hash)

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -163,10 +163,10 @@ where
 
         trace!("Succeed to new block executor, header: {:?}", ctx.header);
         if let Some(ref header) = ctx.header {
-            crate::node::evm::util::HEADER_CACHE_READER
-                .lock()
-                .unwrap()
-                .insert_header_to_cache_with_hash(header.clone(), ctx.header_hash);
+            crate::node::evm::util::insert_header_to_cache_with_hash(
+                header.clone(),
+                ctx.header_hash,
+            );
         } else if !ctx.mode.authors_block() {
             // Block-authoring modes (mining, simulation) have no current header.
             warn!(
@@ -473,7 +473,12 @@ where
             self.check_new_block(&block_env)?;
         }
 
-        let parent_timestamp = self.inner_ctx.parent_header.as_ref().unwrap().timestamp;
+        let parent_timestamp = self
+            .inner_ctx
+            .parent_header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing parent header in execution context"))?
+            .timestamp;
         self.try_update_build_in_system_contract(
             self.evm.block().number().to::<u64>(),
             self.evm.block().timestamp().to::<u64>(),
@@ -651,7 +656,12 @@ where
             "Start to finish"
         );
 
-        let parent_timestamp = self.inner_ctx.parent_header.as_ref().unwrap().timestamp;
+        let parent_timestamp = self
+            .inner_ctx
+            .parent_header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing parent header in execution context"))?
+            .timestamp;
         self.try_update_build_in_system_contract(
             self.evm.block().number().to::<u64>(),
             self.evm.block().timestamp().to::<u64>(),

--- a/src/node/evm/post_execution.rs
+++ b/src/node/evm/post_execution.rs
@@ -66,10 +66,20 @@ where
         self.verify_turn_length(self.inner_ctx.header.clone())?;
 
         // check the system txs.
-        if self.inner_ctx.header.as_ref().unwrap().difficulty != DIFF_INTURN {
+        let header_difficulty = self
+            .inner_ctx
+            .header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing header in execution context"))?
+            .difficulty;
+        if header_difficulty != DIFF_INTURN {
             tracing::debug!("Start to slash spoiled validator, block_number: {}, block_difficulty: {:?}, diff_inturn: {:?}", 
-                block.number(), self.inner_ctx.header.as_ref().unwrap().difficulty, DIFF_INTURN);
-            let snap = self.inner_ctx.snap.as_ref().unwrap();
+                block.number(), header_difficulty, DIFF_INTURN);
+            let snap = self
+                .inner_ctx
+                .snap
+                .as_ref()
+                .ok_or_else(|| BlockExecutionError::msg("Missing snapshot in execution context"))?;
             let spoiled_validator = snap.inturn_validator();
             let signed_recently = if self.spec.is_plato_active_at_block(block.number().to()) {
                 snap.sign_recently(spoiled_validator)
@@ -100,7 +110,12 @@ where
         let header_number = self.evm.block().number().to::<u64>();
         let header_timestamp = self.evm.block().timestamp().to::<u64>();
         let header_beneficiary = self.evm.block().beneficiary();
-        let parent_header = self.inner_ctx.parent_header.as_ref().unwrap().clone();
+        let parent_header = self
+            .inner_ctx
+            .parent_header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing parent header in execution context"))?
+            .clone();
         if self.spec.is_feynman_active_at_timestamp(header_number, header_timestamp) &&
             is_breathe_block(parent_header.timestamp, header_timestamp) &&
             !self.spec.is_feynman_transition_at_timestamp(header_number, header_timestamp, parent_header.timestamp)
@@ -129,14 +144,19 @@ where
             return Err(BscBlockExecutionError::Validation(BscBlockValidationError::UnexpectedSystemTx).into());
         }
 
-        let header = self.inner_ctx.header.as_ref().unwrap().clone();
+        let header = self
+            .inner_ctx
+            .header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing header in execution context"))?
+            .clone();
         
         // Notes: here we get the current block's snapshot (after applying this block's header) to prepare cache.
         // This is important because epoch_num may change during block application
         let current_snap = self
             .snapshot_provider
             .as_ref()
-            .unwrap()
+            .ok_or_else(|| BlockExecutionError::msg("Snapshot provider is not available"))?
             .snapshot_by_hash(&header.hash_slow())
             .ok_or(BlockExecutionError::msg("Failed to get current snapshot from snapshot provider"))?;
         
@@ -177,8 +197,15 @@ where
         current_validators: Option<(Vec<Address>, HashMap<Address, VoteAddress>)>, 
         header: Option<Header>
     ) -> Result<(), BlockExecutionError> {
-        let header_ref = header.as_ref().unwrap();
-        let epoch_length = self.inner_ctx.snap.as_ref().unwrap().epoch_num;
+        let header_ref = header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing header in execution context"))?;
+        let epoch_length = self
+            .inner_ctx
+            .snap
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing snapshot in execution context"))?
+            .epoch_num;
         if !header_ref.number.is_multiple_of(epoch_length) {
             tracing::trace!("Skip verify validator, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());
@@ -208,7 +235,10 @@ where
             })
             .collect();
 
-        let expected = self.parlia.get_validator_bytes_from_header(header_ref, epoch_length).unwrap();
+        let expected = self
+            .parlia
+            .get_validator_bytes_from_header(header_ref, epoch_length)
+            .ok_or_else(|| BlockExecutionError::msg("Missing validator bytes in epoch header"))?;
         if !validator_bytes.as_slice().eq(expected.as_slice()) {
             warn!("validator bytes: {:?}", hex::encode(validator_bytes));
             warn!("expected: {:?}", hex::encode(expected));
@@ -223,8 +253,15 @@ where
         &mut self, 
         header: Option<Header>
     ) -> Result<(), BlockExecutionError> {
-        let header_ref = header.as_ref().unwrap();
-        let epoch_length = self.inner_ctx.snap.as_ref().unwrap().epoch_num;
+        let header_ref = header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing header in execution context"))?;
+        let epoch_length = self
+            .inner_ctx
+            .snap
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing snapshot in execution context"))?
+            .epoch_num;
         if !header_ref.number.is_multiple_of(epoch_length) || !self.spec.is_bohr_active_at_timestamp(header_ref.number, header_ref.timestamp) {
             tracing::trace!("Skip verify turn length, block_number {} is not an epoch boundary, epoch_length: {}", header_ref.number, epoch_length);
             return Ok(());
@@ -264,7 +301,13 @@ where
             let (to, data) = self.system_contracts.get_turn_length();
             let bz = self.eth_call(to, data)?;
 
-            let turn_length = self.system_contracts.unpack_data_into_turn_length(bz.as_ref()).to::<u8>();
+            let turn_length = self
+                .system_contracts
+                .unpack_data_into_turn_length(bz.as_ref())
+                .ok_or_else(|| {
+                    BlockExecutionError::msg("Failed to decode system contract output")
+                })?
+                .to::<u8>();
             return Ok(turn_length);
         }
 
@@ -391,7 +434,9 @@ where
         let tx_env = BscTxEnv {
             base: TxEnv {
                 caller: sender,
-                kind: TxKind::Call(tx_to.unwrap()),
+                kind: TxKind::Call(
+                    tx_to.ok_or_else(|| BlockExecutionError::msg("System tx has no recipient"))?,
+                ),
                 nonce: account.nonce,
                 gas_limit: u64::MAX / 2,
                 value: transaction.value(),
@@ -575,7 +620,7 @@ where
                 ok_or_else(|| BlockExecutionError::msg(format!("Header not found for block hash: {target_hash}")))?;
             let snap = self.snapshot_provider.
                 as_ref().
-                unwrap().
+                ok_or_else(|| BlockExecutionError::msg("Snapshot provider is not available"))?.
                 snapshot_by_hash(&header.parent_hash).
                 ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
 
@@ -613,8 +658,15 @@ where
             .ok_or_else(|| BlockExecutionError::msg(format!("Header not found, block_hash: {}", attestation.data.target_hash)))?;
         let parent = get_header_by_hash_from_cache(&justified_header.parent_hash)
             .ok_or_else(|| BlockExecutionError::msg(format!("Header not found, block_hash: {}", justified_header.parent_hash)))?;
-        let snapshot = self.snapshot_provider.as_ref().unwrap().snapshot_by_hash(&parent.hash_slow());
-        let validators = &snapshot.unwrap().validators;  
+        let snapshot = self
+            .snapshot_provider
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Snapshot provider is not available"))?
+            .snapshot_by_hash(&parent.hash_slow())
+            .ok_or_else(|| BlockExecutionError::msg(format!(
+                "Snapshot not found for block hash: {}", parent.hash_slow()
+            )))?;
+        let validators = &snapshot.validators;
         let mut validators_bit_set = BitSet::new();
         let vote_address_set = attestation.vote_address_set;
         for i in 0..64 {
@@ -675,7 +727,11 @@ where
         block: &BlockEnv
     ) -> Result<(), BlockExecutionError> {
         tracing::debug!("Start to finalize new block, block_number: {}, mode: {:?}", block.number(), self.ctx.mode);
-        let snap = self.inner_ctx.snap.as_ref().unwrap();
+        let snap = self
+            .inner_ctx
+            .snap
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing snapshot in execution context"))?;
         let epoch_length = snap.epoch_num;
         let expected_validator = snap.inturn_validator();
         if block.beneficiary() != expected_validator {
@@ -712,7 +768,12 @@ where
         let header_number = self.evm.block().number().to::<u64>();
         let header_timestamp = self.evm.block().timestamp().to::<u64>();
         let header_beneficiary = self.evm.block().beneficiary();
-        let parent_header = self.inner_ctx.parent_header.as_ref().unwrap().clone();
+        let parent_header = self
+            .inner_ctx
+            .parent_header
+            .as_ref()
+            .ok_or_else(|| BlockExecutionError::msg("Missing parent header in execution context"))?
+            .clone();
         if self.spec.is_feynman_active_at_timestamp(header_number, header_timestamp) &&
             is_breathe_block(parent_header.timestamp, header_timestamp) &&
             !self.spec.is_feynman_transition_at_timestamp(header_number, header_timestamp, parent_header.timestamp)

--- a/src/node/evm/pre_execution.rs
+++ b/src/node/evm/pre_execution.rs
@@ -17,7 +17,6 @@ use crate::consensus::parlia::{VoteAddress, Snapshot, DIFF_INTURN, DIFF_NOTURN};
 use crate::consensus::parlia::util::{is_breathe_block, debug_header};
 use crate::consensus::parlia::vote::MAX_ATTESTATION_EXTRA_LENGTH;
 use crate::node::evm::error::{BscBlockExecutionError, BscBlockValidationError};
-use crate::node::evm::util::HEADER_CACHE_READER;
 use crate::system_contracts::SystemContract;
 use reth_revm::{database::{EvmStateProvider, StateProviderDatabase}, db::State};
 use crate::system_contracts::feynman_fork::ValidatorElectionInfo;
@@ -84,11 +83,16 @@ where
         system_contracts.get_current_validators_before_luban(parent.number())
     };
     let output = view_call_at_header(&mut db, &spec, parent.header(), to, data)?;
-    Ok(if is_luban {
-        system_contracts.unpack_data_into_validator_set(&output)
+    if is_luban {
+        system_contracts
+            .unpack_data_into_validator_set(&output)
+            .ok_or_else(|| BlockExecutionError::msg("Failed to decode system contract output"))
     } else {
-        (system_contracts.unpack_data_into_validator_set_before_luban(&output), Vec::new())
-    })
+        let validators = system_contracts
+            .unpack_data_into_validator_set_before_luban(&output)
+            .ok_or_else(|| BlockExecutionError::msg("Failed to decode system contract output"))?;
+        Ok((validators, Vec::new()))
+    }
 }
 
 /// Which block env a Parlia system-contract read uses.
@@ -171,19 +175,22 @@ where
         tracing::trace!("Check new block, block_number: {}", block_number);
 
         self.inner_ctx.header = self.ctx.header.clone();
-        let header = self.inner_ctx.header.clone().unwrap();
+        let header = self
+            .inner_ctx
+            .header
+            .clone()
+            .ok_or_else(|| BlockExecutionError::msg("Missing header in execution context"))?;
 
-        let parent_header = crate::node::evm::util::HEADER_CACHE_READER
-            .lock()
-            .unwrap()
-            .get_header_by_hash(&header.parent_hash)
-            .ok_or(BlockExecutionError::msg("Failed to get parent header from global header reader"))?;
+        let parent_header =
+            crate::node::evm::util::get_header_by_hash_from_cache(&header.parent_hash).ok_or(
+                BlockExecutionError::msg("Failed to get parent header from global header reader"),
+            )?;
         self.inner_ctx.parent_header = Some(parent_header.clone());
 
         let snap = self
             .snapshot_provider
             .as_ref()
-            .unwrap()
+            .ok_or_else(|| BlockExecutionError::msg("Snapshot provider is not available"))?
             .snapshot_by_hash(&header.parent_hash)
             .ok_or(BlockExecutionError::msg("Failed to get snapshot from snapshot provider"))?;
         self.inner_ctx.snap = Some(snap.clone());
@@ -221,13 +228,26 @@ where
 
             // Also fetch validator NodeIDs after Maxwell.
             if self.spec.is_maxwell_active_at_timestamp(header.number, header.timestamp) {
-                let (to2, data2) = self.system_contracts.get_node_ids(self.inner_ctx.current_validators.as_ref().unwrap().0.clone());
+                let current_validators = self
+                    .inner_ctx
+                    .current_validators
+                    .as_ref()
+                    .ok_or_else(|| BlockExecutionError::msg("Invalid current validators data"))?
+                    .0
+                    .clone();
+                let (to2, data2) = self.system_contracts.get_node_ids(current_validators);
                 if let Ok(output2) = self.eth_call(to2, data2) {
-                    let (_consensus_addrs, node_ids_list) = self.system_contracts.unpack_data_into_node_ids(&output2);
-                    tracing::debug!("node_ids_list: {:?}", node_ids_list);
-                    let mut flat: Vec<[u8; 32]> = Vec::new();
-                    for ids in node_ids_list { for id in ids { flat.push(id); } }
-                    crate::node::network::evn_peers::update_onchain_nodeids(flat);
+                    match self.system_contracts.unpack_data_into_node_ids(&output2) {
+                        Some((_consensus_addrs, node_ids_list)) => {
+                            tracing::debug!("node_ids_list: {:?}", node_ids_list);
+                            let mut flat: Vec<[u8; 32]> = Vec::new();
+                            for ids in node_ids_list { for id in ids { flat.push(id); } }
+                            crate::node::network::evn_peers::update_onchain_nodeids(flat);
+                        }
+                        // Advisory data for EVN peering only, so a decode failure must not
+                        // fail the block.
+                        None => tracing::warn!("Failed to decode getNodeIDs output"),
+                    }
                 }
             }
         }
@@ -238,15 +258,24 @@ where
         {
             let (to, data) = self.system_contracts.get_max_elected_validators();
             let bz = self.eth_call(to, data)?;
-            let max_elected_validators = self.system_contracts.unpack_data_into_max_elected_validators(bz.as_ref());
+            let max_elected_validators = self
+                .system_contracts
+                .unpack_data_into_max_elected_validators(bz.as_ref())
+                .ok_or_else(|| {
+                    BlockExecutionError::msg("Failed to decode system contract output")
+                })?;
             tracing::debug!("max_elected_validators: {:?}", max_elected_validators);
             self.inner_ctx.max_elected_validators = Some(max_elected_validators);
 
             let (to, data) = self.system_contracts.get_validator_election_info();
             let bz = self.eth_call(to, data)?;
 
-            let (validators, voting_powers, vote_addrs, total_length) =
-                self.system_contracts.unpack_data_into_validator_election_info(bz.as_ref());
+            let (validators, voting_powers, vote_addrs, total_length) = self
+                .system_contracts
+                .unpack_data_into_validator_election_info(bz.as_ref())
+                .ok_or_else(|| {
+                    BlockExecutionError::msg("Failed to decode system contract output")
+                })?;
 
             let total_length = total_length.to::<u64>() as usize;
             if validators.len() != total_length ||
@@ -351,11 +380,19 @@ where
             CallBlockEnv::Current => self.eth_call(to, data)?,
             CallBlockEnv::Parent => self.eth_call_at_parent(to, data)?,
         };
-        Ok(if is_luban {
-            self.system_contracts.unpack_data_into_validator_set(&output)
+        if is_luban {
+            self.system_contracts
+                .unpack_data_into_validator_set(&output)
+                .ok_or_else(|| BlockExecutionError::msg("Failed to decode system contract output"))
         } else {
-            (self.system_contracts.unpack_data_into_validator_set_before_luban(&output), Vec::new())
-        })
+            let validators = self
+                .system_contracts
+                .unpack_data_into_validator_set_before_luban(&output)
+                .ok_or_else(|| {
+                    BlockExecutionError::msg("Failed to decode system contract output")
+                })?;
+            Ok((validators, Vec::new()))
+        }
     }
 
     fn verify_cascading_fields(
@@ -426,10 +463,9 @@ where
                     is_match = true;
                     break;
                 }
-                ancestor = crate::node::evm::util::HEADER_CACHE_READER
-                    .lock()
-                    .unwrap()
-                    .get_header_by_hash(&ancestor.parent_hash())
+                ancestor = crate::node::evm::util::get_header_by_hash_from_cache(
+                    &ancestor.parent_hash(),
+                )
                     .ok_or_else(|| BscBlockExecutionError::UnknownHeader { block_hash: ancestor.parent_hash() })?;
                 tracing::debug!("ancestor: {:?}", ancestor);
             }
@@ -462,7 +498,7 @@ where
             let pre_snap = self
                 .snapshot_provider
                 .as_ref()
-                .unwrap()
+                .ok_or_else(|| BlockExecutionError::msg("Snapshot provider is not available"))?
                 .snapshot_by_hash(&ancestor.parent_hash)
                 .ok_or(BlockExecutionError::msg("Failed to get pre snapshot from snapshot provider"))?;
 
@@ -621,19 +657,13 @@ where
         snap: &Snapshot,
     ) -> Result<Header, BlockExecutionError> {
         if snap.vote_data.source_hash == B256::ZERO && snap.vote_data.target_hash == B256::ZERO {
-            return HEADER_CACHE_READER
-                .lock()
-                .unwrap()
-                .get_header_by_number(0)
+            return crate::node::evm::util::get_cannonical_header_from_cache(0)
                 .ok_or_else(|| {
                     BscBlockExecutionError::UnknownHeader { block_hash: B256::ZERO }.into()
                 });
         }
 
-        HEADER_CACHE_READER
-            .lock()
-            .unwrap()
-            .get_header_by_hash(&snap.vote_data.target_hash)
+        crate::node::evm::util::get_header_by_hash_from_cache(&snap.vote_data.target_hash)
             .ok_or_else(|| {
                 BscBlockExecutionError::UnknownHeader { block_hash: snap.vote_data.target_hash }.into()
             })
@@ -644,11 +674,11 @@ where
         &mut self, 
         block: &BlockEnv
     ) -> Result<(), BlockExecutionError> {
-        let parent_header = crate::node::evm::util::HEADER_CACHE_READER
-            .lock()
-            .unwrap()
-            .get_header_by_hash(&self.ctx.base.parent_hash)
-            .ok_or(BlockExecutionError::msg("Failed to get parent header from global header reader"))?;
+        let parent_header =
+            crate::node::evm::util::get_header_by_hash_from_cache(&self.ctx.base.parent_hash)
+                .ok_or(BlockExecutionError::msg(
+                    "Failed to get parent header from global header reader",
+                ))?;
         self.inner_ctx.parent_header = Some(parent_header.clone());
 
         // Only the Parlia finalization in `finish` reads the snapshot, and simulation skips
@@ -676,15 +706,24 @@ where
         {
             let (to, data) = self.system_contracts.get_max_elected_validators();
             let bz = self.eth_call(to, data)?;
-            let max_elected_validators = self.system_contracts.unpack_data_into_max_elected_validators(bz.as_ref());
+            let max_elected_validators = self
+                .system_contracts
+                .unpack_data_into_max_elected_validators(bz.as_ref())
+                .ok_or_else(|| {
+                    BlockExecutionError::msg("Failed to decode system contract output")
+                })?;
             tracing::debug!("max_elected_validators: {:?}", max_elected_validators);
             self.inner_ctx.max_elected_validators = Some(max_elected_validators);
 
             let (to, data) = self.system_contracts.get_validator_election_info();
             let bz = self.eth_call(to, data)?;
 
-            let (validators, voting_powers, vote_addrs, total_length) =
-                self.system_contracts.unpack_data_into_validator_election_info(bz.as_ref());
+            let (validators, voting_powers, vote_addrs, total_length) = self
+                .system_contracts
+                .unpack_data_into_validator_election_info(bz.as_ref())
+                .ok_or_else(|| {
+                    BlockExecutionError::msg("Failed to decode system contract output")
+                })?;
 
             let total_length = total_length.to::<u64>() as usize;
             if validators.len() != total_length ||

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -44,28 +44,15 @@ impl HeaderCacheReader {
         }
     }
 
-    pub fn get_header_by_number(&mut self, block_number: u64) -> Option<Header> {
-        if let Some(header) = self.blocknumber_to_header.get(&block_number) {
-            tracing::trace!("Get header from cache, block_number: {:?}", header.number());
-            return Some(header.clone());
-        }
-        if let Some(header) = crate::shared::get_canonical_header_by_number_from_provider(block_number) {
-            tracing::trace!("Get header from provider, block_number: {:?}", header.number());
-            return Some(header);
-        }
-
-        tracing::warn!("Failed to get header from cache and provider, block_number: {:?}", block_number);
-        None
+    /// Cache-only lookup. The provider fallback lives in the free functions below, so the
+    /// mutex is released before any database read.
+    pub fn cached_header_by_number(&mut self, block_number: u64) -> Option<Header> {
+        self.blocknumber_to_header.get(&block_number).cloned()
     }
 
-    pub fn get_header_by_hash(&mut self, block_hash: &B256) -> Option<Header> {
-        if let Some(header) = self.blockhash_to_header.get(block_hash) {
-            return Some(header.clone());
-        }
-        if let Some(header) = crate::shared::get_canonical_header_by_hash_from_provider(block_hash) {
-            return Some(header);
-        }
-        None
+    /// Cache-only lookup; see [`Self::cached_header_by_number`].
+    pub fn cached_header_by_hash(&mut self, block_hash: &B256) -> Option<Header> {
+        self.blockhash_to_header.get(block_hash).cloned()
     }
 
     pub fn insert_header_to_cache(&mut self, header: Header) {
@@ -86,27 +73,44 @@ pub static HEADER_CACHE_READER: LazyLock<Mutex<HeaderCacheReader>> = LazyLock::n
     Mutex::new(HeaderCacheReader::new(100000))
 });
 
+/// Lock the header cache, recovering from a poisoned mutex.
+///
+/// The cache is a plain LRU: a panic while it was held leaves it structurally intact, and
+/// killing every later header lookup because some unrelated task panicked is worse than
+/// reusing it.
+fn lock_header_cache() -> std::sync::MutexGuard<'static, HeaderCacheReader> {
+    HEADER_CACHE_READER.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 /// Get header by hash from the global header provider
 pub fn get_header_by_hash_from_cache(block_hash: &BlockHash) -> Option<Header> {
-    let header = HEADER_CACHE_READER.lock().unwrap().get_header_by_hash(block_hash);
+    // Cache first, and drop the guard before falling back to the provider: the fallback is a
+    // real database read, and holding the global header lock across it stalls every other
+    // header lookup in the node.
+    if let Some(header) = lock_header_cache().cached_header_by_hash(block_hash) {
+        return Some(header);
+    }
+    let header = crate::shared::get_canonical_header_by_hash_from_provider(block_hash);
     tracing::trace!("Succeed to fetch header by hash, is_none: {} for hash {}", header.is_none(), block_hash);
     header
 }
 
 /// Get canonical header by number from the global header provider
 pub fn get_cannonical_header_from_cache(number: BlockNumber) -> Option<Header> {
-    let header = HEADER_CACHE_READER.lock().unwrap().get_header_by_number(number);
+    if let Some(header) = lock_header_cache().cached_header_by_number(number) {
+        return Some(header);
+    }
+    let header = crate::shared::get_canonical_header_by_number_from_provider(number);
     tracing::debug!("Succeed to fetch canonical header by number, is_none: {} for number {}", header.is_none(), number);
     header
 }
 
 /// Insert header to cache
 pub fn insert_header_to_cache(header: Header) {
-    HEADER_CACHE_READER.lock().unwrap().insert_header_to_cache(header);
+    lock_header_cache().insert_header_to_cache(header);
 }
 
 /// Insert header with a known hash to avoid re-hashing.
 pub fn insert_header_to_cache_with_hash(header: Header, block_hash: Option<BlockHash>) {
-    HEADER_CACHE_READER.lock().unwrap().insert_header_to_cache_with_hash(header, block_hash);
+    lock_header_cache().insert_header_to_cache_with_hash(header, block_hash);
 }

--- a/src/node/evm/util.rs
+++ b/src/node/evm/util.rs
@@ -101,6 +101,9 @@ pub fn get_cannonical_header_from_cache(number: BlockNumber) -> Option<Header> {
         return Some(header);
     }
     let header = crate::shared::get_canonical_header_by_number_from_provider(number);
+    if header.is_none() {
+        tracing::warn!("Failed to get header from cache and provider, block_number: {:?}", number);
+    }
     tracing::debug!("Succeed to fetch canonical header by number, is_none: {} for number {}", header.is_none(), number);
     header
 }

--- a/src/node/miner/bid_simulator.rs
+++ b/src/node/miner/bid_simulator.rs
@@ -736,9 +736,13 @@ where
         if self.greedy_merge {
             let ending_bids_extra = 20;
             let min_time_left_for_ending_bids = DELAY_LEFT_OVER + ending_bids_extra;
+            let Some(header) = bid_runtime.mining_ctx.header.as_ref() else {
+                debug!("bidSimulator: no header in the mining context, skipping bid");
+                return Err(());
+            };
             let delay_ms = self.parlia.delay_for_bid_simulation(
                 &bid_runtime.mining_ctx.parent_snapshot,
-                bid_runtime.mining_ctx.header.as_ref().unwrap(),
+                header,
                 min_time_left_for_ending_bids,
             );
             if delay_ms > 0 {
@@ -1120,7 +1124,11 @@ where
     {
         let base_fee: u64 = builder.evm().block().basefee();
         let blob_params = self.chain_spec.blob_params_at_timestamp(self.attributes.timestamp);
-        let header = self.mining_ctx.header.as_ref().unwrap();
+        let header = self
+            .mining_ctx
+            .header
+            .as_ref()
+            .ok_or("no header in the mining context")?;
         let blob_eligible = is_blob_eligible_block(&self.chain_spec, header.number, header.timestamp);
         let mut max_blob_count =
             blob_params.as_ref().map(|params| params.max_blob_count).unwrap_or_default();
@@ -1288,12 +1296,14 @@ where
             self.parent_header.number,
             self.parent_header.timestamp,
         ) {
-            if let Some(excess) = self.mining_ctx.header.as_ref().unwrap().excess_blob_gas {
+            let header = self
+                .mining_ctx
+                .header
+                .as_ref()
+                .ok_or("no header in the mining context")?;
+            if let Some(excess) = header.excess_blob_gas {
                 if excess != 0 {
-                    blob_fee = Some(calc_blob_fee(
-                        &self.chain_spec,
-                        self.mining_ctx.header.as_ref().unwrap(),
-                    ));
+                    blob_fee = Some(calc_blob_fee(&self.chain_spec, header));
                 }
             }
         }

--- a/src/node/miner/payload.rs
+++ b/src/node/miner/payload.rs
@@ -974,9 +974,21 @@ where
                 "Transaction included in block"
             );
             if tx.is_eip4844() {
-                let sidecar = sidecars_map.get(tx.hash()).unwrap();
+                // The sidecar map is built from the same pool transactions, so a miss here
+                // means the block still seals — only its blob record is missing.
+                let Some(inner) =
+                    sidecars_map.get(tx.hash()).and_then(|sidecar| sidecar.as_eip4844())
+                else {
+                    warn!(
+                        target: "payload_builder",
+                        trace_id,
+                        tx_hash = ?tx.hash(),
+                        "No EIP-4844 sidecar for a blob transaction, skipping its blob record"
+                    );
+                    continue;
+                };
                 let bsc_blob_tx_sidecar = BscBlobTransactionSidecar {
-                    inner: sidecar.as_eip4844().unwrap().clone(),
+                    inner: inner.clone(),
                     block_number: sealed_block.header().number(),
                     block_hash: sealed_block.hash(),
                     tx_index: u64::try_from(index).unwrap_or(u64::MAX),
@@ -1296,7 +1308,9 @@ where
         metrics::histogram!("bsc_miner_effective_reserve_ms").record(effective_reserve as f64);
         let mining_delay = parlia.clone().delay_for_mining(
             &mining_ctx.parent_snapshot,
-            mining_ctx.header.as_ref().unwrap(),
+            // Set by `BscMiner` before the job is created; a payload job without it is a
+            // construction bug, not a runtime condition.
+            mining_ctx.header.as_ref().expect("mining context has a header for the block"),
             effective_reserve,
         );
         let pending_basefee = builder.pool.block_info().pending_basefee;

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -342,9 +342,11 @@ impl BscNetworkBuilder {
                 .take()
                 .expect("node should only be launched once")
                 .await
-                .unwrap();
+                .expect("engine handle sender dropped before the beacon engine was built");
 
-            ImportService::new(
+            // This task is critical: returning quietly would leave the node without block
+            // import, so surface the error and let the node go down with it.
+            if let Err(err) = ImportService::new(
                 provider,
                 chain_spec,
                 handle,
@@ -355,7 +357,10 @@ impl BscNetworkBuilder {
                 to_network,
             )
             .await
-            .unwrap();
+            {
+                tracing::error!(target: "bsc::network", ?err, "Block import service exited");
+                panic!("block import service exited: {err:?}");
+            }
         });
 
         // TODO: update network with the latest canonical head, but has a fork id issue, can fix it later.

--- a/src/node/vote_journal.rs
+++ b/src/node/vote_journal.rs
@@ -179,6 +179,15 @@ static GLOBAL_JOURNAL: LazyLock<Mutex<VoteJournal>> = LazyLock::new(|| {
 });
 
 /// Get a guard to the global vote journal.
+///
+/// The guard is deliberately held across the journal's file I/O in [`persist_vote`]: the
+/// rules check and the append have to be one atomic step, or two votes for the same height
+/// could both pass the check and be signed. The write is a single small append plus
+/// `sync_all`, and vote signing is once per block, so the contention is bounded.
+///
+/// Poisoning panics rather than recovering: a panic mid-`write_vote` can leave the in-memory
+/// height claim and the on-disk journal disagreeing, and silently continuing with that is how
+/// a double sign gets through.
 pub fn global() -> std::sync::MutexGuard<'static, VoteJournal> { GLOBAL_JOURNAL.lock().expect("vote journal poisoned") }
 
 /// Helper for external modules to check the rules via global journal.

--- a/src/system_contracts/mod.rs
+++ b/src/system_contracts/mod.rs
@@ -55,6 +55,13 @@ lazy_static! {
     );
 }
 
+/// `(consensusAddresses, votingPowers, voteAddresses, totalLength)` from
+/// `StakeHub.getValidatorElectionInfo`.
+type ValidatorElectionInfo = (Vec<Address>, Vec<U256>, Vec<Vec<u8>>, U256);
+
+/// `(consensusAddresses, nodeIDsList)` from `StakeHub.getNodeIDs`.
+type NodeIds = (Vec<Address>, Vec<Vec<[u8; 32]>>);
+
 impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     pub(crate) fn new(chain_spec: Spec) -> Self {
         let validator_abi_before_luban = Arc::clone(&VALIDATOR_SET_ABI_BEFORE_LUBAN_JSON);
@@ -79,18 +86,19 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     }
 
     /// Unpack the data into validator set before luban.
-    pub fn unpack_data_into_validator_set_before_luban(&self, data: &[u8]) -> Vec<Address> {
+    ///
+    /// `data` is whatever the system contract returned, so its shape is only guaranteed while
+    /// the deployed contract matches the ABI compiled in here; `None` means it did not.
+    pub fn unpack_data_into_validator_set_before_luban(&self, data: &[u8]) -> Option<Vec<Address>> {
         let function =
             self.validator_abi_before_luban.function("getValidators").unwrap().first().unwrap();
-        let output = function.abi_decode_output(data).unwrap();
+        let output = function.abi_decode_output(data).ok()?;
 
         output
-            .first()
-            .unwrap()
-            .as_array()
-            .unwrap()
+            .first()?
+            .as_array()?
             .iter()
-            .map(|val| val.as_address().unwrap())
+            .map(|val| val.as_address())
             .collect()
     }
 
@@ -101,26 +109,32 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     }
 
     /// Unpack the data into validator set.
-    pub fn unpack_data_into_validator_set(&self, data: &[u8]) -> (Vec<Address>, Vec<VoteAddress>) {
+    ///
+    /// `None` if the returned data does not match the ABI compiled in here.
+    pub fn unpack_data_into_validator_set(
+        &self,
+        data: &[u8],
+    ) -> Option<(Vec<Address>, Vec<VoteAddress>)> {
         let function = self.validator_abi.function("getMiningValidators").unwrap().first().unwrap();
-        let output = function.abi_decode_output(data).unwrap();
+        let output = function.abi_decode_output(data).ok()?;
 
-        let consensus_addresses =
-            output[0].as_array().unwrap().iter().map(|val| val.as_address().unwrap()).collect();
-        let vote_address = output[1]
-            .as_array()
-            .unwrap()
+        let consensus_addresses: Vec<Address> =
+            output.first()?.as_array()?.iter().map(|val| val.as_address()).collect::<Option<_>>()?;
+        let vote_address = output
+            .get(1)?
+            .as_array()?
             .iter()
             .map(|val| {
-                if val.as_bytes().unwrap().is_empty() {
+                let bytes = val.as_bytes()?;
+                Some(if bytes.is_empty() {
                     VoteAddress::default()
                 } else {
-                    VoteAddress::from_slice(val.as_bytes().unwrap())
-                }
+                    VoteAddress::from_slice(bytes)
+                })
             })
-            .collect();
+            .collect::<Option<_>>()?;
 
-        (consensus_addresses, vote_address)
+        Some((consensus_addresses, vote_address))
     }
 
     /// Return system address and input which is used to query max elected validators.
@@ -132,12 +146,14 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     }
 
     /// Unpack the data into max elected validators.
-    pub fn unpack_data_into_max_elected_validators(&self, data: &[u8]) -> U256 {
+    ///
+    /// `None` if the returned data does not match the ABI compiled in here.
+    pub fn unpack_data_into_max_elected_validators(&self, data: &[u8]) -> Option<U256> {
         let function =
             self.stake_hub_abi.function("maxElectedValidators").unwrap().first().unwrap();
-        let output = function.abi_decode_output(data).unwrap();
+        let output = function.abi_decode_output(data).ok()?;
 
-        output[0].as_uint().unwrap().0
+        Some(output.first()?.as_uint()?.0)
     }
 
     /// Return system address and input which is used to query validator election info.
@@ -164,27 +180,33 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     }
 
     /// Unpack the data into validator election info.
+    ///
+    /// `None` if the returned data does not match the ABI compiled in here.
     pub fn unpack_data_into_validator_election_info(
         &self,
         data: &[u8],
-    ) -> (Vec<Address>, Vec<U256>, Vec<Vec<u8>>, U256) {
+    ) -> Option<ValidatorElectionInfo> {
         let function =
             self.stake_hub_abi.function("getValidatorElectionInfo").unwrap().first().unwrap();
-        let output = function.abi_decode_output(data).unwrap();
+        let output = function.abi_decode_output(data).ok()?;
 
-        let consensus_address =
-            output[0].as_array().unwrap().iter().map(|val| val.as_address().unwrap()).collect();
-        let voting_powers =
-            output[1].as_array().unwrap().iter().map(|val| val.as_uint().unwrap().0).collect();
-        let vote_addresses = output[2]
-            .as_array()
-            .unwrap()
+        let consensus_address: Vec<Address> =
+            output.first()?.as_array()?.iter().map(|val| val.as_address()).collect::<Option<_>>()?;
+        let voting_powers: Vec<U256> = output
+            .get(1)?
+            .as_array()?
             .iter()
-            .map(|val| val.as_bytes().unwrap().to_vec())
-            .collect();
-        let total_length = output[3].as_uint().unwrap().0;
+            .map(|val| Some(val.as_uint()?.0))
+            .collect::<Option<_>>()?;
+        let vote_addresses: Vec<Vec<u8>> = output
+            .get(2)?
+            .as_array()?
+            .iter()
+            .map(|val| Some(val.as_bytes()?.to_vec()))
+            .collect::<Option<_>>()?;
+        let total_length = output.get(3)?.as_uint()?.0;
 
-        (consensus_address, voting_powers, vote_addresses, total_length)
+        Some((consensus_address, voting_powers, vote_addresses, total_length))
     }
 
     /// Return system address and input which is used to query turn length.
@@ -195,11 +217,13 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
     }
 
     /// Unpack the data into turn length.
-    pub fn unpack_data_into_turn_length(&self, data: &[u8]) -> U256 {
+    ///
+    /// `None` if the returned data does not match the ABI compiled in here.
+    pub fn unpack_data_into_turn_length(&self, data: &[u8]) -> Option<U256> {
         let function = self.validator_abi.function("getTurnLength").unwrap().first().unwrap();
-        let output = function.abi_decode_output(data).unwrap();
+        let output = function.abi_decode_output(data).ok()?;
 
-        output[0].as_uint().unwrap().0
+        Some(output.first()?.as_uint()?.0)
     }
 
     /// Return system address and input to query validator NodeIDs from StakeHub.
@@ -213,36 +237,36 @@ impl<Spec: EthChainSpec + crate::hardforks::BscHardforks> SystemContract<Spec> {
 
     /// Unpack the data into (consensusAddresses, nodeIDsList)
     /// Note: This function should only be called after Maxwell hardfork when StakeHub.getNodeIDs is available.
-    pub fn unpack_data_into_node_ids(&self, data: &[u8]) -> (Vec<Address>, Vec<Vec<[u8; 32]>>) {
+    ///
+    /// `None` if the returned data does not match the ABI compiled in here.
+    pub fn unpack_data_into_node_ids(
+        &self,
+        data: &[u8],
+    ) -> Option<NodeIds> {
         let function = self.stake_hub_abi.function("getNodeIDs").unwrap().first().unwrap();
-        let output = function.abi_decode_output(data).unwrap();
+        let output = function.abi_decode_output(data).ok()?;
 
-        let consensus_addresses = output[0]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|val| val.as_address().unwrap())
-            .collect::<Vec<_>>();
+        let consensus_addresses: Vec<Address> =
+            output.first()?.as_array()?.iter().map(|val| val.as_address()).collect::<Option<_>>()?;
 
-        let node_ids_list = output[1]
-            .as_array()
-            .unwrap()
+        let node_ids_list: Vec<Vec<[u8; 32]>> = output
+            .get(1)?
+            .as_array()?
             .iter()
             .map(|arr| {
-                arr.as_array()
-                    .unwrap()
+                arr.as_array()?
                     .iter()
                     .map(|v| {
-                        let (b, _size) = v.as_fixed_bytes().unwrap();
-                        let mut out = [0u8; 32];
-                        out.copy_from_slice(b);
-                        out
+                        let (b, _size) = v.as_fixed_bytes()?;
+                        // A node ID is a bytes32; anything else means the ABI moved on.
+                        let out: [u8; 32] = b.try_into().ok()?;
+                        Some(out)
                     })
-                    .collect::<Vec<[u8; 32]>>()
+                    .collect::<Option<Vec<[u8; 32]>>>()
             })
-            .collect::<Vec<_>>();
+            .collect::<Option<_>>()?;
 
-        (consensus_addresses, node_ids_list)
+        Some((consensus_addresses, node_ids_list))
     }
 
     /// Return a transaction to slash a validator.
@@ -1162,6 +1186,30 @@ mod tests {
     use super::*;
     use alloy_consensus::TxEip1559;
     use alloy_primitives::{address, Signature, U256};
+
+    /// The unpackers decode whatever the system contract returned. That shape is only
+    /// guaranteed while the deployed contract matches the ABI compiled in here, so a
+    /// mismatch has to surface as `None` instead of unwinding the block execution.
+    #[test]
+    fn unpacking_unexpected_system_contract_output_returns_none() {
+        let contracts = SystemContract::new(crate::chainspec::BscChainSpec::from(
+            crate::chainspec::bsc::bsc_mainnet(),
+        ));
+        // Empty output: what a call to a contract that no longer has the function returns.
+        assert!(contracts.unpack_data_into_validator_set(&[]).is_none());
+        assert!(contracts.unpack_data_into_validator_set_before_luban(&[]).is_none());
+        assert!(contracts.unpack_data_into_max_elected_validators(&[]).is_none());
+        assert!(contracts.unpack_data_into_validator_election_info(&[]).is_none());
+        assert!(contracts.unpack_data_into_turn_length(&[]).is_none());
+        assert!(contracts.unpack_data_into_node_ids(&[]).is_none());
+
+        // Well-sized but structurally wrong output (the dynamic offsets are nonsense).
+        let garbage = [0xffu8; 64];
+        assert!(contracts.unpack_data_into_validator_set(&garbage).is_none());
+        assert!(contracts.unpack_data_into_validator_set_before_luban(&garbage).is_none());
+        assert!(contracts.unpack_data_into_validator_election_info(&garbage).is_none());
+        assert!(contracts.unpack_data_into_node_ids(&garbage).is_none());
+    }
 
     fn dummy_sig() -> Signature {
         Signature::new(U256::ZERO, U256::ZERO, false)


### PR DESCRIPTION
Follow-up to the static-scan `unwrap()`/`expect()` inventory. Of the 60 callsites that scan flagged for review, 57 were still open on `develop`; this closes all of them. Line numbers below are post-change.

## The two confirmed bugs

`signed_header` and `validator_set` are optional fields in the CometBFT light-block protobuf, so anyone can omit them by crafting the precompile calldata. The `unwrap`s panicked the node before the precompile's own `InvalidInput` arms — sitting right below them — could run, for the base gas cost and with no privileges. Both are now `ok_or(BscPrecompileError::InvalidInput)?`, and `convert_light_block_from_proto` is shared by the Hertz and Pasteur entry points, so both are covered.

`light_block_missing_optional_proto_fields_is_invalid_input` is a real regression test: with the `unwrap`s restored it fails on the original panic.

The third confirmed bug (the BLS vote-signature `unwrap`) was already fixed on `develop` and is untouched here.

## High tier

- **`parlia/util.rs`** — the eight optional-field unwraps in the chain-id header hasher become `unwrap_or_default()` in **both** the encoder and the length calculation; they have to agree, or the declared RLP payload length no longer matches the bytes written. One of the two new tests asserts exactly that. The `extra_data` slice is now `saturating_sub`. Note these were rated too high in the scan: a wire-decoded header cannot reach them with the fields unset, because they precede `parent_beacon_block_root` positionally in the RLP list. This is insurance for hand-built headers, not a live hole.
- **`snapshot_provider.as_ref().unwrap()` ×5** (`post_execution.rs:156/621/661`, `pre_execution.rs:190/498`) — `ok_or(…"Snapshot provider is not available")?`, matching the pattern the `eth_simulateV1` fix already established in `prepare_new_block`.
- **`post_execution.rs:667`** — the `snapshot_by_hash(...).unwrap()` in `process_attestation`, which was inconsistent with the `ok_or_else` calls on the two lines above it.
- **`post_execution.rs:241`** — `get_validator_bytes_from_header` returns `Option`; unwrapping it panicked on the epoch validator-bytes check.

## Medium

- **`system_contracts`** — the six `unpack_data_into_*` functions decode whatever the deployed contract returned, so they return `Option<T>` now; all ten call sites map that to a `BlockExecutionError`. The ABI-lookup unwraps stay (hardcoded names against a compiled-in ABI). This also fixes a latent `copy_from_slice` length panic in `unpack_data_into_node_ids`.
- **Header cache** — `HeaderCacheReader::get_header_by_*` lose their provider fallback (now `cached_header_by_*`); the fallback moved into the free functions, which **drop the guard before the database read**. All six direct-lock call sites route through them, and `lock_header_cache` is poison-tolerant. Cache hit/miss semantics are unchanged: provider results are deliberately still not inserted, since a hash-keyed lookup would otherwise poison the number→header map with non-canonical entries.
- **`network/mod.rs`** — both `unwrap`s become `expect`s naming the actual failure, and the import-service error is logged before it panics. Still fatal by design: it is a critical task, and returning quietly would leave the node with no block import.
- **`miner/payload.rs`** — a blob transaction with no sidecar warns and skips its blob record instead of panicking mid-seal.
- **`main.rs`** — an IPC client failure propagates as a startup error via `?` instead of panicking.

## Deliberately not converted

- **`vote_journal.rs` `global()`** — the guard must span the rules check and the append, or two votes for the same height can both pass and be signed. Releasing it would trade a latency concern for a double-sign race, and poisoning must stay fatal for the same reason. Documented rather than changed.
- **`engine.rs:281`** and **`payload.rs:1299`** — inside a `get_or_init` closure and a `new() -> (Self, Handle)` respectively, neither of which can return an error. Both now carry `expect`s that state the invariant.

## Verification

- `cargo clippy --workspace --tests --all-features` with `RUSTFLAGS="-D warnings"`: clean
- `cargo test --all -- --test-threads=1`: passes (544 lib tests plus the rest)
- 5 new tests: 1 cometbft, 2 parlia header hasher, 1 system-contract unpacking (plus the payload-length consistency assertion inside the hasher test)
- No `cargo fmt` run (it would reformat ~110 unrelated files); added lines hand-wrapped to 100 columns

Not yet exercised on a devnet — worth a run before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
