### PR TITLE
deps: bump reth to pick up the trace_filter fan-out fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -4638,7 +4638,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6949,7 +6949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7019,7 +7019,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7057,7 +7057,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7535,7 +7535,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7636,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7656,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7769,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7847,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -7886,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -7915,7 +7915,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7941,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -7990,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8015,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8039,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -8063,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8098,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8149,7 +8149,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8174,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8263,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "bytes 1.11.1",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8328,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8382,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "clap",
  "eyre",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8437,7 +8437,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8481,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8495,7 +8495,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8550,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8600,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "serde",
  "serde_json",
@@ -8662,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "bytes 1.11.1",
  "futures",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "bindgen",
  "cc",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "futures",
  "metrics",
@@ -8762,7 +8762,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8771,7 +8771,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8785,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8891,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8906,7 +8906,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8937,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8961,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -9124,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "bytes 1.11.1",
  "eyre",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9232,7 +9232,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9244,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9268,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9359,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9419,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -9527,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9622,7 +9622,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9670,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.1",
@@ -9733,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9846,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9860,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9880,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9919,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9974,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "clap",
  "eyre",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "clap",
  "eyre",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10062,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10138,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/bnb-chain/reth.git?branch=develop#759fececb867c0a3250b1593006f3d39be92497a"
+source = "git+https://github.com/bnb-chain/reth.git?branch=develop#c8e1e73b4b7ca6b4784e0bfe2672e9a70bfa908e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13173,7 +13173,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Bumps the locked `reth` rev from `759fececb8` to `c8e1e73b4b` to pick up [bnb-chain/reth#230](https://github.com/bnb-chain/reth/pull/230), which cherry-picks upstream [paradigmxyz/reth#25133](https://github.com/paradigmxyz/reth/pull/25133) (`d062b3fb`, "fix(rpc): buffer trace_filter block replays") onto our 2.2.0-based `develop`.

Lockfile-only change — the manifests keep `branch = "develop"`. The commit range `759fececb8..c8e1e73b4b` contains just that merge and its one commit, touching only `crates/rpc/rpc/src/trace.rs` (+171/−68).

Closes #505.

### Rationale

Before the fix, `trace_filter` took **2** permits from the `--rpc.max-tracing-requests` semaphore for the *entire* call, then internally replayed up to `max_tracing_requests` blocks **concurrently** on the tokio blocking pool with no per-block permit. The worst case was `N/2` concurrent calls × `N` replays = **N²/2** concurrent replays; with `--rpc.max-tracing-requests=16` that is 128 replays on a 16c/32t host. `--rpc.max-trace-filter-blocks` did not help, because the fan-out was per *chunk*, not per *range*.

Reported in #505 against a BSC mainnet archive fleet (9 nodes, `reth-bsc:v0.1.2`, `--rpc.max-tracing-requests=16`, load balancer already capping each call at 100 blocks):

* a few 100-block `trace_filter` calls/sec/node took CPU from ~20% to 92–99% within 60 seconds, load average 200–500 on 32 hardware threads; a control node on the same binary and flags with no RPC traffic stayed at 8%.
* block import stalled and nodes fell >1,000 blocks behind tip within ~20 minutes, logging `A database read transaction has been open for too long open_duration=60.0s` — the same signature as [paradigmxyz/reth#24473](https://github.com/paradigmxyz/reth/issues/24473), which #25133 closes.

Per-call replay cost on StorageV2 is high (#466), which makes this easier to hit on BSC than on Ethereum mainnet.

No BSC-side code change is needed: nothing under `src/` or `testing/` references `trace_filter`, `TraceApi`, `max_tracing_requests`, or `blocking_task_guard`, so the trace API comes wholly from reth and the dep bump is the entire fix.

### Example

With `--rpc.max-tracing-requests=16`, one in-flight `trace_filter` over a 100-block range:

```
before:  16 concurrent block replays on the tokio blocking pool, holding 2 semaphore permits
after:   min(16, 4) = 4 concurrent block replays, each holding its own tracing permit
```

Total concurrent replays per node is now bounded by `--rpc.max-tracing-requests`, as documented.

### Changes

Notable changes:
* `Cargo.lock`: reth git rev `759fececb8` → `c8e1e73b4b` across all 129 `reth-*` entries. No manifest change.

### Potential Impacts

* **`trace_filter` pagination grouping changes.** `after`/`count` now apply per replayed block rather than per chunk, and a block's reward traces follow that block's transaction traces instead of being appended after the whole chunk. The trace *set* is unchanged; the grouping when paginating is not. Upstream calls this out in #25133 and ships a unit test pinning the expected order. A geth RPC-diff on `trace_filter` with `after`/`count` set is worth running before release.
* **Reward traces:** the fix replaces a per-chunk `break` with a latched `include_reward_traces` flag. Equivalent for any monotonic Paris activation (blocks are processed in ascending order), so no output change expected on BSC.
* **Throughput:** a single `trace_filter` call now replays at most 4 blocks at a time instead of `max_tracing_requests`, so one large-range call can be slower on an otherwise idle node. That is the intended trade — it is what stops a call from monopolizing the blocking pool and starving block import.
* **No API/CLI surface change.** `--rpc.max-tracing-requests` and `--rpc.max-trace-filter-blocks` keep their meaning; the first now actually holds.
* Operators currently working around this by lowering `--rpc.max-tracing-requests` (the reporter went 16 → 6) can restore their previous value after this ships.

### Testing

* `cargo clippy --workspace --tests --all-features` — 0 errors, 0 warnings across both workspace members (102 crates rebuilt from `branch=develop#c8e1e73b`, including `reth-rpc`).
* `cargo test --all -- --test-threads=1` — 561 passed, 0 failed.
* Verified the resolved checkout (`~/.cargo/git/checkouts/…/c8e1e73`) actually carries the fix: `TRACE_FILTER_BLOCK_BUFFER_SIZE = 4` and the `.buffered(block_buffer_size)` fan-out present; `try_join_all` and `acquire_many_owned(2)` gone.
* Upstream's `trace::tests::trace_filter_paginates_after_per_block_reward_order` passes on the 2.2.0 base (run in bnb-chain/reth#230).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
